### PR TITLE
Generalize prefilter config: externalize rules, drop Tier-1 bonus (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ data/pipeline.db-shm
 scripts/transfer_from_mac.sh
 scripts/setup_launchd.sh
 docs/master_resume.md.example
+
+config/prefilter_rules.yaml
+config/in_domain_patterns.yaml
+config/companies_of_interest.txt

--- a/config/companies_of_interest.txt.example
+++ b/config/companies_of_interest.txt.example
@@ -1,0 +1,34 @@
+# companies_of_interest.txt — employers worth tracking closely.
+# Copy this file to companies_of_interest.txt and edit. This file is gitignored.
+#
+# One company per line. Lines starting with # and blank lines are skipped.
+# Matching is case-insensitive substring, so "meta" matches "Meta Platforms, Inc."
+#
+# Used by:
+#   - scripts/sync_sheet.py — a job from one of these companies stays on Sheet1
+#     even if it scored low and is past the archive threshold.
+#   - scripts/notify.py — a job from one of these companies scored 3-6 shows up
+#     in the daily health check as a potential mis-score worth reviewing.
+#
+# NOT used by the prefilter — scoring is the same whether a company is on this
+# list or not.
+#
+# Missing file → both features degrade gracefully (warn).
+
+# Tech / AI infrastructure example:
+# meta
+# google
+# openai
+# anthropic
+
+# Healthcare example:
+# kaiser permanente
+# cedars-sinai
+
+# Education example:
+# lausd
+# san diego unified
+
+# Social services example:
+# la county department of mental health
+# st. jude children's research hospital

--- a/config/in_domain_patterns.yaml.example
+++ b/config/in_domain_patterns.yaml.example
@@ -1,0 +1,47 @@
+# in_domain_patterns.yaml — positive signal + poison for Stage 2 prefilter.
+# Copy this file to in_domain_patterns.yaml and edit. This file is gitignored.
+#
+# SHAPE:
+#   positive: (required; list of title regex — in-domain signal)
+#     - '<regex>'
+#   poison:   (optional; list of regex — negates an otherwise in-domain match)
+#     - '<regex>'
+#
+# When a job has no usable JD (auth wall, under 30 words, etc.), the prefilter
+# falls back to title-only signal. If a positive pattern matches AND no poison
+# pattern matches, the job scores 5 and bypasses the LLM.
+#
+# Missing file → Stage 2 becomes a no-op (warn); unknown-title no-JD jobs
+# just go to the LLM.
+
+positive:
+  # Placeholder — replace with patterns that identify your target roles by title.
+  - '\b__replace_me_with_a_title_regex__\b'
+
+# ── Suggested positive patterns per field ────────────────────────────────────
+# Tech / DC operations:
+#   - '\bdata\s*center\s+(operations|site|manager|lead|technician|engineer)\b'
+#   - '\bnpi\s+(manager|lead|engineer|program\s+manager)\b'
+#   - '\boperational\s+readiness\b'
+#
+# Healthcare / nursing:
+#   - '\b(registered|charge|ICU|PACU)\s+nurse\b'
+#   - '\bnurse\s+(manager|director|educator)\b'
+#
+# Teaching:
+#   - '\b(elementary|middle|high)\s+school\s+teacher\b'
+#   - '\bteach(er|ing)\s+(assistant|aide)\b'
+#
+# Social work:
+#   - '\bsocial\s+worker\b'
+#   - '\bclinical\s+social\s+worker\b'
+#   - '\bcase\s+manager\b'
+
+# ── Poison patterns ──────────────────────────────────────────────────────────
+# Title fragments that cancel an otherwise-positive match. Example: a DC ops
+# candidate's positive pattern for "site operations manager" would otherwise
+# match "workplace services site operations manager" — which is janitorial.
+# Adding "workplace services" as poison prevents that false positive.
+#
+# poison:
+#   - '\b(workplace\s+services|custodial|janitorial|facilities\s+only)\b'

--- a/config/prefilter_rules.yaml.example
+++ b/config/prefilter_rules.yaml.example
@@ -1,0 +1,57 @@
+# prefilter_rules.yaml — deterministic hard rejects for the title-only prefilter.
+# Copy this file to prefilter_rules.yaml and edit. This file is gitignored.
+#
+# SHAPE:
+#   hard_rejects:          (required; mapping of category → list of title regex)
+#     <category_name>:
+#       - '<regex>'
+#   context_suppressors:   (optional; list of regex that override a reject)
+#     - '<regex>'
+#
+# If any hard_reject pattern matches a job's title, the job scores 1
+# with no LLM call. If a context_suppressor also matches, the reject
+# is skipped and the title goes on to Stage 2 / LLM scoring.
+#
+# Missing file → prefilter hard-reject stage becomes a no-op (warn).
+
+hard_rejects:
+  spam:
+    # Job-board noise that isn't a real posting. Usually safe to keep this.
+    - '^manage\s+job\s+alerts?\b'
+    - '^your\s+job\s+alert\s+for\b'
+    - '\bjoin\s+our\s+talent\s+network\b'
+
+# ── Suggested categories to customize ──────────────────────────────────────────
+# Uncomment the block that fits your field, edit the patterns, delete the rest.
+#
+# Tech / data center operations candidate:
+#   software_engineering:
+#     - '\bsoftware\s+engineer(ing)?\b'
+#     - '\b(swe|sde)\b'
+#   sales:
+#     - '\baccount\s+executive\b'
+#     - '\bsales\s+representative\b'
+#
+# Healthcare / nursing candidate:
+#   non_clinical_admin:
+#     - '\bbilling\s+specialist\b'
+#     - '\bpatient\s+access\b'
+#
+# Education / teaching candidate:
+#   non_instructional:
+#     - '\bbus\s+driver\b'
+#     - '\bcafeteria\s+manager\b'
+#
+# Social work / human services candidate:
+#   unrelated_social:
+#     - '\bcase\s+manager\b.*\binsurance\b'
+
+# ── Context suppressors ──────────────────────────────────────────────────────
+# Title fragments that override a hard-reject match. Example: a candidate in DC
+# ops wants to see "Data Center Security Engineer" (a real job) even though
+# "security" is in their hard-reject list. Adding "data center" as a suppressor
+# lets that title through.
+#
+# context_suppressors:
+#   - '\bdata\s*center\b'
+#   - '\bdatacenter\b'

--- a/docs/GENERALIZATION.md
+++ b/docs/GENERALIZATION.md
@@ -25,24 +25,21 @@ domain. Each item is a future task to make the pipeline domain-neutral.
 
 ## Hardcoded Domain Content (needs work)
 
-### Scorer prefilter — `scripts/scorer_prefilter.py`
+### Scorer prefilter — `src/findajob/scorer_prefilter.py`
 
-- [ ] **`TIER1` frozenset** (lines 22-27) — hardcoded tech/AI companies (Meta, Google, Microsoft, OpenAI, Nscale, etc.)
-  - Should be loaded from `config/target_companies.md` or a dedicated `config/tier1.txt`
-  - `_is_tier1()` already takes company name as arg; just needs the list externalized
+- [x] **`TIER1` frozenset** — dropped entirely in favor of `config/companies_of_interest.txt` (see changelog below). The prefilter no longer consults any company-level list.
 
-- [ ] **`_HARD_REJECT_PATTERNS`** (lines 39-225) — ~200 regex patterns for tech jobs
-  - Categories assume tech domain: software engineering, security, IT service management, supply chain (as a hard reject!), networking, hardware design, etc.
-  - For a social worker, "supply chain manager" isn't a hard reject — it's irrelevant (score low) but not a categorical NO
-  - Should be loaded from `config/prefilter_rules.yaml` or similar
-  - Structure: per-candidate categories, each with title regex patterns
+- [x] **`_HARD_REJECT_PATTERNS`** — externalized to `config/prefilter_rules.yaml` under `hard_rejects`, grouped by category. Loaded via `src/findajob/config_loader.py`.
 
-- [ ] **`_IN_DOMAIN_PATTERNS`** (lines 251-267) — tech/DC ops specific positive patterns
-  - "data center technician", "DC operations", "NPI program manager", "forward deployed engineer"
-  - Should be loaded from candidate profile or `config/in_domain_patterns.txt`
+- [x] **`_IN_DOMAIN_PATTERNS`** — externalized to `config/in_domain_patterns.yaml` under `positive`.
 
-- [ ] **`_IN_DOMAIN_POISON`** (lines 275-278) — "workplace services, custodial, janitorial, facilities only" — tech-ops specific disambiguation
-  - Each candidate needs their own poison patterns (e.g., for a teacher searching "principal": "managing principal" = finance, not education)
+- [x] **`_IN_DOMAIN_POISON`** — externalized to `config/in_domain_patterns.yaml` under `poison`.
+
+**Resolved 2026-04-17 (#10):**
+- `TIER1` was *dropped*, not externalized. The Tier-1 prefilter bonus (+1 score at the in-domain/no-JD floor) was removed entirely — the LLM already sees the target-companies list via prompt context, so the prefilter kludge is unnecessary.
+- The "companies I care about" concept lives on via `config/companies_of_interest.txt`, consumed by `scripts/sync_sheet.py` (archival exception for low-score-old jobs at these companies) and `scripts/notify.py` (mis-score health check). The prefilter does NOT consult this file.
+- Hard-reject + in-domain rules now load from `config/prefilter_rules.yaml` and `config/in_domain_patterns.yaml` through `src/findajob/config_loader.py`. Both files are gitignored; see `.example` siblings for templates.
+- Items 4 and 5 of #10 (prompt-level neutralization: `job_scorer.md` hard-reject enumerations + ENGINEER TITLE CALIBRATION move to `profile.md`) are **deferred** — they change LLM behavior and need their own validation loop. Tracked as a follow-up issue.
 
 ### Scorer role prompt — `config/roles/job_scorer.md`
 
@@ -133,10 +130,10 @@ All of these need a pass with a non-tech candidate profile to see what breaks.
 
 ## Order of Work (suggested)
 
-**Phase 1: Config externalization (high value, mechanical)**
-1. Move `TIER1` out of `scorer_prefilter.py` into `config/tier1.txt` (gitignored)
-2. Move `_HARD_REJECT_PATTERNS` into `config/prefilter_rules.yaml` (gitignored), keep the code as a rule loader
-3. Move `_IN_DOMAIN_PATTERNS` and `_IN_DOMAIN_POISON` similarly
+**Phase 1: Config externalization (high value, mechanical)** — ✅ shipped 2026-04-17 (#10)
+1. ~~Move `TIER1` out~~ → dropped; replaced by `config/companies_of_interest.txt` for non-prefilter consumers.
+2. ~~Move `_HARD_REJECT_PATTERNS`~~ → loaded from `config/prefilter_rules.yaml` via `config_loader`.
+3. ~~Move `_IN_DOMAIN_PATTERNS` and `_IN_DOMAIN_POISON`~~ → loaded from `config/in_domain_patterns.yaml`.
 
 **Phase 2: Prompt neutralization**
 4. Rewrite `job_scorer.md` hard reject section to reference profile categories rather than enumerate tech

--- a/docs/superpowers/plans/2026-04-17-generalize-prefilter-config.md
+++ b/docs/superpowers/plans/2026-04-17-generalize-prefilter-config.md
@@ -1,0 +1,1695 @@
+# Generalize Prefilter Config — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Externalize `scorer_prefilter.py`'s hardcoded domain rules into gitignored YAML/txt config files, drop the Tier-1 prefilter bonus, and route two other consumers (`sync_sheet.py`, `notify.py`) through a new `companies_of_interest` config.
+
+**Architecture:** New `src/findajob/config_loader.py` reads three configs (`prefilter_rules.yaml`, `in_domain_patterns.yaml`, `companies_of_interest.txt`) from `BASE/config/`, validates them, compiles regexes, and caches at import. `scorer_prefilter.py` becomes a thin consumer. Missing files emit warnings and return no-op sentinels; malformed files raise `ConfigError`.
+
+**Tech Stack:** Python 3.12, PyYAML (already a dep via `cost_tracking.py`), pytest, existing `findajob.paths` resolver.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-17-generalize-prefilter-config-design.md`
+
+---
+
+## File Structure
+
+**New files (tracked):**
+- `src/findajob/config_loader.py` — loader module, public API.
+- `tests/conftest.py` — autouse fixture redirecting the loader at test fixtures, resetting cache per test.
+- `tests/test_config_loader.py` — unit tests for the loader.
+- `tests/test_companies_of_interest_consumers.py` — regression guard on consumer imports.
+- `tests/fixtures/config/prefilter_rules.yaml` — test fixture (minimal but covers every code path).
+- `tests/fixtures/config/in_domain_patterns.yaml` — test fixture.
+- `tests/fixtures/config/companies_of_interest.txt` — test fixture.
+- `config/prefilter_rules.yaml.example` — field-agnostic template.
+- `config/in_domain_patterns.yaml.example` — field-agnostic template.
+- `config/companies_of_interest.txt.example` — template.
+
+**New files (gitignored, hand-populated on Brock's machine only):**
+- `config/prefilter_rules.yaml`
+- `config/in_domain_patterns.yaml`
+- `config/companies_of_interest.txt`
+
+**Modified files:**
+- `src/findajob/scorer_prefilter.py` — deletes literals, reads from loader, drops Tier-1 bonus.
+- `scripts/sync_sheet.py` — swaps `_is_tier1` for `is_company_of_interest`.
+- `scripts/notify.py` — swaps `TIER1` for `is_company_of_interest`.
+- `tests/test_scorer_prefilter.py` — removes `TestIsTier1`, updates Stage-2 score assertions.
+- `.gitignore` — adds the three new gitignored configs.
+- `docs/GENERALIZATION.md` — marks items 1–3 under "Scorer prefilter" done; notes items 4–5 deferred.
+
+---
+
+## Task 1: Loader skeleton + test fixtures + conftest
+
+Stand up the empty loader module, test fixtures, and the conftest that points the loader at fixtures. No loader logic yet — just the import surface and the test harness. Downstream tasks implement behavior TDD-style.
+
+**Files:**
+- Create: `src/findajob/config_loader.py`
+- Create: `tests/conftest.py`
+- Create: `tests/fixtures/config/prefilter_rules.yaml`
+- Create: `tests/fixtures/config/in_domain_patterns.yaml`
+- Create: `tests/fixtures/config/companies_of_interest.txt`
+
+- [ ] **Step 1: Create the loader skeleton**
+
+Create `src/findajob/config_loader.py`:
+
+```python
+"""Loads prefilter rules and companies-of-interest from gitignored configs.
+
+Reads from BASE/config/:
+  - prefilter_rules.yaml        (hard_rejects + context_suppressors)
+  - in_domain_patterns.yaml     (positive + poison)
+  - companies_of_interest.txt   (one company per line; case-insensitive)
+
+Missing files emit a UserWarning and return no-op sentinels so the pipeline
+degrades gracefully on a fresh install. Malformed files raise ConfigError.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from findajob.paths import BASE
+
+# Module-level paths (overridden in tests via conftest)
+_RULES_PATH = Path(BASE) / "config" / "prefilter_rules.yaml"
+_IN_DOMAIN_PATH = Path(BASE) / "config" / "in_domain_patterns.yaml"
+_COMPANIES_PATH = Path(BASE) / "config" / "companies_of_interest.txt"
+
+# Sentinel regex that never matches anything. Used when a config is missing
+# or empty. Returned in place of None so callers don't need a None-check.
+_NEVER_MATCH = re.compile(r"(?!x)x")
+
+# Caches
+_hard_reject_cache: Optional[tuple[re.Pattern[str], Optional[re.Pattern[str]]]] = None
+_in_domain_cache: Optional[tuple[re.Pattern[str], Optional[re.Pattern[str]]]] = None
+_companies_cache: Optional[frozenset[str]] = None
+
+# Warnings emitted (dedup per process)
+_warned: set[str] = set()
+
+
+class ConfigError(Exception):
+    """Raised when a config file is malformed (bad YAML, bad regex, wrong shape)."""
+
+
+def load_hard_reject_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+    """(reject_re, suppressor_re). suppressor_re is None if no suppressors configured."""
+    raise NotImplementedError
+
+
+def load_in_domain_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+    """(in_domain_re, poison_re). poison_re is None if no poison configured."""
+    raise NotImplementedError
+
+
+def load_companies_of_interest() -> frozenset[str]:
+    """Lowercase company names. Used for case-insensitive substring matching."""
+    raise NotImplementedError
+
+
+def is_company_of_interest(company: str) -> bool:
+    """Case-insensitive substring check. False for empty/None inputs."""
+    raise NotImplementedError
+
+
+def _reset_cache() -> None:
+    """Test-only. Clears module-level caches and warning dedup."""
+    global _hard_reject_cache, _in_domain_cache, _companies_cache
+    _hard_reject_cache = None
+    _in_domain_cache = None
+    _companies_cache = None
+    _warned.clear()
+```
+
+- [ ] **Step 2: Create the three test fixtures**
+
+Create `tests/fixtures/config/prefilter_rules.yaml`:
+
+```yaml
+# Test fixture — small but covers hard_rejects, grouping, and suppressors.
+hard_rejects:
+  software:
+    - '\bsoftware\s+engineer(ing)?\b'
+    - '\b(swe|sde)\b'
+  healthcare:
+    - '\bnurs(e|ing)\b'
+  sales:
+    - '\baccount\s+executive\b'
+
+context_suppressors:
+  - '\bdata\s*center\b|\bdatacenter\b'
+```
+
+Create `tests/fixtures/config/in_domain_patterns.yaml`:
+
+```yaml
+positive:
+  - '\bdata\s*center\s+(operations|technician|engineer)\b'
+  - '\bnpi\s+(manager|lead|engineer)\b'
+  - '\boperational\s+readiness\b'
+
+poison:
+  - '\b(workplace\s+services|custodial|janitorial)\b'
+```
+
+Create `tests/fixtures/config/companies_of_interest.txt`:
+
+```
+# Test fixture
+meta
+google
+openai
+anthropic
+aws
+microsoft
+```
+
+- [ ] **Step 3: Create `tests/conftest.py`**
+
+```python
+"""Global test fixtures.
+
+Redirects findajob.config_loader to read from tests/fixtures/config/
+instead of the production config directory, and resets its cache before
+each test so a test's config edits don't leak into the next test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from findajob import config_loader
+
+FIXTURES = Path(__file__).parent / "fixtures" / "config"
+
+
+@pytest.fixture(autouse=True)
+def _use_fixture_configs(monkeypatch):
+    monkeypatch.setattr(config_loader, "_RULES_PATH", FIXTURES / "prefilter_rules.yaml")
+    monkeypatch.setattr(config_loader, "_IN_DOMAIN_PATH", FIXTURES / "in_domain_patterns.yaml")
+    monkeypatch.setattr(config_loader, "_COMPANIES_PATH", FIXTURES / "companies_of_interest.txt")
+    config_loader._reset_cache()
+    yield
+    config_loader._reset_cache()
+```
+
+- [ ] **Step 4: Verify the skeleton imports cleanly**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -c "from findajob.config_loader import ConfigError, load_hard_reject_rules, load_in_domain_rules, load_companies_of_interest, is_company_of_interest, _reset_cache; print('imports OK')"
+```
+
+Expected output:
+```
+imports OK
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/findajob/config_loader.py tests/conftest.py tests/fixtures/
+git commit -m "$(cat <<'EOF'
+feat(config-loader): skeleton module + test fixtures (#10)
+
+Empty public API (raises NotImplementedError), conftest redirects the
+loader to tests/fixtures/config/ and resets cache per test. Downstream
+tasks implement behavior TDD-style.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Implement `load_companies_of_interest` + `is_company_of_interest` (TDD)
+
+Start with the simplest loader: a flat text file. Covers happy path, comment/blank line handling, case normalization, and the substring-match helper.
+
+**Files:**
+- Modify: `src/findajob/config_loader.py`
+- Create: `tests/test_config_loader.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_config_loader.py`:
+
+```python
+"""Tests for findajob.config_loader."""
+
+from __future__ import annotations
+
+import pytest
+
+from findajob import config_loader
+from findajob.config_loader import (
+    ConfigError,
+    is_company_of_interest,
+    load_companies_of_interest,
+)
+
+
+class TestLoadCompaniesOfInterest:
+    def test_loads_from_fixture(self):
+        result = load_companies_of_interest()
+        assert isinstance(result, frozenset)
+        assert "meta" in result
+        assert "google" in result
+        assert "openai" in result
+
+    def test_lowercases_entries(self):
+        result = load_companies_of_interest()
+        assert all(c == c.lower() for c in result)
+
+    def test_caches_result(self):
+        result1 = load_companies_of_interest()
+        result2 = load_companies_of_interest()
+        assert result1 is result2  # same object — cache hit
+
+
+class TestIsCompanyOfInterest:
+    @pytest.mark.parametrize(
+        "company",
+        ["Meta", "meta", "META", "Meta Platforms, Inc.", "Google Cloud", "Amazon Web Services"],
+    )
+    def test_positive_substring(self, company):
+        # "aws" is in the fixture; "Amazon Web Services" contains "aws" lowercased? No —
+        # the fixture lists "aws" and "Amazon Web Services" lowercased is "amazon web services"
+        # which contains "aws"? "aws" is 3 chars; "amazon web services" has "aws" as substring
+        # in "web services" → yes. But this is fragile. Let's keep the tests focused on
+        # clear substring cases:
+        pass  # replaced by the narrower cases below
+
+    @pytest.mark.parametrize(
+        "company",
+        ["Meta", "meta", "META", "Meta Platforms, Inc.", "Google Cloud", "OpenAI Research"],
+    )
+    def test_positive_substring_clear(self, company):
+        assert is_company_of_interest(company) is True
+
+    @pytest.mark.parametrize(
+        "company",
+        ["Walmart", "Starbucks", "Acme Corp", "Random Startup LLC"],
+    )
+    def test_negative(self, company):
+        assert is_company_of_interest(company) is False
+
+    def test_empty_string(self):
+        assert is_company_of_interest("") is False
+
+    def test_none(self):
+        # Typed as str but guard handles falsy
+        assert is_company_of_interest(None) is False  # type: ignore[arg-type]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py -v 2>&1 | head -40
+```
+
+Expected: every test fails with `NotImplementedError`.
+
+- [ ] **Step 3: Implement the two functions**
+
+In `src/findajob/config_loader.py`, replace the two `NotImplementedError` stubs:
+
+```python
+def load_companies_of_interest() -> frozenset[str]:
+    global _companies_cache
+    if _companies_cache is not None:
+        return _companies_cache
+
+    try:
+        raw = _COMPANIES_PATH.read_text()
+    except FileNotFoundError:
+        _warn_once(f"config/companies_of_interest.txt missing — sync_sheet archival exception and notify mis-score check will be disabled")
+        _companies_cache = frozenset()
+        return _companies_cache
+
+    entries: set[str] = set()
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        entries.add(stripped.lower())
+
+    if not entries:
+        _warn_once(f"config/companies_of_interest.txt is empty — sync_sheet archival exception and notify mis-score check will be disabled")
+
+    _companies_cache = frozenset(entries)
+    return _companies_cache
+
+
+def is_company_of_interest(company: str) -> bool:
+    if not company:
+        return False
+    c = company.lower()
+    return any(t in c for t in load_companies_of_interest())
+
+
+def _warn_once(msg: str) -> None:
+    if msg in _warned:
+        return
+    _warned.add(msg)
+    warnings.warn(msg, UserWarning, stacklevel=3)
+```
+
+Remove the two stub functions that raised `NotImplementedError`.
+
+- [ ] **Step 4: Trim the broken parametrize in the test**
+
+In `tests/test_config_loader.py`, delete the `test_positive_substring` method that has `pass` inside it (the narrower `test_positive_substring_clear` replaces it).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py -v 2>&1 | head -40
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/findajob/config_loader.py tests/test_config_loader.py
+git commit -m "$(cat <<'EOF'
+feat(config-loader): companies_of_interest loader + substring helper (#10)
+
+Reads config/companies_of_interest.txt (comments + blanks skipped,
+lowercased). Missing/empty file → empty frozenset + UserWarning.
+is_company_of_interest does case-insensitive substring match with
+empty-input guard.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Implement `load_hard_reject_rules` happy path (TDD)
+
+YAML → compiled regex pair. Covers grouped categories, suppressors, and the no-suppressor case.
+
+**Files:**
+- Modify: `src/findajob/config_loader.py`
+- Modify: `tests/test_config_loader.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_config_loader.py`:
+
+```python
+class TestLoadHardRejectRules:
+    def test_returns_two_regexes(self):
+        reject_re, suppressor_re = config_loader.load_hard_reject_rules()
+        assert reject_re.search("Software Engineer") is not None
+        assert suppressor_re is not None  # fixture has suppressors
+
+    def test_matches_across_categories(self):
+        reject_re, _ = config_loader.load_hard_reject_rules()
+        # software category
+        assert reject_re.search("Senior Software Engineer") is not None
+        assert reject_re.search("SWE II") is not None
+        # healthcare category
+        assert reject_re.search("Registered Nurse") is not None
+        # sales category
+        assert reject_re.search("Enterprise Account Executive") is not None
+
+    def test_no_match_for_in_domain_title(self):
+        reject_re, _ = config_loader.load_hard_reject_rules()
+        assert reject_re.search("Data Center Operations Engineer") is None
+
+    def test_suppressor_compiled(self):
+        _, suppressor_re = config_loader.load_hard_reject_rules()
+        assert suppressor_re.search("Data Center Security Analyst") is not None
+        assert suppressor_re.search("Datacenter NOC") is not None
+        assert suppressor_re.search("Security Analyst") is None  # no DC context
+
+    def test_caches_result(self):
+        r1 = config_loader.load_hard_reject_rules()
+        r2 = config_loader.load_hard_reject_rules()
+        assert r1 is r2  # cache hit returns same tuple
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py::TestLoadHardRejectRules -v 2>&1 | head -30
+```
+
+Expected: all fail with `NotImplementedError`.
+
+- [ ] **Step 3: Implement `load_hard_reject_rules`**
+
+In `src/findajob/config_loader.py`, replace the `NotImplementedError` stub:
+
+```python
+def load_hard_reject_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+    global _hard_reject_cache
+    if _hard_reject_cache is not None:
+        return _hard_reject_cache
+
+    data = _safe_load_yaml(_RULES_PATH, "prefilter_rules.yaml")
+    if data is None:
+        _hard_reject_cache = (_NEVER_MATCH, None)
+        return _hard_reject_cache
+
+    hard_rejects = data.get("hard_rejects", {})
+    if not isinstance(hard_rejects, dict):
+        raise ConfigError(
+            f"prefilter_rules.yaml: 'hard_rejects' must be a mapping of category→list, got {type(hard_rejects).__name__}"
+        )
+
+    reject_patterns: list[str] = []
+    for category, patterns in hard_rejects.items():
+        if not isinstance(patterns, list):
+            raise ConfigError(
+                f"prefilter_rules.yaml: hard_rejects['{category}'] must be a list, got {type(patterns).__name__}"
+            )
+        for p in patterns:
+            if not isinstance(p, str):
+                raise ConfigError(f"prefilter_rules.yaml: pattern in '{category}' is not a string: {p!r}")
+            reject_patterns.append(p)
+
+    reject_re = _compile_patterns(reject_patterns, _RULES_PATH, "hard_rejects")
+
+    suppressors = data.get("context_suppressors", []) or []
+    if not isinstance(suppressors, list):
+        raise ConfigError(
+            f"prefilter_rules.yaml: 'context_suppressors' must be a list, got {type(suppressors).__name__}"
+        )
+    for p in suppressors:
+        if not isinstance(p, str):
+            raise ConfigError(f"prefilter_rules.yaml: context_suppressor pattern is not a string: {p!r}")
+
+    suppressor_re: Optional[re.Pattern[str]] = None
+    if suppressors:
+        suppressor_re = _compile_patterns(suppressors, _RULES_PATH, "context_suppressors")
+
+    _hard_reject_cache = (reject_re, suppressor_re)
+    return _hard_reject_cache
+
+
+def _safe_load_yaml(path: Path, label: str) -> Optional[dict]:
+    """Read YAML. Returns None if file missing (with warning) or empty.
+    Raises ConfigError on parse error or non-mapping top-level."""
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        _warn_once(f"config/{label} missing — prefilter will be a no-op for this config")
+        return None
+
+    if not text.strip():
+        _warn_once(f"config/{label} is empty — prefilter will be a no-op for this config")
+        return None
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        raise ConfigError(f"config/{label}: YAML parse error: {e}") from e
+
+    if data is None:
+        _warn_once(f"config/{label} parsed to null — prefilter will be a no-op for this config")
+        return None
+
+    if not isinstance(data, dict):
+        raise ConfigError(f"config/{label}: top level must be a mapping, got {type(data).__name__}")
+
+    return data
+
+
+def _compile_patterns(patterns: list[str], path: Path, label: str) -> re.Pattern[str]:
+    """Compile a list of regex strings into a single alternation. Bad patterns
+    raise ConfigError with the offending pattern surfaced."""
+    if not patterns:
+        return _NEVER_MATCH
+    for p in patterns:
+        try:
+            re.compile(p)
+        except re.error as e:
+            raise ConfigError(f"{path.name}: invalid regex in {label}: {p!r} — {e}") from e
+    return re.compile("|".join(f"(?:{p})" for p in patterns), re.IGNORECASE)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py::TestLoadHardRejectRules -v 2>&1 | head -30
+```
+
+Expected: all 5 tests in `TestLoadHardRejectRules` pass. Earlier tests still pass.
+
+Run full file:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py -v 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/findajob/config_loader.py tests/test_config_loader.py
+git commit -m "$(cat <<'EOF'
+feat(config-loader): hard_reject_rules loader with suppressors (#10)
+
+Compiles grouped YAML category→patterns into a single alternation regex.
+Optional context_suppressors compiled separately. Bad shape or bad regex
+raises ConfigError naming the file + offending pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Implement `load_in_domain_rules` (TDD)
+
+Mirrors `load_hard_reject_rules` but with `positive` + optional `poison` top-level keys.
+
+**Files:**
+- Modify: `src/findajob/config_loader.py`
+- Modify: `tests/test_config_loader.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_config_loader.py`:
+
+```python
+class TestLoadInDomainRules:
+    def test_positive_matches(self):
+        in_domain_re, _ = config_loader.load_in_domain_rules()
+        assert in_domain_re.search("Data Center Operations Engineer") is not None
+        assert in_domain_re.search("NPI Manager") is not None
+        assert in_domain_re.search("Operational Readiness Lead") is not None
+
+    def test_positive_misses_out_of_domain(self):
+        in_domain_re, _ = config_loader.load_in_domain_rules()
+        assert in_domain_re.search("Software Engineer") is None
+        assert in_domain_re.search("Account Executive") is None
+
+    def test_poison_compiled(self):
+        _, poison_re = config_loader.load_in_domain_rules()
+        assert poison_re is not None
+        assert poison_re.search("Data Center Workplace Services Manager") is not None
+        assert poison_re.search("Custodial Lead") is not None
+        assert poison_re.search("Data Center Operations") is None  # no poison term
+
+    def test_caches_result(self):
+        r1 = config_loader.load_in_domain_rules()
+        r2 = config_loader.load_in_domain_rules()
+        assert r1 is r2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py::TestLoadInDomainRules -v 2>&1 | head -20
+```
+
+Expected: all fail with `NotImplementedError`.
+
+- [ ] **Step 3: Implement `load_in_domain_rules`**
+
+In `src/findajob/config_loader.py`, replace the `NotImplementedError` stub:
+
+```python
+def load_in_domain_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+    global _in_domain_cache
+    if _in_domain_cache is not None:
+        return _in_domain_cache
+
+    data = _safe_load_yaml(_IN_DOMAIN_PATH, "in_domain_patterns.yaml")
+    if data is None:
+        _in_domain_cache = (_NEVER_MATCH, None)
+        return _in_domain_cache
+
+    positive = data.get("positive", [])
+    if not isinstance(positive, list):
+        raise ConfigError(
+            f"in_domain_patterns.yaml: 'positive' must be a list, got {type(positive).__name__}"
+        )
+    for p in positive:
+        if not isinstance(p, str):
+            raise ConfigError(f"in_domain_patterns.yaml: positive pattern is not a string: {p!r}")
+
+    positive_re = _compile_patterns(positive, _IN_DOMAIN_PATH, "positive")
+
+    poison = data.get("poison", []) or []
+    if not isinstance(poison, list):
+        raise ConfigError(
+            f"in_domain_patterns.yaml: 'poison' must be a list, got {type(poison).__name__}"
+        )
+    for p in poison:
+        if not isinstance(p, str):
+            raise ConfigError(f"in_domain_patterns.yaml: poison pattern is not a string: {p!r}")
+
+    poison_re: Optional[re.Pattern[str]] = None
+    if poison:
+        poison_re = _compile_patterns(poison, _IN_DOMAIN_PATH, "poison")
+
+    _in_domain_cache = (positive_re, poison_re)
+    return _in_domain_cache
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py -v 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/findajob/config_loader.py tests/test_config_loader.py
+git commit -m "$(cat <<'EOF'
+feat(config-loader): in_domain_rules loader with poison patterns (#10)
+
+Mirrors hard_reject_rules shape — positive (required) + poison (optional).
+Same validation + caching semantics.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Missing-file + malformed-file behavior tests
+
+Lock in the graceful-degrade and ConfigError paths that the previous tasks implemented but didn't explicitly test through their observable behavior.
+
+**Files:**
+- Modify: `tests/test_config_loader.py`
+
+- [ ] **Step 1: Write tests for missing files**
+
+Append to `tests/test_config_loader.py`:
+
+```python
+class TestMissingFiles:
+    def test_missing_rules_file_returns_never_match(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_RULES_PATH", tmp_path / "does-not-exist.yaml")
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="prefilter_rules.yaml missing"):
+            reject_re, suppressor_re = config_loader.load_hard_reject_rules()
+        assert reject_re.search("Software Engineer") is None
+        assert reject_re is config_loader._NEVER_MATCH
+        assert suppressor_re is None
+
+    def test_missing_in_domain_file_returns_never_match(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_IN_DOMAIN_PATH", tmp_path / "does-not-exist.yaml")
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="in_domain_patterns.yaml missing"):
+            in_domain_re, poison_re = config_loader.load_in_domain_rules()
+        assert in_domain_re.search("Data Center Operations") is None
+        assert poison_re is None
+
+    def test_missing_companies_file_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_COMPANIES_PATH", tmp_path / "does-not-exist.txt")
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="companies_of_interest.txt missing"):
+            result = config_loader.load_companies_of_interest()
+        assert result == frozenset()
+        assert config_loader.is_company_of_interest("Meta") is False
+
+    def test_empty_rules_file(self, monkeypatch, tmp_path):
+        empty = tmp_path / "prefilter_rules.yaml"
+        empty.write_text("")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", empty)
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="prefilter_rules.yaml is empty"):
+            reject_re, _ = config_loader.load_hard_reject_rules()
+        assert reject_re.search("anything") is None
+
+
+class TestMalformedFiles:
+    def test_bad_yaml_raises_config_error(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects: {unclosed")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="YAML parse error"):
+            config_loader.load_hard_reject_rules()
+
+    def test_top_level_list_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("- just\n- a\n- list\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="top level must be a mapping"):
+            config_loader.load_hard_reject_rules()
+
+    def test_hard_rejects_as_list_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects:\n  - '\\bfoo\\b'\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="'hard_rejects' must be a mapping"):
+            config_loader.load_hard_reject_rules()
+
+    def test_bad_regex_raises_with_pattern(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects:\n  broken:\n    - '(unclosed'\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match=r"invalid regex.*\(unclosed"):
+            config_loader.load_hard_reject_rules()
+
+    def test_non_string_pattern_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects:\n  bad:\n    - 42\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="pattern in 'bad' is not a string"):
+            config_loader.load_hard_reject_rules()
+
+    def test_in_domain_positive_as_dict_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "in_domain_patterns.yaml"
+        bad.write_text("positive:\n  nested: value\n")
+        monkeypatch.setattr(config_loader, "_IN_DOMAIN_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="'positive' must be a list"):
+            config_loader.load_in_domain_rules()
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_config_loader.py -v 2>&1 | tail -30
+```
+
+Expected: all tests pass, including the new `TestMissingFiles` and `TestMalformedFiles` classes. No production code changes needed — this task locks in behavior already implemented in Tasks 2–4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_config_loader.py
+git commit -m "$(cat <<'EOF'
+test(config-loader): missing + malformed file coverage (#10)
+
+Locks in graceful degrade (warn + no-op sentinels) and ConfigError
+surface for bad YAML / wrong shape / invalid regex / non-string items.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Refactor `scorer_prefilter.py` to use the loader
+
+Delete the literals, wire up the loader, drop the Tier-1 bonus. Update the existing 444-line prefilter test file in the same commit.
+
+**Files:**
+- Modify: `src/findajob/scorer_prefilter.py`
+- Modify: `tests/test_scorer_prefilter.py`
+
+- [ ] **Step 1: Rewrite `src/findajob/scorer_prefilter.py`**
+
+Replace the entire file with:
+
+```python
+#!/usr/bin/env python3
+"""
+Deterministic pre-filter for job scoring.
+Runs BEFORE any LLM call. Two stages:
+
+  Stage 1 — Hard reject by title regex → score 1, scored, no LLM
+            (context_suppressors in prefilter_rules.yaml can override)
+  Stage 2 — In-domain title + no usable JD → score 5, no LLM
+
+If neither stage fires, returns (None, None) and caller should invoke the LLM.
+
+Rules are loaded from config/prefilter_rules.yaml and config/in_domain_patterns.yaml
+(both gitignored). See src/findajob/config_loader.py.
+
+Usage:
+    from findajob.scorer_prefilter import prefilter_score
+    result, reason = prefilter_score(title, company, jd_is_usable)
+    if result is not None:
+        return result, 0   # latency=0, no subprocess
+    # ... LLM path
+"""
+
+from __future__ import annotations
+
+from findajob.config_loader import load_hard_reject_rules, load_in_domain_rules
+
+# Compile once at import. Loader handles missing/empty configs with sentinels.
+_HARD_REJECT_RE, _SUPPRESSOR_RE = load_hard_reject_rules()
+_IN_DOMAIN_RE, _POISON_RE = load_in_domain_rules()
+
+
+def _hard_reject_match(title: str) -> str | None:
+    """Return the matched pattern string, or None."""
+    m = _HARD_REJECT_RE.search(title)
+    if not m:
+        return None
+    # If a context suppressor also matches, don't reject.
+    if _SUPPRESSOR_RE is not None and _SUPPRESSOR_RE.search(title):
+        return None
+    return m.group(0).strip()
+
+
+def _in_domain_match(title: str) -> bool:
+    if _POISON_RE is not None and _POISON_RE.search(title):
+        return False
+    return bool(_IN_DOMAIN_RE.search(title))
+
+
+def prefilter_score(title: str, company: str, jd_usable: bool) -> tuple[dict[str, object] | None, str | None]:
+    """
+    Returns (result_dict, reason_str) if a deterministic decision can be made,
+    or (None, None) if the LLM should be invoked.
+    """
+    t = (title or "").strip()
+
+    # ── Stage 1: Hard reject ──────────────────────────────────────────────────
+    match = _hard_reject_match(t)
+    if match:
+        reason = f'Pre-filter hard reject: title matched "{match}"'
+        return {
+            "score_status": "scored",
+            "relevance_score": 1,
+            "interview_likelihood": 1,
+            "strengths_alignment": "Hard reject — title is outside candidate domain.",
+            "industry_sector": None,
+            "comp_estimate": None,
+            "ai_notes": reason,
+            "score_flag_reason": reason,
+            "remote_status": "Unknown",
+        }, reason
+
+    # ── Stage 2: In-domain title, JD absent → score 5 ─────────────────────────
+    if not jd_usable and _in_domain_match(t):
+        reason = "Pre-filter in-domain/no-JD: scored 5"
+        return {
+            "score_status": "scored",
+            "relevance_score": 5,
+            "interview_likelihood": 4,
+            "strengths_alignment": "Title is directionally in-domain. JD unavailable — scored 5 per policy.",
+            "industry_sector": None,
+            "comp_estimate": None,
+            "ai_notes": reason,
+            "score_flag_reason": None,
+            "remote_status": "Unknown",
+        }, reason
+
+    return None, None
+```
+
+Note: `company` parameter is retained in the signature even though it's no longer used, to preserve the public API for existing callers (`scoring.py`). It's a no-op for now.
+
+- [ ] **Step 2: Update `tests/test_scorer_prefilter.py`**
+
+Two changes:
+
+(a) Remove the `TestIsTier1` class entirely and the import of `_is_tier1`. Edit the import at the top:
+
+Change:
+```python
+from findajob.scorer_prefilter import _hard_reject_match, _in_domain_match, _is_tier1, prefilter_score
+```
+
+To:
+```python
+from findajob.scorer_prefilter import _hard_reject_match, _in_domain_match, prefilter_score
+```
+
+Delete the entire `class TestIsTier1:` block and its decorators.
+
+(b) Inside `TestPrefilterScore` (and any other class that asserts score=6 for Tier-1 companies), update the Stage-2 assertions so `relevance_score == 5` in all cases. The easiest approach: grep for any assertion of `relevance_score == 6` or `"relevance_score": 6` in that file and change it to 5. Any `interview_likelihood` derived from it should become 4 (score - 1).
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && grep -n "relevance_score.*6\|== 6\b" tests/test_scorer_prefilter.py
+```
+
+For each hit where the test is exercising Stage 2 with a Tier-1 company, change the expected score from 6 to 5 and, if the test also checked `interview_likelihood`, from 5 to 4.
+
+If the existing `TestPrefilterScore` class has any test that asserted the Tier-1 bonus specifically (e.g., "in-domain title at a Tier-1 company scores higher than the same title elsewhere"), delete that test — the behavior no longer exists.
+
+- [ ] **Step 3: Run the prefilter tests**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_scorer_prefilter.py -v 2>&1 | tail -40
+```
+
+Expected: all remaining tests pass. If tests reference patterns not in the fixture (e.g., `"aircraft mechanic"`), they'll fail on the hard-reject assertion — add those patterns to `tests/fixtures/config/prefilter_rules.yaml` under an appropriate category (e.g., `aviation:`). Same for in-domain patterns not in the fixture.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/ 2>&1 | tail -10
+```
+
+Expected: all tests pass. If `tests/test_scoring.py` or others import from `scorer_prefilter` and break, the autouse conftest fixture will already have redirected the loader paths — so failures are unexpected and should be diagnosed individually. The most likely break is a test elsewhere that imports `_is_tier1` or `TIER1` — fix by deleting the import and the dependent assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/findajob/scorer_prefilter.py tests/test_scorer_prefilter.py tests/fixtures/config/
+git commit -m "$(cat <<'EOF'
+refactor(prefilter): load rules from config, drop Tier-1 bonus (#10)
+
+scorer_prefilter.py now reads hard_rejects + context_suppressors +
+positive/poison patterns from gitignored configs via config_loader.
+Stage 2 in-domain/no-JD always scores 5 — the Tier-1 +1 bonus is
+removed. TIER1 frozenset and _is_tier1 deleted.
+
+Tests updated: TestIsTier1 removed, Stage-2 Tier-1 assertions updated
+from 6→5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Swap `sync_sheet.py` and `notify.py` consumers
+
+Route them through `is_company_of_interest` instead of `_is_tier1` / `TIER1`.
+
+**Files:**
+- Modify: `scripts/sync_sheet.py`
+- Modify: `scripts/notify.py`
+- Create: `tests/test_companies_of_interest_consumers.py`
+
+- [ ] **Step 1: Update `scripts/sync_sheet.py`**
+
+In `scripts/sync_sheet.py`:
+
+Change line 18 from:
+```python
+from findajob.scorer_prefilter import _is_tier1
+```
+to:
+```python
+from findajob.config_loader import is_company_of_interest
+```
+
+Change line 195 from:
+```python
+    target_extras = [r for r in all_rows if r["id"] not in target_ids and _is_tier1(r["company"])]
+```
+to:
+```python
+    target_extras = [r for r in all_rows if r["id"] not in target_ids and is_company_of_interest(r["company"])]
+```
+
+- [ ] **Step 2: Update `scripts/notify.py`**
+
+In `scripts/notify.py`:
+
+Change line 407 from:
+```python
+    from findajob.scorer_prefilter import TIER1
+```
+to:
+```python
+    from findajob.config_loader import is_company_of_interest
+```
+
+Change the mis-scored filter (lines ~419–424) from:
+```python
+    # Filter in Python since TIER1 check is a substring match
+    mis_scored = [
+        (r["title"], r["company"], r["relevance_score"])
+        for r in low_target
+        if r["company"] and any(t in r["company"].lower() for t in TIER1)
+    ]
+```
+to:
+```python
+    mis_scored = [
+        (r["title"], r["company"], r["relevance_score"])
+        for r in low_target
+        if is_company_of_interest(r["company"])
+    ]
+```
+
+- [ ] **Step 3: Write the regression test**
+
+Create `tests/test_companies_of_interest_consumers.py`:
+
+```python
+"""Regression guard: sync_sheet and notify must consume companies_of_interest
+via the config_loader, not via the now-deleted _is_tier1 / TIER1 from the
+prefilter module.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text()
+
+
+def test_sync_sheet_uses_is_company_of_interest():
+    src = _read("scripts/sync_sheet.py")
+    assert "from findajob.config_loader import is_company_of_interest" in src
+    assert "is_company_of_interest(" in src
+    assert "_is_tier1" not in src
+    assert "from findajob.scorer_prefilter import TIER1" not in src
+
+
+def test_notify_uses_is_company_of_interest():
+    src = _read("scripts/notify.py")
+    assert "from findajob.config_loader import is_company_of_interest" in src
+    assert "is_company_of_interest(" in src
+    assert "from findajob.scorer_prefilter import TIER1" not in src
+    assert "_is_tier1" not in src
+```
+
+- [ ] **Step 4: Run the regression test + full suite**
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/test_companies_of_interest_consumers.py tests/test_sync_sheet.py -v 2>&1 | tail -20
+```
+
+Expected: regression tests pass. `test_sync_sheet.py` tests pass (behavior unchanged — just the membership-check source changed).
+
+Run full suite:
+```bash
+cd /home/brockamer/Code/findajob && python3 -m pytest tests/ 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/sync_sheet.py scripts/notify.py tests/test_companies_of_interest_consumers.py
+git commit -m "$(cat <<'EOF'
+refactor: route sync_sheet + notify through is_company_of_interest (#10)
+
+Replaces _is_tier1 / TIER1 usage with config_loader.is_company_of_interest.
+Behavior unchanged — same substring semantics, new config source.
+
+Regression test asserts neither script imports the deleted prefilter
+symbols.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Ship `.example` files + update `.gitignore`
+
+Tracked templates for a new user. Gitignore entries for the real configs.
+
+**Files:**
+- Create: `config/prefilter_rules.yaml.example`
+- Create: `config/in_domain_patterns.yaml.example`
+- Create: `config/companies_of_interest.txt.example`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Create `config/prefilter_rules.yaml.example`**
+
+```yaml
+# prefilter_rules.yaml — deterministic hard rejects for the title-only prefilter.
+# Copy this file to prefilter_rules.yaml and edit. This file is gitignored.
+#
+# SHAPE:
+#   hard_rejects:          (required; mapping of category → list of title regex)
+#     <category_name>:
+#       - '<regex>'
+#   context_suppressors:   (optional; list of regex that override a reject)
+#     - '<regex>'
+#
+# If any hard_reject pattern matches a job's title, the job scores 1
+# with no LLM call. If a context_suppressor also matches, the reject
+# is skipped and the title goes on to Stage 2 / LLM scoring.
+#
+# Missing file → prefilter hard-reject stage becomes a no-op (warn).
+
+hard_rejects:
+  spam:
+    # Job-board noise that isn't a real posting. Usually safe to keep this.
+    - '^manage\s+job\s+alerts?\b'
+    - '^your\s+job\s+alert\s+for\b'
+    - '\bjoin\s+our\s+talent\s+network\b'
+
+# ── Suggested categories to customize ──────────────────────────────────────────
+# Uncomment the block that fits your field, edit the patterns, delete the rest.
+#
+# Tech / data center operations candidate:
+#   software_engineering:
+#     - '\bsoftware\s+engineer(ing)?\b'
+#     - '\b(swe|sde)\b'
+#   sales:
+#     - '\baccount\s+executive\b'
+#     - '\bsales\s+representative\b'
+#
+# Healthcare / nursing candidate:
+#   non_clinical_admin:
+#     - '\bbilling\s+specialist\b'
+#     - '\bpatient\s+access\b'
+#
+# Education / teaching candidate:
+#   non_instructional:
+#     - '\bbus\s+driver\b'
+#     - '\bcafeteria\s+manager\b'
+#
+# Social work / human services candidate:
+#   unrelated_social:
+#     - '\bcase\s+manager\b.*\binsurance\b'
+
+# ── Context suppressors ──────────────────────────────────────────────────────
+# Title fragments that override a hard-reject match. Example: a candidate in DC
+# ops wants to see "Data Center Security Engineer" (a real job) even though
+# "security" is in their hard-reject list. Adding "data center" as a suppressor
+# lets that title through.
+#
+# context_suppressors:
+#   - '\bdata\s*center\b|\bdatacenter\b'
+```
+
+- [ ] **Step 2: Create `config/in_domain_patterns.yaml.example`**
+
+```yaml
+# in_domain_patterns.yaml — positive signal + poison for Stage 2 prefilter.
+# Copy this file to in_domain_patterns.yaml and edit. This file is gitignored.
+#
+# SHAPE:
+#   positive: (required; list of title regex — in-domain signal)
+#     - '<regex>'
+#   poison:   (optional; list of regex — negates an otherwise in-domain match)
+#     - '<regex>'
+#
+# When a job has no usable JD (auth wall, under 30 words, etc.), the prefilter
+# falls back to title-only signal. If a positive pattern matches AND no poison
+# pattern matches, the job scores 5 and bypasses the LLM.
+#
+# Missing file → Stage 2 becomes a no-op (warn); unknown-title no-JD jobs
+# just go to the LLM.
+
+positive:
+  # Placeholder — replace with patterns that identify your target roles by title.
+  - '\b__replace_me_with_a_title_regex__\b'
+
+# ── Suggested positive patterns per field ────────────────────────────────────
+# Tech / DC operations:
+#   - '\bdata\s*center\s+(operations|site|manager|lead|technician|engineer)\b'
+#   - '\bnpi\s+(manager|lead|engineer|program\s+manager)\b'
+#   - '\boperational\s+readiness\b'
+#
+# Healthcare / nursing:
+#   - '\b(registered|charge|ICU|PACU)\s+nurse\b'
+#   - '\bnurse\s+(manager|director|educator)\b'
+#
+# Teaching:
+#   - '\b(elementary|middle|high)\s+school\s+teacher\b'
+#   - '\bteach(er|ing)\s+(assistant|aide)\b'
+#
+# Social work:
+#   - '\bsocial\s+worker\b'
+#   - '\bclinical\s+social\s+worker\b'
+#   - '\bcase\s+manager\b'
+
+# ── Poison patterns ──────────────────────────────────────────────────────────
+# Title fragments that cancel an otherwise-positive match. Example: a DC ops
+# candidate's positive pattern for "site operations manager" would otherwise
+# match "workplace services site operations manager" — which is janitorial.
+# Adding "workplace services" as poison prevents that false positive.
+#
+# poison:
+#   - '\b(workplace\s+services|custodial|janitorial|facilities\s+only)\b'
+```
+
+- [ ] **Step 3: Create `config/companies_of_interest.txt.example`**
+
+```
+# companies_of_interest.txt — employers worth tracking closely.
+# Copy this file to companies_of_interest.txt and edit. This file is gitignored.
+#
+# One company per line. Lines starting with # and blank lines are skipped.
+# Matching is case-insensitive substring, so "meta" matches "Meta Platforms, Inc."
+#
+# Used by:
+#   - scripts/sync_sheet.py — a job from one of these companies stays on Sheet1
+#     even if it scored low and is past the archive threshold.
+#   - scripts/notify.py — a job from one of these companies scored 3-6 shows up
+#     in the daily health check as a potential mis-score worth reviewing.
+#
+# NOT used by the prefilter — scoring is the same whether a company is on this
+# list or not.
+#
+# Missing file → both features degrade gracefully (warn).
+
+# Tech / AI infrastructure example:
+# meta
+# google
+# openai
+# anthropic
+
+# Healthcare example:
+# kaiser permanente
+# cedars-sinai
+
+# Education example:
+# lausd
+# san diego unified
+
+# Social services example:
+# la county department of mental health
+# st. jude children's research hospital
+```
+
+- [ ] **Step 4: Update `.gitignore`**
+
+Append to `.gitignore`:
+
+```
+config/prefilter_rules.yaml
+config/in_domain_patterns.yaml
+config/companies_of_interest.txt
+```
+
+Run:
+```bash
+cd /home/brockamer/Code/findajob && grep -nE "^config/(prefilter_rules|in_domain_patterns|companies_of_interest)" .gitignore
+```
+
+Expected: all three lines appear.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config/prefilter_rules.yaml.example config/in_domain_patterns.yaml.example config/companies_of_interest.txt.example .gitignore
+git commit -m "$(cat <<'EOF'
+feat(config): add .example templates for prefilter + companies config (#10)
+
+Field-agnostic stubs with commented-out per-field examples (tech,
+healthcare, education, social work). .gitignore blocks the real files.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Hand-populate Brock's real configs + parity check
+
+Transcribe the literals that were deleted in Task 6 into the real, gitignored config files. Run a diff-check against the pre-refactor behavior to confirm no unintended changes.
+
+**Files (local-only, gitignored):**
+- Create: `config/prefilter_rules.yaml`
+- Create: `config/in_domain_patterns.yaml`
+- Create: `config/companies_of_interest.txt`
+
+- [ ] **Step 1: Create `config/prefilter_rules.yaml`** with Brock's full rule set
+
+Transcribe the old `_HARD_REJECT_PATTERNS` list from `scorer_prefilter.py` (retrievable via `git show HEAD~3:src/findajob/scorer_prefilter.py`) into YAML, preserving the category grouping that lives in code comments today:
+
+```yaml
+hard_rejects:
+  software_engineering:
+    - '\bsoftware\s+engineer(ing)?\b'
+    - '\bsoftware\s+developer\b'
+    - '\bsoftware\s+architect\b'
+    - '\bsoftware\s+development\s+engineer\b'
+    - '\b(swe|sde)\b'
+  security:
+    - '\bsecurity\s+analyst\b'
+    - '\bsoc\s+analyst\b'
+    - '\bthreat\s+(detection|intelligence|hunting)\b'
+    - '\bcyber\s*security\b'
+    - '\binformation\s+security\b'
+    - '\bsecurity\s+sales\b'
+    - '\bsecurity\s+site\s+(operations|manager)\b'
+    - '\bsecurity\s+operations\s+center\b'
+  sales_bd:
+    - '\baccount\s+executive\b'
+    - '\bsales\s+specialist\b'
+    # ... and so on, one category per comment header from the old file
+  # continue until all ~150 patterns are transcribed
+context_suppressors:
+  - '\bdata\s*center\b|\bdatacenter\b|\bdc\s+(ops|operations|site)\b'
+```
+
+Use `git show` to fetch the pre-refactor file if needed:
+```bash
+cd /home/brockamer/Code/findajob && git log --oneline --follow src/findajob/scorer_prefilter.py | head -5
+```
+
+Find the commit just before Task 6's refactor, then:
+```bash
+cd /home/brockamer/Code/findajob && git show <commit_sha>:src/findajob/scorer_prefilter.py | less
+```
+
+Transcribe every comment-delimited block into its own `hard_rejects:<category>:` key. Suggested category names match the comment headers: `software_engineering`, `security`, `sales_bd`, `it_service_management`, `general_it_management`, `supply_chain`, `networking`, `hardware_design`, `healthcare`, `finance_legal_hr`, `construction_trades`, `aviation`, `av_events`, `food_service`, `landscaping`, `property_management`, `chemical`, `manufacturing`, `quality_process`, `systems_development`, `transportation_warehouse`, `childcare_education`, `digital_signage`, `systems_admin`, `software_ops`, `data_engineering`, `general_management`, `spam`, `facilities`.
+
+- [ ] **Step 2: Create `config/in_domain_patterns.yaml`**
+
+From the old `_IN_DOMAIN_PATTERNS` list and `_IN_DOMAIN_POISON`:
+
+```yaml
+positive:
+  - '\bdata\s*center\s+(operations|site|manager|lead|technician|engineer)\b'
+  - '\bdatacenter\s+(operations|site|manager|lead)\b'
+  - '\bdc\s+(ops|operations|site\s+manager)\b'
+  - '\bnpi\s+(manager|lead|engineer|program\s+manager)\b'
+  - '\bhardware\s+(ops|operations|bring.up|npi|program\s+manager)\b'
+  - '\binfrastructure\s+operations\s+(manager|lead|director)\b'
+  - '\boperational\s+readiness\b'
+  - '\blab\s+operations\s+(manager|lead)\b'
+  - '\bsite\s+manager,?\s+datacenter\b'
+  - '\bdatacenter.*\boperations\s+manager\b'
+  - '\bdata\s+center.*\boperations\s+(area\s+)?manager\b'
+  - '\bsite\s+operations\s+manager\b'
+  - '\bengineering\s+operations\s+manager\b'
+  - '\bfield\s+operations\s+(manager|lead)\b'
+
+poison:
+  - '\b(workplace\s+services|custodial|janitorial|facilities\s+only|office\s+services)\b'
+```
+
+- [ ] **Step 3: Create `config/companies_of_interest.txt`**
+
+From the old `TIER1` frozenset:
+
+```
+# Brock's companies-of-interest set, migrated from TIER1 on 2026-04-17.
+meta
+google
+alphabet
+microsoft
+amazon
+aws
+openai
+anthropic
+xai
+etched
+nscale
+cerebras
+groq
+tenstorrent
+sambanova
+nebius
+coreweave
+crusoe
+astera
+spacex
+together ai
+runpod
+fireworks
+edgeconnex
+hut 8
+core scientific
+fluidstack
+aetherflux
+cleanspark
+t5 data
+figure ai
+figureai
+agility robotics
+apptronik
+sanctuary ai
+collaborative robotics
+serve robotics
+locus robotics
+waymo
+zoox
+motional
+nuro
+helion
+```
+
+- [ ] **Step 4: Parity check — run the pipeline's prefilter against a sample**
+
+Create a one-off script (not committed — can live in `/tmp`):
+
+```bash
+cat > /tmp/parity_check.py <<'EOF'
+"""One-off: compare new loader-backed prefilter against the pre-refactor
+hardcoded implementation. Run after configs are populated. NOT committed."""
+import sqlite3
+import subprocess
+import sys
+
+from findajob.scorer_prefilter import prefilter_score as new_score
+
+# Fetch the pre-refactor implementation via git
+pre_ref_commit = sys.argv[1]  # pass the commit sha right before Task 6
+old_code = subprocess.check_output(
+    ["git", "show", f"{pre_ref_commit}:src/findajob/scorer_prefilter.py"], text=True
+)
+old_module = {}
+exec(old_code, old_module)
+old_score = old_module["prefilter_score"]
+
+conn = sqlite3.connect("/home/brockamer/Code/findajob/data/pipeline.db")
+conn.row_factory = sqlite3.Row
+rows = conn.execute(
+    "SELECT title, company, COALESCE(jd_text,'') AS jd FROM jobs ORDER BY created_at DESC LIMIT 500"
+).fetchall()
+
+diffs_non_tier1 = 0
+diffs_tier1_bonus = 0
+for r in rows:
+    jd_usable = len(r["jd"].split()) > 30
+    o, _ = old_score(r["title"], r["company"], jd_usable)
+    n, _ = new_score(r["title"], r["company"], jd_usable)
+
+    if (o is None) != (n is None):
+        print(f"STAGE MISMATCH: {r['title']!r} @ {r['company']!r}  old={o} new={n}")
+        diffs_non_tier1 += 1
+        continue
+
+    if o is None:
+        continue  # both went to LLM
+
+    if o["relevance_score"] != n["relevance_score"]:
+        # Expected diff: Tier 1 bonus dropped (old=6 → new=5)
+        if o["relevance_score"] == 6 and n["relevance_score"] == 5:
+            diffs_tier1_bonus += 1
+        else:
+            print(f"SCORE MISMATCH: {r['title']!r} @ {r['company']!r}  old={o['relevance_score']} new={n['relevance_score']}")
+            diffs_non_tier1 += 1
+
+print(f"\nTotal rows: {len(rows)}")
+print(f"Expected diffs (Tier-1 bonus dropped, 6→5): {diffs_tier1_bonus}")
+print(f"Unexpected diffs: {diffs_non_tier1}")
+EOF
+
+cd /home/brockamer/Code/findajob && git log --oneline src/findajob/scorer_prefilter.py | head -5
+# Note the commit sha just BEFORE Task 6's refactor commit, then:
+python3 /tmp/parity_check.py <commit_sha>
+```
+
+Expected output:
+```
+Total rows: 500
+Expected diffs (Tier-1 bonus dropped, 6→5): <small number, maybe 5-30>
+Unexpected diffs: 0
+```
+
+**Acceptance criteria:** `Unexpected diffs` must be 0. If not, the YAML transcription missed a pattern — diff the YAML vs the old Python literals and reconcile.
+
+- [ ] **Step 5: No commit**
+
+These files are gitignored — nothing to commit. Run `git status` to confirm:
+
+```bash
+cd /home/brockamer/Code/findajob && git status
+```
+
+Expected: `working tree clean` (or only unrelated untracked files from earlier sessions). The three `config/*.yaml` / `.txt` files should NOT appear.
+
+---
+
+## Task 10: Update docs + close #10
+
+Mark the generalization items done, file the follow-up issue, perform the Docs audit, and close.
+
+**Files:**
+- Modify: `docs/GENERALIZATION.md`
+
+- [ ] **Step 1: Update `docs/GENERALIZATION.md`**
+
+Under "Scorer prefilter — `scripts/scorer_prefilter.py`":
+
+Change the `[ ]` checkboxes for `TIER1`, `_HARD_REJECT_PATTERNS`, `_IN_DOMAIN_PATTERNS`, `_IN_DOMAIN_POISON` to `[x]`.
+
+Append a note under that section:
+
+```markdown
+**Resolved in PR for #10 (2026-04-17):**
+- `TIER1` was dropped entirely rather than externalized. The Tier-1 prefilter bonus (+1 score at the in-domain / no-JD floor) was removed.
+- The "companies I care about" concept lives on via `config/companies_of_interest.txt`, consumed by `sync_sheet.py` (archival exception) and `notify.py` (mis-score health check). It does NOT feed the prefilter.
+- Hard-rejects and in-domain/poison patterns now load from `config/prefilter_rules.yaml` and `config/in_domain_patterns.yaml` via `src/findajob/config_loader.py`.
+- Items 4 and 5 (scorer prompt neutralization, engineer-calibration move to profile.md) are deferred — they change LLM behavior and need a separate validation loop. See follow-up issue.
+```
+
+- [ ] **Step 2: Docs audit grep**
+
+```bash
+cd /home/brockamer/Code/findajob && grep -rn "TIER1\|_is_tier1" docs/ src/ scripts/ tests/
+```
+
+Expected output: references only in (a) `docs/GENERALIZATION.md` change log entries you just added, (b) `docs/superpowers/specs/2026-04-17-generalize-prefilter-config-design.md` (the spec we committed), (c) `docs/superpowers/plans/2026-04-17-generalize-prefilter-config.md` (this plan), and (d) possibly `docs/superpowers/specs/2026-04-15-search-expansion-design.md` (prior spec — leave untouched; specs are historical). Zero hits in `src/`, `scripts/`, `tests/` (except `tests/test_companies_of_interest_consumers.py`, which asserts the absence — that's fine).
+
+If there are unexpected hits in live code, fix them before closing.
+
+- [ ] **Step 3: File the follow-up issue**
+
+```bash
+cd /home/brockamer/Code/findajob && gh issue create \
+  --title "Neutralize job_scorer.md prompt: move domain enumerations + engineer calibration to profile" \
+  --body "$(cat <<'EOF'
+## Summary
+Follow-up to #10. Items 4 and 5 from #10 were deferred because changing LLM scoring behavior needs its own validation loop.
+
+## Scope
+- Rewrite \`HARD REJECT RULES\` section of \`config/roles/job_scorer.md\` to reference profile categories instead of enumerating tech job types inline.
+- Move \`ENGINEER TITLE CALIBRATION\` section from \`job_scorer.md\` into \`candidate_context/profile.md\` as per-candidate scoring guidance.
+- Rewrite \`TIER 1 COMPANY EXCEPTION\` in-domain title enumeration to reference profile.md's \`Target Roles\` section.
+
+## Validation
+- Re-score a sample of ~50 recent jobs with old vs. new prompt. Compare scores side-by-side. Document any drift.
+- Monitor feedback_log for 7 days post-deploy.
+
+## Blocks
+- #11 (user docs)
+- #12 (guided onboarding)
+- #13 (Docker containerization)
+- #20 (Amy beta test)
+
+## Depends on
+- #10 (config externalization — needed for profile-referencing prompts to work on a generalized install)
+EOF
+)" --label enhancement,open-source
+```
+
+Note the issue number, then add it to the project board:
+
+```bash
+cd /home/brockamer/Code/findajob && gh project item-add 1 --owner brockamer --url <new_issue_url>
+```
+
+Set priority and work stream on the new issue per the conventions in `docs/project-board.md`:
+
+```bash
+# Get the project item ID for the new issue
+NEW_ISSUE=<new_issue_number>
+ITEM_ID=$(gh project item-list 1 --owner brockamer --format json --limit 100 | jq -r ".items[] | select(.content.number == $NEW_ISSUE) | .id")
+
+# Priority: Medium (follow-up, not blocking anything today)
+gh project item-edit --project-id PVT_kwHOAgGulc4BUtxZ --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHOAgGulc4BUtxZzhCWZ08 --single-select-option-id 4e8ef0ac
+
+# Work Stream: Generalization
+gh project item-edit --project-id PVT_kwHOAgGulc4BUtxZ --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHOAgGulc4BUtxZzhCWa0Y --single-select-option-id 506d8256
+```
+
+- [ ] **Step 4: Commit docs update**
+
+```bash
+git add docs/GENERALIZATION.md
+git commit -m "$(cat <<'EOF'
+docs(generalization): mark prefilter externalization done (#10)
+
+Items 1-3 of #10 shipped. Items 4-5 (prompt neutralization) moved to
+a follow-up issue — they change LLM behavior and need separate
+validation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Close #10**
+
+```bash
+cd /home/brockamer/Code/findajob && gh issue close 10 --comment "$(cat <<'EOF'
+Completed in the prefilter-externalization branch.
+
+**What shipped:**
+- \`src/findajob/config_loader.py\` — loader for \`prefilter_rules.yaml\`, \`in_domain_patterns.yaml\`, \`companies_of_interest.txt\`.
+- Prefilter reads rules from gitignored YAML instead of Python literals.
+- Tier-1 bonus dropped (score 5 instead of 6 for in-domain/no-JD at bonus-eligible companies). The "companies I care about" concept lives on as \`companies_of_interest.txt\`, consumed by sync_sheet (archival exception) and notify (mis-score health check).
+- \`.example\` templates ship field-agnostic stubs with per-field commentary.
+- 444-line prefilter test suite preserved via \`tests/fixtures/config/\` + autouse conftest.
+
+**What deferred:** items 4 and 5 (scorer prompt rewrite, engineer calibration move to profile) — these change LLM behavior and need their own validation loop. Filed as #<NEW_ISSUE>.
+
+**Parity check:** 500 recent jobs scored via old vs. new prefilter — zero unexpected diffs; only the intentional Tier-1 bonus drops (6→5).
+
+**Docs audit:** \`docs/GENERALIZATION.md\` updated — items 1–3 under "Scorer prefilter" marked \`[x]\` with a changelog entry explaining the TIER1 deletion and the companies_of_interest consumer routing. Grep of \`docs/ src/ scripts/ tests/\` for \`TIER1\`/\`_is_tier1\` shows zero live-code hits (specs/plans in \`docs/superpowers/\` contain historical references, as expected).
+
+**Board state:** #10 → Done (auto). Follow-up issue #<NEW_ISSUE> → Backlog, Priority: Medium, Work Stream: Generalization. In Progress count stays ≤ 3.
+EOF
+)"
+```
+
+Replace `<NEW_ISSUE>` with the actual follow-up issue number from Step 3.
+
+- [ ] **Step 6: Verify #10 moved to Done on the board**
+
+```bash
+cd /home/brockamer/Code/findajob && gh project item-list 1 --owner brockamer --format json --limit 100 | jq '.items[] | select(.content.number == 10) | {number: .content.number, status: .status}'
+```
+
+Expected: `"status": "Done"`. If it didn't auto-move, edit manually:
+
+```bash
+ITEM_ID=$(gh project item-list 1 --owner brockamer --format json --limit 100 | jq -r '.items[] | select(.content.number == 10) | .id')
+gh project item-edit --project-id PVT_kwHOAgGulc4BUtxZ --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHOAgGulc4BUtxZzhCOoMM --single-select-option-id a2d5723e
+```
+
+---
+
+## Self-review checklist (run after plan is complete)
+
+- [x] **Spec coverage:** every behavior change in the spec maps to a task:
+  - Config files shape → Tasks 8, 9 (templates + real configs)
+  - `config_loader.py` API → Tasks 1–5
+  - Prefilter refactor + Tier-1 bonus drop → Task 6
+  - Consumer swap → Task 7
+  - Tests → Tasks 2–5 (unit), Task 6 (integration), Task 7 (regression), Task 9 (parity)
+  - Docs audit → Task 10
+  - Follow-up issue → Task 10
+
+- [x] **Placeholder scan:** no "TBD", "TODO", "fill in", or unnamed functions.
+
+- [x] **Type consistency:** `load_hard_reject_rules` return type `tuple[re.Pattern[str], Optional[re.Pattern[str]]]` consistent across skeleton (Task 1), implementation (Task 3), and consumer (Task 6). Same for `load_in_domain_rules`. `is_company_of_interest(company: str) -> bool` consistent across skeleton (Task 1), implementation (Task 2), and consumers (Task 7).

--- a/docs/superpowers/specs/2026-04-17-generalize-prefilter-config-design.md
+++ b/docs/superpowers/specs/2026-04-17-generalize-prefilter-config-design.md
@@ -1,0 +1,256 @@
+# Generalize Prefilter Config — Design
+
+**Issue:** [#10](https://github.com/brockamer/findajob/issues/10) — Generalize config layer: externalize TIER1, prefilter, in-domain patterns
+**Scope:** Items 1–3 from the issue (prefilter externalization). Items 4–5 (prompt rewrites) deferred to a follow-up.
+**Date:** 2026-04-17
+
+---
+
+## Goal
+
+Move domain-specific rule data out of `scorer_prefilter.py` into gitignored config files, so a new user in a different field can run the pipeline without editing tracked Python code.
+
+## Non-goals
+
+- Rewriting `config/roles/job_scorer.md` hard-reject / engineer-calibration sections (items 4–5 of the issue — follow-up).
+- Building a guided `setup_profile.py` onboarding flow (that is issue #12).
+- Changing the prefilter's Stage 1 / Stage 2 control flow. Only the *source* of the data moves.
+
+## Behavior change inventory
+
+| Component | Before | After |
+|---|---|---|
+| Tier-1 prefilter bonus (in-domain + no JD → score 6) | Scores 6 for Tier-1 companies, 5 otherwise | Always scores 5. Bonus deleted. |
+| `_is_tier1()` / `TIER1` frozenset | Public in `scorer_prefilter.py` | Removed entirely |
+| Archival exception in `sync_sheet.py` | Driven by `_is_tier1()` | Driven by `is_company_of_interest()` from new config |
+| Mis-score health check in `notify.py` | Driven by `TIER1` | Driven by `is_company_of_interest()` from new config |
+| `_HARD_REJECT_PATTERNS` literal | ~150 regex in code | Loaded from `config/prefilter_rules.yaml` |
+| `_DC_CONTEXT_RE` override | Hardcoded in module | Loaded as `context_suppressors` from `config/prefilter_rules.yaml` |
+| `_IN_DOMAIN_PATTERNS` + `_IN_DOMAIN_POISON` | In-code | Loaded from `config/in_domain_patterns.yaml` (`positive` + `poison` keys) |
+
+All other prefilter behavior is preserved bit-for-bit.
+
+## Architecture
+
+### New module: `src/findajob/config_loader.py`
+
+Single module responsible for reading the three config files, validating, compiling regexes, caching.
+
+Public API:
+
+```python
+def load_hard_reject_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
+    """(reject_re, suppressor_re). suppressor_re is None if no suppressors configured."""
+
+def load_in_domain_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
+    """(in_domain_re, poison_re). poison_re is None if no poison configured."""
+
+def load_companies_of_interest() -> frozenset[str]:
+    """Lowercase company names. Used for case-insensitive substring matching."""
+
+def is_company_of_interest(company: str) -> bool:
+    """Case-insensitive substring check. False for empty/None inputs."""
+
+class ConfigError(Exception):
+    """Raised when a config file is malformed (bad YAML, bad regex, wrong shape)."""
+
+def _reset_cache() -> None:
+    """Test-only. Clears module-level caches."""
+```
+
+- **Caching:** each `load_*` computes once, stashes in module-level global, returns cached result on subsequent calls.
+- **Empty/missing file:** returns a sentinel regex that never matches (`re.compile(r"(?!x)x")`) for regex loaders; empty `frozenset()` for companies. Emits `warnings.warn(UserWarning, ...)` once per affected file per process.
+- **Malformed:** raises `ConfigError` naming the file and the offending input (bad YAML, bad regex, wrong top-level shape). Strict — partially working prefilters are worse than loud failures.
+- **File locations:** via `findajob.paths.BASE`. No new path constants.
+
+### Refactored module: `src/findajob/scorer_prefilter.py`
+
+Regex objects now come from the loader at import time:
+
+```python
+from findajob.config_loader import load_hard_reject_rules, load_in_domain_rules
+
+_HARD_REJECT_RE, _SUPPRESSOR_RE = load_hard_reject_rules()
+_IN_DOMAIN_RE, _POISON_RE = load_in_domain_rules()
+```
+
+Functions `_hard_reject_match()`, `_in_domain_match()`, and `prefilter_score()` keep their signatures. Stage 2 simplifies: no Tier-1 branch, score is always 5 when matched. All `TIER1`, `_is_tier1`, and literal pattern lists are deleted.
+
+### Consumer updates
+
+- **`scripts/sync_sheet.py:18,195`** — replace `from findajob.scorer_prefilter import _is_tier1` with `from findajob.config_loader import is_company_of_interest`; update the list comprehension.
+- **`scripts/notify.py:407,423`** — replace `from findajob.scorer_prefilter import TIER1` with `from findajob.config_loader import is_company_of_interest`; replace the substring loop with a call per row.
+
+## Config file shapes
+
+### `config/prefilter_rules.yaml` (gitignored)
+
+```yaml
+# Hard-reject title patterns. If any matches, score=1 (no LLM).
+# Exception: if any context_suppressor also matches, the reject is skipped.
+hard_rejects:
+  software_engineering:
+    - '\bsoftware\s+engineer(ing)?\b'
+    - '\b(swe|sde)\b'
+  healthcare:
+    - '\bnurs(e|ing)\b'
+  # ... more categories (grouping is presentational; loader flattens)
+
+context_suppressors:
+  - '\bdata\s*center\b|\bdatacenter\b|\bdc\s+(ops|operations|site)\b'
+```
+
+Top-level keys: `hard_rejects` (required, dict of category → list of regex) and `context_suppressors` (optional, list of regex). Unknown keys raise `ConfigError`.
+
+### `config/in_domain_patterns.yaml` (gitignored)
+
+```yaml
+positive:
+  - '\bdata\s*center\s+(operations|site|manager|lead|technician|engineer)\b'
+  - '\bnpi\s+(manager|lead|engineer|program\s+manager)\b'
+
+poison:
+  - '\b(workplace\s+services|custodial|janitorial|facilities\s+only|office\s+services)\b'
+```
+
+Top-level keys: `positive` (required, list), `poison` (optional, list).
+
+### `config/companies_of_interest.txt` (gitignored)
+
+```
+# One company per line. Case-insensitive substring match.
+# Used by sync_sheet.py (archival exception) and notify.py (mis-score health check).
+# NOT used by the prefilter.
+meta
+google
+# ...
+```
+
+Blank lines and lines starting with `#` are skipped. Each entry lowercased at load time. No validation beyond that.
+
+## Example files (tracked)
+
+Per CLAUDE.md generalization rules, `.example` files must not hardcode one-field content. Each example is a **minimal stub with multi-field commentary**:
+
+- `config/prefilter_rules.yaml.example` — one sample category with one pattern (field-agnostic, e.g., a generic "job alert" spam filter), plus a commented-out block per field (tech / healthcare / education / social work) showing suggested categories for that field so a new user can uncomment and edit the one that fits them.
+- `config/in_domain_patterns.yaml.example` — one sample positive + one sample poison using field-agnostic placeholders, commentary on how the two interact.
+- `config/companies_of_interest.txt.example` — empty, with a comment block explaining the purpose and showing a few generic placeholder entries.
+
+The actual `.yaml` and `.txt` files on Brock's machine are populated by hand during the PR (see Migration).
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| File missing | `warnings.warn(UserWarning)`, return empty / no-op. |
+| File exists, empty or whitespace-only | Warn, return empty / no-op. |
+| File exists, YAML parses but wrong top-level shape (e.g., `hard_rejects` is a list not a dict) | `ConfigError` with path + expected shape. |
+| File exists, YAML parse error | `ConfigError` with path + parser error. |
+| Valid shape, one regex fails to compile | `ConfigError` naming the file, the category (if applicable), and the pattern. Do NOT continue with partial config. |
+| `companies_of_interest.txt` has invalid chars | No validation — anything goes (substring match is forgiving). |
+
+The warning surface uses `warnings.warn(UserWarning)` so it appears in pytest output, CLI stderr, and systemd journal without requiring a logger.
+
+## Migration
+
+**One-time, manual, done as part of the PR:**
+
+1. Hand-translate the current Python literals in `scorer_prefilter.py` into `config/prefilter_rules.yaml` and `config/in_domain_patterns.yaml` on Brock's machine. Preserve the category comments as YAML keys under `hard_rejects`.
+2. Hand-create `config/companies_of_interest.txt` from the current `TIER1` set (49 entries).
+3. Verify via a one-off diff-check: on a branch with both the old `scorer_prefilter.py` and the new loader-backed version reachable, pull a sample of ~200 recent jobs from `data/pipeline.db`, run each title through both implementations, assert identical `(score_status, relevance_score)` outputs — modulo the intentional Tier-1 bonus drop (old score=6 → new score=5 when `_is_tier1(company)` was true). The diff-check runs once on Brock's laptop and is not committed.
+
+Git history preserves the old literals for reference.
+
+## Test strategy
+
+### Fixtures
+
+New `tests/fixtures/config/` directory containing:
+- `prefilter_rules.yaml` — representative subset of Brock's current rules, enough to exercise every code path (reject hit, suppressor override, miss).
+- `in_domain_patterns.yaml` — subset of positive + poison.
+- `companies_of_interest.txt` — handful of well-known company names matching existing test assertions.
+
+### `conftest.py` autouse fixture
+
+Monkeypatches `config_loader`'s path constants to point at `tests/fixtures/config/`. Calls `_reset_cache()` before each test. Every existing `test_scorer_prefilter.py` test continues to pass because the fixture patterns include the strings those tests assert against.
+
+### Existing test file: `tests/test_scorer_prefilter.py`
+
+- `TestIsTier1` class → **deleted** (underlying function is gone).
+- Stage 2 tests asserting `score == 6` for Tier-1 companies → updated to assert `score == 5`.
+- All other test classes unchanged.
+
+### New test file: `tests/test_config_loader.py`
+
+Covers:
+- Valid YAML → correct regex objects + correct sentinel regex on empty lists.
+- Missing file → no-op regex + one `UserWarning`.
+- Empty file / empty list → no-op + warning.
+- Malformed YAML → `ConfigError`.
+- Bad regex → `ConfigError` naming file + pattern.
+- Top-level shape violations (wrong type, unknown keys) → `ConfigError`.
+- `companies_of_interest.txt`: comment handling, case normalization, empty file → empty + warning.
+- `is_company_of_interest`: substring match, empty input guard, None input guard.
+
+### New test file: `tests/test_companies_of_interest_consumers.py`
+
+- Asserts `scripts/sync_sheet.py` and `scripts/notify.py` import `is_company_of_interest` (regression guard against re-introducing `_is_tier1`).
+
+### Manual validation after landing
+
+- Run `triage.py` on today's fetched jobs. Compare prefilter decisions to the previous day's log.
+- `SELECT COUNT(*) FROM jobs WHERE relevance_score=6 AND ai_notes LIKE '%Tier 1%'` before and after to quantify the dropped-bonus impact.
+
+## Deletion inventory
+
+From `src/findajob/scorer_prefilter.py`:
+- `TIER1` frozenset
+- `_is_tier1()`
+- `_HARD_REJECT_PATTERNS` list
+- `_HARD_REJECT_RE` compiled pattern (replaced by loader output)
+- `_DC_CONTEXT_RE` compiled pattern (replaced by `_SUPPRESSOR_RE` from loader)
+- `_IN_DOMAIN_PATTERNS` list
+- `_IN_DOMAIN_RE` compiled pattern (replaced by loader output)
+- `_IN_DOMAIN_POISON` compiled pattern (replaced by loader output)
+- Stage 2 Tier-1 branch in `prefilter_score()` (the `tier1 = _is_tier1(company)` line and the `score = 6 if tier1 else 5` split)
+
+From `tests/test_scorer_prefilter.py`:
+- `TestIsTier1` class
+- Stage 2 Tier-1 score assertions (updated, not fully deleted)
+
+## Build sequence inside the PR
+
+1. Add `src/findajob/config_loader.py` (with empty-sentinel stubs, no consumers yet).
+2. Add `tests/test_config_loader.py` + `tests/fixtures/config/*`.
+3. Add `conftest.py` autouse fixture pointing the loader at fixtures.
+4. Create `.example` files (tracked).
+5. Hand-create real `config/prefilter_rules.yaml`, `in_domain_patterns.yaml`, `companies_of_interest.txt` on Brock's machine (gitignored).
+6. Refactor `scorer_prefilter.py` to read from loader; delete the literals.
+7. Update `tests/test_scorer_prefilter.py` (delete `TestIsTier1`, update Stage-2 assertions).
+8. Update `scripts/sync_sheet.py` and `scripts/notify.py` to use `is_company_of_interest`.
+9. Add `tests/test_companies_of_interest_consumers.py`.
+10. Run diff-check: sample jobs through old vs. new prefilter, confirm identical decisions modulo the dropped bonus.
+11. Update `docs/GENERALIZATION.md`: mark items 1–3 of "Scorer prefilter" done; note items 4–5 deferred to a follow-up issue.
+12. Update `.gitignore` if `companies_of_interest.txt` / `prefilter_rules.yaml` / `in_domain_patterns.yaml` aren't already covered.
+
+## Documentation updates (Docs audit gate)
+
+Per CLAUDE.md Definition of Done, before closing this issue:
+
+- [ ] `docs/GENERALIZATION.md` — items 1–3 under "Scorer prefilter" marked `[x]`, with a note that `TIER1` was dropped rather than externalized and `companies_of_interest.txt` now serves the archival + health-check use cases.
+- [ ] `docs/architecture.md` — if it references the prefilter rules, update.
+- [ ] `docs/operations.md` — if it mentions `TIER1` or the Tier-1 bonus, update.
+- [ ] Grep check: `grep -r 'TIER1\|_is_tier1' docs/` — should return zero after this PR.
+
+## Follow-up issue to file
+
+Items 4–5 of #10 (prompt rewrites) deferred to a new issue titled "Neutralize job_scorer.md prompt — reference profile categories, move engineer calibration to profile.md". Blocks: #11, #12, #13, #20.
+
+## Open questions resolved in brainstorming
+
+- Q1 → no `tier1` file; `target_companies.md` untouched.
+- Q2 → items 1–3 only, not 4–5.
+- Q3 → YAML for both rule files, txt for companies_of_interest.
+- Q4 → empty defaults + warning.
+- Q5 → minimal stub `.example` with multi-field comments.
+- Q6 → drop Tier-1 prefilter bonus entirely (Option X-a). New `companies_of_interest.txt` for sync_sheet + notify consumers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "requests>=2.31.0",
     "jsonschema>=4.26.0",
     "beautifulsoup4>=4.14.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -315,7 +315,7 @@ def cmd_health_check():
 
     # Target company jobs scored 3-6 in the last N days (potential mis-scores worth reviewing).
     # Score 1-2 are excluded — prefilter hard rejects or clear mismatches, not actionable.
-    from findajob.scorer_prefilter import TIER1
+    from findajob.config_loader import is_company_of_interest
 
     cutoff = (datetime.now(UTC) - timedelta(days=TARGET_LOWSCORE_DAYS)).isoformat()
     low_target = conn.execute(
@@ -327,11 +327,8 @@ def cmd_health_check():
     """,
         (cutoff,),
     ).fetchall()
-    # Filter in Python since TIER1 check is a substring match
     mis_scored = [
-        (r["title"], r["company"], r["relevance_score"])
-        for r in low_target
-        if r["company"] and any(t in r["company"].lower() for t in TIER1)
+        (r["title"], r["company"], r["relevance_score"]) for r in low_target if is_company_of_interest(r["company"])
     ]
     if mis_scored:
         issues.append(f"REVIEW: {len(mis_scored)} target-company job(s) scored 3-6 in last {TARGET_LOWSCORE_DAYS}d:")

--- a/scripts/sync_sheet.py
+++ b/scripts/sync_sheet.py
@@ -14,8 +14,8 @@ from pathlib import Path
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
+from findajob.config_loader import is_company_of_interest
 from findajob.paths import BASE
-from findajob.scorer_prefilter import _is_tier1
 from findajob.utils import log_event
 
 DB_PATH = f"{BASE}/data/pipeline.db"
@@ -192,7 +192,7 @@ def sync_sheet1(svc, conn):
     """,
         (SHEET1_ARCHIVE_DAYS,),
     ).fetchall()
-    target_extras = [r for r in all_rows if r["id"] not in target_ids and _is_tier1(r["company"])]
+    target_extras = [r for r in all_rows if r["id"] not in target_ids and is_company_of_interest(r["company"])]
 
     combined = list(rows) + target_extras
     # Highest score first, then newest first within same score (ISO dates sort lexically)

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -97,7 +97,43 @@ def load_hard_reject_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
 
 def load_in_domain_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
     """(in_domain_re, poison_re). poison_re is None if no poison configured."""
-    raise NotImplementedError
+    global _in_domain_cache
+    if _in_domain_cache is not None:
+        return _in_domain_cache
+
+    data = _safe_load_yaml(_IN_DOMAIN_PATH, "in_domain_patterns.yaml")
+    if data is None:
+        _in_domain_cache = (_NEVER_MATCH, None)
+        return _in_domain_cache
+
+    positive = data.get("positive", [])
+    if not isinstance(positive, list):
+        raise ConfigError(
+            f"in_domain_patterns.yaml: 'positive' must be a list, "
+            f"got {type(positive).__name__}"
+        )
+    for p in positive:
+        if not isinstance(p, str):
+            raise ConfigError(f"in_domain_patterns.yaml: positive pattern is not a string: {p!r}")
+
+    positive_re = _compile_patterns(positive, _IN_DOMAIN_PATH, "positive")
+
+    poison = data.get("poison", []) or []
+    if not isinstance(poison, list):
+        raise ConfigError(
+            f"in_domain_patterns.yaml: 'poison' must be a list, "
+            f"got {type(poison).__name__}"
+        )
+    for p in poison:
+        if not isinstance(p, str):
+            raise ConfigError(f"in_domain_patterns.yaml: poison pattern is not a string: {p!r}")
+
+    poison_re: re.Pattern[str] | None = None
+    if poison:
+        poison_re = _compile_patterns(poison, _IN_DOMAIN_PATH, "poison")
+
+    _in_domain_cache = (positive_re, poison_re)
+    return _in_domain_cache
 
 
 def load_companies_of_interest() -> frozenset[str]:

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -1,0 +1,71 @@
+"""Loads prefilter rules and companies-of-interest from gitignored configs.
+
+Reads from BASE/config/:
+  - prefilter_rules.yaml        (hard_rejects + context_suppressors)
+  - in_domain_patterns.yaml     (positive + poison)
+  - companies_of_interest.txt   (one company per line; case-insensitive)
+
+Missing files emit a UserWarning and return no-op sentinels so the pipeline
+degrades gracefully on a fresh install. Malformed files raise ConfigError.
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from findajob.paths import BASE
+
+# Module-level paths (overridden in tests via conftest)
+_RULES_PATH = Path(BASE) / "config" / "prefilter_rules.yaml"
+_IN_DOMAIN_PATH = Path(BASE) / "config" / "in_domain_patterns.yaml"
+_COMPANIES_PATH = Path(BASE) / "config" / "companies_of_interest.txt"
+
+# Sentinel regex that never matches anything. Used when a config is missing
+# or empty. Returned in place of None so callers don't need a None-check.
+_NEVER_MATCH = re.compile(r"(?!x)x")
+
+# Caches
+_hard_reject_cache: Optional[tuple[re.Pattern[str], Optional[re.Pattern[str]]]] = None
+_in_domain_cache: Optional[tuple[re.Pattern[str], Optional[re.Pattern[str]]]] = None
+_companies_cache: Optional[frozenset[str]] = None
+
+# Warnings emitted (dedup per process)
+_warned: set[str] = set()
+
+
+class ConfigError(Exception):
+    """Raised when a config file is malformed (bad YAML, bad regex, wrong shape)."""
+
+
+def load_hard_reject_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+    """(reject_re, suppressor_re). suppressor_re is None if no suppressors configured."""
+    raise NotImplementedError
+
+
+def load_in_domain_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+    """(in_domain_re, poison_re). poison_re is None if no poison configured."""
+    raise NotImplementedError
+
+
+def load_companies_of_interest() -> frozenset[str]:
+    """Lowercase company names. Used for case-insensitive substring matching."""
+    raise NotImplementedError
+
+
+def is_company_of_interest(company: str) -> bool:
+    """Case-insensitive substring check. False for empty/None inputs."""
+    raise NotImplementedError
+
+
+def _reset_cache() -> None:
+    """Test-only. Clears module-level caches and warning dedup."""
+    global _hard_reject_cache, _in_domain_cache, _companies_cache
+    _hard_reject_cache = None
+    _in_domain_cache = None
+    _companies_cache = None
+    _warned.clear()

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -54,12 +54,45 @@ def load_in_domain_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
 
 def load_companies_of_interest() -> frozenset[str]:
     """Lowercase company names. Used for case-insensitive substring matching."""
-    raise NotImplementedError
+    global _companies_cache
+    if _companies_cache is not None:
+        return _companies_cache
+
+    try:
+        raw = _COMPANIES_PATH.read_text()
+    except FileNotFoundError:
+        _warn_once("config/companies_of_interest.txt missing — sync_sheet archival exception and notify mis-score check will be disabled")
+        _companies_cache = frozenset()
+        return _companies_cache
+
+    entries: set[str] = set()
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        entries.add(stripped.lower())
+
+    if not entries:
+        _warn_once("config/companies_of_interest.txt is empty — sync_sheet archival exception and notify mis-score check will be disabled")
+
+    _companies_cache = frozenset(entries)
+    return _companies_cache
 
 
 def is_company_of_interest(company: str) -> bool:
     """Case-insensitive substring check. False for empty/None inputs."""
-    raise NotImplementedError
+    if not company:
+        return False
+    c = company.lower()
+    return any(t in c for t in load_companies_of_interest())
+
+
+def _warn_once(msg: str) -> None:
+    """Emit a UserWarning only once per process. Deduped via _warned set."""
+    if msg in _warned:
+        return
+    _warned.add(msg)
+    warnings.warn(msg, UserWarning, stacklevel=3)
 
 
 def _reset_cache() -> None:

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -15,6 +15,8 @@ import re
 import warnings
 from pathlib import Path
 
+import yaml
+
 from findajob.paths import BASE
 
 # Module-level paths (overridden in tests via conftest)
@@ -41,7 +43,56 @@ class ConfigError(Exception):
 
 def load_hard_reject_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
     """(reject_re, suppressor_re). suppressor_re is None if no suppressors configured."""
-    raise NotImplementedError
+    global _hard_reject_cache
+    if _hard_reject_cache is not None:
+        return _hard_reject_cache
+
+    data = _safe_load_yaml(_RULES_PATH, "prefilter_rules.yaml")
+    if data is None:
+        _hard_reject_cache = (_NEVER_MATCH, None)
+        return _hard_reject_cache
+
+    hard_rejects = data.get("hard_rejects", {})
+    if not isinstance(hard_rejects, dict):
+        raise ConfigError(
+            f"prefilter_rules.yaml: 'hard_rejects' must be a mapping of category→list, "
+            f"got {type(hard_rejects).__name__}"
+        )
+
+    reject_patterns: list[str] = []
+    for category, patterns in hard_rejects.items():
+        if not isinstance(patterns, list):
+            raise ConfigError(
+                f"prefilter_rules.yaml: hard_rejects['{category}'] must be a list, "
+                f"got {type(patterns).__name__}"
+            )
+        for p in patterns:
+            if not isinstance(p, str):
+                raise ConfigError(
+                    f"prefilter_rules.yaml: pattern in '{category}' is not a string: {p!r}"
+                )
+            reject_patterns.append(p)
+
+    reject_re = _compile_patterns(reject_patterns, _RULES_PATH, "hard_rejects")
+
+    suppressors = data.get("context_suppressors", []) or []
+    if not isinstance(suppressors, list):
+        raise ConfigError(
+            f"prefilter_rules.yaml: 'context_suppressors' must be a list, "
+            f"got {type(suppressors).__name__}"
+        )
+    for p in suppressors:
+        if not isinstance(p, str):
+            raise ConfigError(
+                f"prefilter_rules.yaml: context_suppressor pattern is not a string: {p!r}"
+            )
+
+    suppressor_re: re.Pattern[str] | None = None
+    if suppressors:
+        suppressor_re = _compile_patterns(suppressors, _RULES_PATH, "context_suppressors")
+
+    _hard_reject_cache = (reject_re, suppressor_re)
+    return _hard_reject_cache
 
 
 def load_in_domain_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
@@ -105,3 +156,44 @@ def _reset_cache() -> None:
     _in_domain_cache = None
     _companies_cache = None
     _warned.clear()
+
+
+def _safe_load_yaml(path: Path, label: str) -> dict | None:
+    """Read YAML. Returns None if file missing (with warning) or empty.
+    Raises ConfigError on parse error or non-mapping top-level."""
+    try:
+        text = path.read_text()
+    except FileNotFoundError:
+        _warn_once(f"config/{label} missing — prefilter will be a no-op for this config")
+        return None
+
+    if not text.strip():
+        _warn_once(f"config/{label} is empty — prefilter will be a no-op for this config")
+        return None
+
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        raise ConfigError(f"config/{label}: YAML parse error: {e}") from e
+
+    if data is None:
+        _warn_once(f"config/{label} parsed to null — prefilter will be a no-op for this config")
+        return None
+
+    if not isinstance(data, dict):
+        raise ConfigError(f"config/{label}: top level must be a mapping, got {type(data).__name__}")
+
+    return data
+
+
+def _compile_patterns(patterns: list[str], path: Path, label: str) -> re.Pattern[str]:
+    """Compile a list of regex strings into a single alternation. Bad patterns
+    raise ConfigError with the offending pattern surfaced."""
+    if not patterns:
+        return _NEVER_MATCH
+    for p in patterns:
+        try:
+            re.compile(p)
+        except re.error as e:
+            raise ConfigError(f"{path.name}: invalid regex in {label}: {p!r} — {e}") from e
+    return re.compile("|".join(f"(?:{p})" for p in patterns), re.IGNORECASE)

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import re
 import warnings
 from pathlib import Path
-from typing import Optional
 
 from findajob.paths import BASE
 
@@ -28,9 +27,9 @@ _COMPANIES_PATH = Path(BASE) / "config" / "companies_of_interest.txt"
 _NEVER_MATCH = re.compile(r"(?!x)x")
 
 # Caches
-_hard_reject_cache: Optional[tuple[re.Pattern[str], Optional[re.Pattern[str]]]] = None
-_in_domain_cache: Optional[tuple[re.Pattern[str], Optional[re.Pattern[str]]]] = None
-_companies_cache: Optional[frozenset[str]] = None
+_hard_reject_cache: tuple[re.Pattern[str], re.Pattern[str] | None] | None = None
+_in_domain_cache: tuple[re.Pattern[str], re.Pattern[str] | None] | None = None
+_companies_cache: frozenset[str] | None = None
 
 # Warnings emitted (dedup per process)
 _warned: set[str] = set()
@@ -40,12 +39,12 @@ class ConfigError(Exception):
     """Raised when a config file is malformed (bad YAML, bad regex, wrong shape)."""
 
 
-def load_hard_reject_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+def load_hard_reject_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
     """(reject_re, suppressor_re). suppressor_re is None if no suppressors configured."""
     raise NotImplementedError
 
 
-def load_in_domain_rules() -> tuple[re.Pattern[str], Optional[re.Pattern[str]]]:
+def load_in_domain_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
     """(in_domain_re, poison_re). poison_re is None if no poison configured."""
     raise NotImplementedError
 

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -16,8 +16,6 @@ import warnings
 from pathlib import Path
 from typing import Optional
 
-import yaml
-
 from findajob.paths import BASE
 
 # Module-level paths (overridden in tests via conftest)
@@ -61,7 +59,10 @@ def load_companies_of_interest() -> frozenset[str]:
     try:
         raw = _COMPANIES_PATH.read_text()
     except FileNotFoundError:
-        _warn_once("config/companies_of_interest.txt missing — sync_sheet archival exception and notify mis-score check will be disabled")
+        _warn_once(
+            "config/companies_of_interest.txt missing — "
+            "sync_sheet archival exception and notify mis-score check will be disabled"
+        )
         _companies_cache = frozenset()
         return _companies_cache
 
@@ -73,7 +74,10 @@ def load_companies_of_interest() -> frozenset[str]:
         entries.add(stripped.lower())
 
     if not entries:
-        _warn_once("config/companies_of_interest.txt is empty — sync_sheet archival exception and notify mis-score check will be disabled")
+        _warn_once(
+            "config/companies_of_interest.txt is empty — "
+            "sync_sheet archival exception and notify mis-score check will be disabled"
+        )
 
     _companies_cache = frozenset(entries)
     return _companies_cache

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -63,14 +63,11 @@ def load_hard_reject_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
     for category, patterns in hard_rejects.items():
         if not isinstance(patterns, list):
             raise ConfigError(
-                f"prefilter_rules.yaml: hard_rejects['{category}'] must be a list, "
-                f"got {type(patterns).__name__}"
+                f"prefilter_rules.yaml: hard_rejects['{category}'] must be a list, got {type(patterns).__name__}"
             )
         for p in patterns:
             if not isinstance(p, str):
-                raise ConfigError(
-                    f"prefilter_rules.yaml: pattern in '{category}' is not a string: {p!r}"
-                )
+                raise ConfigError(f"prefilter_rules.yaml: pattern in '{category}' is not a string: {p!r}")
             reject_patterns.append(p)
 
     reject_re = _compile_patterns(reject_patterns, _RULES_PATH, "hard_rejects")
@@ -78,14 +75,11 @@ def load_hard_reject_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
     suppressors = data.get("context_suppressors", []) or []
     if not isinstance(suppressors, list):
         raise ConfigError(
-            f"prefilter_rules.yaml: 'context_suppressors' must be a list, "
-            f"got {type(suppressors).__name__}"
+            f"prefilter_rules.yaml: 'context_suppressors' must be a list, got {type(suppressors).__name__}"
         )
     for p in suppressors:
         if not isinstance(p, str):
-            raise ConfigError(
-                f"prefilter_rules.yaml: context_suppressor pattern is not a string: {p!r}"
-            )
+            raise ConfigError(f"prefilter_rules.yaml: context_suppressor pattern is not a string: {p!r}")
 
     suppressor_re: re.Pattern[str] | None = None
     if suppressors:
@@ -108,10 +102,7 @@ def load_in_domain_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
 
     positive = data.get("positive", [])
     if not isinstance(positive, list):
-        raise ConfigError(
-            f"in_domain_patterns.yaml: 'positive' must be a list, "
-            f"got {type(positive).__name__}"
-        )
+        raise ConfigError(f"in_domain_patterns.yaml: 'positive' must be a list, got {type(positive).__name__}")
     for p in positive:
         if not isinstance(p, str):
             raise ConfigError(f"in_domain_patterns.yaml: positive pattern is not a string: {p!r}")
@@ -120,10 +111,7 @@ def load_in_domain_rules() -> tuple[re.Pattern[str], re.Pattern[str] | None]:
 
     poison = data.get("poison", []) or []
     if not isinstance(poison, list):
-        raise ConfigError(
-            f"in_domain_patterns.yaml: 'poison' must be a list, "
-            f"got {type(poison).__name__}"
-        )
+        raise ConfigError(f"in_domain_patterns.yaml: 'poison' must be a list, got {type(poison).__name__}")
     for p in poison:
         if not isinstance(p, str):
             raise ConfigError(f"in_domain_patterns.yaml: poison pattern is not a string: {p!r}")

--- a/src/findajob/scorer_prefilter.py
+++ b/src/findajob/scorer_prefilter.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-# ~/JobSearchPipeline/scripts/scorer_prefilter.py
 """
 Deterministic pre-filter for job scoring.
 Runs BEFORE any LLM call. Two stages:
 
   Stage 1 — Hard reject by title regex → score 1, scored, no LLM
-  Stage 2 — In-domain title + no usable JD → score 5 (or 6 for Tier 1), no LLM
+            (context_suppressors in prefilter_rules.yaml can override)
+  Stage 2 — In-domain title + no usable JD → score 5, no LLM
 
 If neither stage fires, returns (None, None) and caller should invoke the LLM.
 
+Rules are loaded from config/prefilter_rules.yaml and config/in_domain_patterns.yaml
+(both gitignored). See src/findajob/config_loader.py.
+
 Usage:
-    from scorer_prefilter import prefilter_score
+    from findajob.scorer_prefilter import prefilter_score
     result, reason = prefilter_score(title, company, jd_is_usable)
     if result is not None:
         return result, 0   # latency=0, no subprocess
@@ -19,308 +22,32 @@ Usage:
 
 from __future__ import annotations
 
-import re
-
-# ── Tier 1 companies ──────────────────────────────────────────────────────────
-TIER1: frozenset[str] = frozenset(
-    [
-        "meta",
-        "google",
-        "alphabet",
-        "microsoft",
-        "amazon",
-        "aws",
-        "openai",
-        "anthropic",
-        "xai",
-        "etched",
-        "nscale",
-        "cerebras",
-        "groq",
-        "tenstorrent",
-        "sambanova",
-        "nebius",
-        "coreweave",
-        "crusoe",
-        "astera",
-        # Expansion (2026-04-15)
-        "spacex",
-        "together ai",
-        "runpod",
-        "fireworks",
-        "edgeconnex",
-        "hut 8",
-        "core scientific",
-        "fluidstack",
-        "aetherflux",
-        "cleanspark",
-        "t5 data",
-        # Robotics / AV / Adjacent (2026-04-16, issue #1)
-        "figure ai",
-        "figureai",
-        "agility robotics",
-        "apptronik",
-        "sanctuary ai",
-        "collaborative robotics",
-        "serve robotics",
-        "locus robotics",
-        "waymo",
-        "zoox",
-        "motional",
-        "nuro",
-        "helion",
-    ]
-)
-
-
-def _is_tier1(company: str) -> bool:
-    if not company:
-        return False
-    c = company.lower()
-    return any(t in c for t in TIER1)
-
-
-# ── Stage 1: Hard reject patterns ─────────────────────────────────────────────
-# Applied to title only. Any match → score 1 immediately, no JD needed.
-# Order: specific before general to aid readability; all case-insensitive.
-_HARD_REJECT_PATTERNS: list[str] = [
-    # Software engineering
-    r"\bsoftware\s+engineer(ing)?\b",
-    r"\bsoftware\s+developer\b",
-    r"\bsoftware\s+architect\b",
-    r"\bsoftware\s+development\s+engineer\b",
-    r"\b(swe|sde)\b",
-    # Security (cyber / logical — not physical DC security which would be facilities)
-    r"\bsecurity\s+analyst\b",
-    r"\bsoc\s+analyst\b",
-    r"\bthreat\s+(detection|intelligence|hunting)\b",
-    r"\bcyber\s*security\b",
-    r"\binformation\s+security\b",
-    r"\bsecurity\s+sales\b",
-    r"\bsecurity\s+site\s+(operations|manager)\b",
-    r"\bsecurity\s+operations\s+center\b",
-    # Sales / BD
-    r"\baccount\s+executive\b",
-    r"\bsales\s+specialist\b",
-    r"\bsales\s+representative\b",
-    r"\bsales\s+manager\b",
-    r"\benterprise\s+sales\b",
-    r"\bkey\s+account\b",
-    r"\bfield\s+sales\b",
-    r"\bbusiness\s+development\s+(manager|lead|director|representative)\b",
-    # IT service management
-    r"\bit\s+service\s+management\b",
-    r"\bitsm\b",
-    r"\bit\s+help\s*desk\b",
-    r"\bservice\s+desk\s+manager\b",
-    r"\bit\s+support\s+manager\b",
-    # General IT management (no DC scope)
-    r"\bregional\s+it\s+manager\b",
-    r"\bworkplace\s+technology\s+manager\b",
-    r"\bend.user\s+computing\b",
-    # Supply chain
-    r"\bsupply\s+chain\b",
-    r"\bprocurement\s+(manager|lead|specialist|director)\b",
-    r"\bsourcing\s+(manager|lead|specialist)\b",
-    r"\blogistics\s+manager\b",
-    r"\bfulfillment\s+manager\b",
-    r"\binventory\s+(manager|analyst)\b",
-    # Networking
-    r"\bnetwork\s+engineer(ing)?\b",
-    r"\bnetwork\s+architect\b",
-    r"\bnoc\s+engineer\b",
-    r"\bconnectivity\s+engineer\b",
-    # Hardware design (NOT ops — Tier 1 does NOT override these)
-    r"\bcontrols\s+engineer(ing)?\b",
-    r"\belectrical\s+engineer(ing)?\b",
-    r"\bmechanical\s+engineer(ing)?\b",
-    r"\bfirmware\s+engineer(ing)?\b",
-    r"\bfpga\b",
-    r"\bboard\s+design\b",
-    r"\bhardware\s+development\s+engineer\b",
-    r"\bhardware\s+design\s+engineer\b",
-    # Healthcare / life sciences
-    r"\bnurs(e|ing)\b",
-    r"\bclinical\s+(manager|director|lead|specialist|coordinator|trial|research|lab)\b",
-    r"\bpatient\s+care\b",
-    r"\bhealthcare\s+(manager|administrator|coordinator)\b",
-    r"\bpharmaceut",
-    r"\bbiotech\b",
-    r"\blife\s+sciences\s+(manager|director|lead)\b",
-    r"\bphlebotom",
-    r"\bbiomedical?\s+(equip|tech)",
-    r"\blab\s+scientist\b",
-    r"\bcare\s+(coordinator|at\s+home)\b",
-    r"\bnephrology\b",
-    # Finance / legal / HR / admin
-    r"\bfinancial\s+(analyst|advisor|planner|controller)\b",
-    r"\baudit\s+(manager|director|analyst)\b",
-    r"\bcompliance\s+(manager|officer|analyst)\b",
-    r"\blegal\s+(counsel|manager|director)\b",
-    r"\bhuman\s+resources\s+(manager|director|business\s+partner)\b",
-    r"\btalent\s+acquisition\b",
-    r"\brecruiter\b",
-    r"\bmarketing\s+manager\b",
-    r"\bfp&?a\s+(manager|analyst|director)\b",
-    r"\b(senior\s+)?gl\s+accountant\b",
-    r"\bpayroll\s+(manager|operations|specialist)\b",
-    r"\breal\s+estate\s+operations\s+accountant\b",
-    # Construction / trades
-    r"\bconstruction\s+(manager|safety|specialist)\b",
-    r"\bmep\s+superintendent\b",
-    r"\bcrane\b.*\b(supt|superintendent)\b",
-    r"\brigging\s+(supt|superintendent)\b",
-    r"\bgeneral\s+superintendent\b",
-    r"\bsite\s+superintendent\b",
-    r"\bsurvey\s+technician\b",
-    r"\bsignal\s+engineer\b",
-    # Aviation / military hardware
-    r"\baircraft\s+mechanic\b",
-    r"\bf-\d+\b",
-    # AV / events
-    r"\bevent\s+techni(cian|cal)\b",
-    r"\baudio\s+visual\b",
-    r"\bevent\s+tech\s",
-    r"\bdirector\s+event\s+tech\b",
-    # Food service / culinary
-    r"\bschool\s+nutrition\b",
-    r"\bculinary\b",
-    r"\b(lead\s+)?cook\b",
-    r"\bfood\s+service\b",
-    r"\bchef\b",
-    # Landscaping / groundskeeping
-    r"\blandscap(e|ing)\b",
-    r"\blawn\b",
-    # Property management
-    r"\bproperty\s+manager\b",
-    r"\bcommunity\s+association\b",
-    # Chemical
-    r"\bchemist\b",
-    # Manufacturing / production / plant (non-DC)
-    r"\bproduction\s+(buyer|planner|engineer)\b",
-    r"\bplant\s+(manager|maintenance)\b",
-    r"\bmanufacturing\s+(engineer|manager|operations|test)\b",
-    r"\bmanufacturing\s+test\b",
-    # Quality / process engineering (0% applied rate in feedback data)
-    r"\bquality\s+(engineer|technician|assurance|control)\b",
-    r"\bprocess\s+engineer\b",
-    r"\bprocess\s+quality\s+engineer\b",
-    # Systems development engineering (SDE-adjacent, not DC ops)
-    r"\bsystems\s+development\s+engineer\b",
-    # Transportation / warehouse / logistics expansions
-    r"\btransportation\s+coordinator\b",
-    r"\bhauling\b",
-    r"\blogistics\s+(analyst|associate)\b",
-    r"\bwarehouse\s+manager\b",
-    r"\bfulfillment\s+operations\b",
-    # Childcare / education
-    r"\bchildcare\b",
-    r"\bdaycare\b",
-    r"\bstipend\b.*\bsite\s+supervisor\b",
-    # Digital signage
-    r"\bdigital\s+signage\b",
-    # Salesperson / GTM
-    r"\bsalesperson\b",
-    r"\bsales\s+lead\b",
-    # Systems admin (not DC ops)
-    r"\bsystems\s+administrator\b",
-    # Storage / SRE / DevOps (pure software roles)
-    r"\bstorage\s+engineer\b",
-    r"\bsite\s+reliability\s+engineer\b",
-    r"\bdevops\s+engineer\b",
-    r"\bkernel\s+engineer\b",
-    # Data engineering / BI (not DC)
-    r"\bdata\s+engineer\b",
-    r"\bbusiness\s+intelligence\s+(developer|analyst)\b",
-    r"\bdata\s+strategist\b",
-    # General manager / maintenance tech (DC override prevents false positives)
-    r"\bgeneral\s+manager\b",
-    r"\bmaintenance\s+technician\b",
-    # Generic junk / non-job entries
-    r"^manage\s+job\s+alerts?\b",
-    r"^your\s+job\s+alert\s+for\b",
-    r"\bjoin\s+our\s+talent\s+network\b",
-    # Facilities (no DC scope in title)
-    r"\bcustodial\b",
-    r"\bjanitorial\b",
-    r"\bvenue\s+operations\b",
-    r"\bfacilities\s+coordinator\b",
-    r"\bbuilding\s+manager\b",
-    r"\bworkplace\s+services\s+manager\b",
-    r"\boffice\s+manager\b",
-    r"\bworkplace\s+manager\b",
-]
-
-_HARD_REJECT_RE: re.Pattern[str] = re.compile(
-    "|".join(f"(?:{p})" for p in _HARD_REJECT_PATTERNS),
-    re.IGNORECASE,
-)
-
-# If title contains DC context, suppress the hard reject — the job may be in-domain
-_DC_CONTEXT_RE: re.Pattern[str] = re.compile(
-    r"\bdata\s*center\b|\bdatacenter\b|\bdc\s+(ops|operations|site)\b",
-    re.IGNORECASE,
-)
+from findajob.config_loader import load_hard_reject_rules, load_in_domain_rules
 
 
 def _hard_reject_match(title: str) -> str | None:
     """Return the matched pattern string, or None."""
-    m = _HARD_REJECT_RE.search(title)
+    reject_re, suppressor_re = load_hard_reject_rules()
+    m = reject_re.search(title)
     if not m:
         return None
-    # Don't reject if the title also contains data center context
-    if _DC_CONTEXT_RE.search(title):
+    # If a context suppressor also matches, don't reject.
+    if suppressor_re is not None and suppressor_re.search(title):
         return None
     return m.group(0).strip()
 
 
-# ── Stage 2: In-domain title patterns ─────────────────────────────────────────
-# If title matches and JD is unusable → score 5 (or 6 for Tier 1), no LLM.
-_IN_DOMAIN_PATTERNS: list[str] = [
-    r"\bdata\s*center\s+(operations|site|manager|lead|technician|engineer)\b",
-    r"\bdatacenter\s+(operations|site|manager|lead)\b",
-    r"\bdc\s+(ops|operations|site\s+manager)\b",
-    r"\bnpi\s+(manager|lead|engineer|program\s+manager)\b",
-    r"\bhardware\s+(ops|operations|bring.up|npi|program\s+manager)\b",
-    r"\binfrastructure\s+operations\s+(manager|lead|director)\b",
-    r"\boperational\s+readiness\b",
-    r"\blab\s+operations\s+(manager|lead)\b",
-    r"\bsite\s+manager,?\s+datacenter\b",
-    r"\bdatacenter.*\boperations\s+manager\b",
-    r"\bdata\s+center.*\boperations\s+(area\s+)?manager\b",
-    r"\bsite\s+operations\s+manager\b",  # without "workplace services"
-    r"\bengineering\s+operations\s+manager\b",
-    r"\bfield\s+operations\s+(manager|lead)\b",
-]
-
-_IN_DOMAIN_RE: re.Pattern[str] = re.compile(
-    "|".join(f"(?:{p})" for p in _IN_DOMAIN_PATTERNS),
-    re.IGNORECASE,
-)
-
-# These terms in the same title poison an otherwise in-domain match
-_IN_DOMAIN_POISON: re.Pattern[str] = re.compile(
-    r"\b(workplace\s+services|custodial|janitorial|facilities\s+only|office\s+services)\b",
-    re.IGNORECASE,
-)
-
-
 def _in_domain_match(title: str) -> bool:
-    if _IN_DOMAIN_POISON.search(title):
+    in_domain_re, poison_re = load_in_domain_rules()
+    if poison_re is not None and poison_re.search(title):
         return False
-    return bool(_IN_DOMAIN_RE.search(title))
-
-
-# ── Public API ─────────────────────────────────────────────────────────────────
+    return bool(in_domain_re.search(title))
 
 
 def prefilter_score(title: str, company: str, jd_usable: bool) -> tuple[dict[str, object] | None, str | None]:
     """
     Returns (result_dict, reason_str) if a deterministic decision can be made,
     or (None, None) if the LLM should be invoked.
-
-    result_dict matches the scoring_schema.json shape.
-    latency_ms should be logged as 0 by the caller.
     """
     t = (title or "").strip()
 
@@ -340,17 +67,14 @@ def prefilter_score(title: str, company: str, jd_usable: bool) -> tuple[dict[str
             "remote_status": "Unknown",
         }, reason
 
-    # ── Stage 2: In-domain title, JD absent ──────────────────────────────────
+    # ── Stage 2: In-domain title, JD absent → score 5 ─────────────────────────
     if not jd_usable and _in_domain_match(t):
-        tier1 = _is_tier1(company)
-        score = 6 if tier1 else 5
-        tier_note = " (Tier 1 company bonus)" if tier1 else ""
-        reason = f"Pre-filter in-domain/no-JD: scored {score}{tier_note}"
+        reason = "Pre-filter in-domain/no-JD: scored 5"
         return {
             "score_status": "scored",
-            "relevance_score": score,
-            "interview_likelihood": score - 1,
-            "strengths_alignment": f"Title is directionally in-domain. JD unavailable — scored {score} per policy{tier_note}.",
+            "relevance_score": 5,
+            "interview_likelihood": 4,
+            "strengths_alignment": "Title is directionally in-domain. JD unavailable — scored 5 per policy.",
             "industry_sector": None,
             "comp_estimate": None,
             "ai_notes": reason,

--- a/src/findajob/scorer_prefilter.py
+++ b/src/findajob/scorer_prefilter.py
@@ -10,7 +10,9 @@ Runs BEFORE any LLM call. Two stages:
 If neither stage fires, returns (None, None) and caller should invoke the LLM.
 
 Rules are loaded from config/prefilter_rules.yaml and config/in_domain_patterns.yaml
-(both gitignored). See src/findajob/config_loader.py.
+(both gitignored). See src/findajob/config_loader.py. If either file is missing,
+that stage becomes a no-op (all jobs pass through to the LLM) — install config
+files per docs/setup/configure.md.
 
 Usage:
     from findajob.scorer_prefilter import prefilter_score
@@ -48,6 +50,10 @@ def prefilter_score(title: str, company: str, jd_usable: bool) -> tuple[dict[str
     """
     Returns (result_dict, reason_str) if a deterministic decision can be made,
     or (None, None) if the LLM should be invoked.
+
+    `company` is accepted for signature stability; no per-company rule is
+    supported today. Kept for callers (scoring.py) and potential future
+    per-company overrides.
     """
     t = (title or "").strip()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Global test fixtures.
+
+Redirects findajob.config_loader to read from tests/fixtures/config/
+instead of the production config directory, and resets its cache before
+each test so a test's config edits don't leak into the next test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from findajob import config_loader
+
+FIXTURES = Path(__file__).parent / "fixtures" / "config"
+
+
+@pytest.fixture(autouse=True)
+def _use_fixture_configs(monkeypatch):
+    monkeypatch.setattr(config_loader, "_RULES_PATH", FIXTURES / "prefilter_rules.yaml")
+    monkeypatch.setattr(config_loader, "_IN_DOMAIN_PATH", FIXTURES / "in_domain_patterns.yaml")
+    monkeypatch.setattr(config_loader, "_COMPANIES_PATH", FIXTURES / "companies_of_interest.txt")
+    config_loader._reset_cache()
+    yield
+    config_loader._reset_cache()

--- a/tests/fixtures/config/companies_of_interest.txt
+++ b/tests/fixtures/config/companies_of_interest.txt
@@ -1,0 +1,7 @@
+# Test fixture
+meta
+google
+openai
+anthropic
+aws
+microsoft

--- a/tests/fixtures/config/in_domain_patterns.yaml
+++ b/tests/fixtures/config/in_domain_patterns.yaml
@@ -1,7 +1,18 @@
 positive:
-  - '\bdata\s*center\s+(operations|technician|engineer)\b'
-  - '\bnpi\s+(manager|lead|engineer)\b'
+  - '\bdata\s*center\s+(operations|site|manager|lead|technician|engineer)\b'
+  - '\bdatacenter\s+(operations|site|manager|lead)\b'
+  - '\bdc\s+(ops|operations|site\s+manager)\b'
+  - '\bnpi\s+(manager|lead|engineer|program\s+manager)\b'
+  - '\bhardware\s+(ops|operations|bring.up|npi|program\s+manager)\b'
+  - '\binfrastructure\s+operations\s+(manager|lead|director)\b'
   - '\boperational\s+readiness\b'
+  - '\blab\s+operations\s+(manager|lead)\b'
+  - '\bsite\s+manager,?\s+datacenter\b'
+  - '\bdatacenter.*\boperations\s+manager\b'
+  - '\bdata\s+center.*\boperations\s+(area\s+)?manager\b'
+  - '\bsite\s+operations\s+manager\b'
+  - '\bengineering\s+operations\s+manager\b'
+  - '\bfield\s+operations\s+(manager|lead)\b'
 
 poison:
-  - '\b(workplace\s+services|custodial|janitorial)\b'
+  - '\b(workplace\s+services|custodial|janitorial|facilities\s+only|office\s+services)\b'

--- a/tests/fixtures/config/in_domain_patterns.yaml
+++ b/tests/fixtures/config/in_domain_patterns.yaml
@@ -1,0 +1,7 @@
+positive:
+  - '\bdata\s*center\s+(operations|technician|engineer)\b'
+  - '\bnpi\s+(manager|lead|engineer)\b'
+  - '\boperational\s+readiness\b'
+
+poison:
+  - '\b(workplace\s+services|custodial|janitorial)\b'

--- a/tests/fixtures/config/prefilter_rules.yaml
+++ b/tests/fixtures/config/prefilter_rules.yaml
@@ -1,12 +1,98 @@
-# Test fixture — small but covers hard_rejects, grouping, and suppressors.
+# Test fixture — expanded to cover every pattern the test suite exercises.
 hard_rejects:
-  software:
+  software_engineering:
     - '\bsoftware\s+engineer(ing)?\b'
+    - '\bsoftware\s+developer\b'
+    - '\bsoftware\s+architect\b'
+    - '\bsoftware\s+development\s+engineer\b'
     - '\b(swe|sde)\b'
+  security:
+    - '\bsecurity\s+analyst\b'
+    - '\bsoc\s+analyst\b'
+    - '\bthreat\s+(detection|intelligence|hunting)\b'
+    - '\bcyber\s*security\b'
+    - '\binformation\s+security\b'
+  sales_bd:
+    - '\baccount\s+executive\b'
+    - '\bsales\s+specialist\b'
+    - '\bsales\s+representative\b'
+    - '\bsales\s+manager\b'
+    - '\benterprise\s+sales\b'
+    - '\bfield\s+sales\b'
+    - '\bbusiness\s+development\s+(manager|lead|director|representative)\b'
+  it_service:
+    - '\bit\s+service\s+management\b'
+    - '\bitsm\b'
+    - '\bit\s+help\s*desk\b'
+    - '\bservice\s+desk\s+manager\b'
+    - '\bit\s+support\s+manager\b'
+  supply_chain:
+    - '\bsupply\s+chain\b'
+    - '\bprocurement\s+(manager|lead|specialist|director)\b'
+    - '\bsourcing\s+(manager|lead|specialist)\b'
+    - '\blogistics\s+manager\b'
+    - '\bfulfillment\s+manager\b'
+    - '\binventory\s+(manager|analyst)\b'
+    - '\bwarehouse\s+manager\b'
+  networking:
+    - '\bnetwork\s+engineer(ing)?\b'
+    - '\bnetwork\s+architect\b'
+    - '\bnoc\s+engineer\b'
+    - '\bconnectivity\s+engineer\b'
+  hardware_design:
+    - '\bcontrols\s+engineer(ing)?\b'
+    - '\belectrical\s+engineer(ing)?\b'
+    - '\bmechanical\s+engineer(ing)?\b'
+    - '\bfirmware\s+engineer(ing)?\b'
+    - '\bfpga\b'
+    - '\bboard\s+design\b'
+    - '\bhardware\s+development\s+engineer\b'
+    - '\bhardware\s+design\s+engineer\b'
   healthcare:
     - '\bnurs(e|ing)\b'
-  sales:
-    - '\baccount\s+executive\b'
+    - '\bclinical\s+(manager|director|lead|specialist|coordinator|trial|research|lab)\b'
+    - '\bpatient\s+care\b'
+    - '\bhealthcare\s+(manager|administrator|coordinator)\b'
+    - '\bpharmaceut'
+    - '\bbiotech\b'
+  finance_legal_hr:
+    - '\bfinancial\s+(analyst|advisor|planner|controller)\b'
+    - '\baudit\s+(manager|director|analyst)\b'
+    - '\bcompliance\s+(manager|officer|analyst)\b'
+    - '\blegal\s+(counsel|manager|director)\b'
+    - '\bhuman\s+resources\s+(manager|director|business\s+partner)\b'
+    - '\btalent\s+acquisition\b'
+    - '\brecruiter\b'
+    - '\bmarketing\s+manager\b'
+  construction:
+    - '\bconstruction\s+(manager|safety|specialist)\b'
+    - '\bmep\s+superintendent\b'
+    - '\bcrane\b.*\b(supt|superintendent)\b'
+    - '\brigging\s+(supt|superintendent)\b'
+    - '\bgeneral\s+superintendent\b'
+    - '\bsite\s+superintendent\b'
+  manufacturing_quality:
+    - '\bproduction\s+(buyer|planner|engineer)\b'
+    - '\bplant\s+(manager|maintenance)\b'
+    - '\bmanufacturing\s+(engineer|manager|operations|test)\b'
+    - '\bquality\s+(engineer|technician|assurance|control)\b'
+    - '\bprocess\s+engineer\b'
+  sysadmin_sre_devops:
+    - '\bsystems\s+administrator\b'
+    - '\bstorage\s+engineer\b'
+    - '\bsite\s+reliability\s+engineer\b'
+    - '\bdevops\s+engineer\b'
+    - '\bdata\s+engineer\b'
+    - '\bkernel\s+engineer\b'
+  facilities_general:
+    - '\bcustodial\b'
+    - '\bjanitorial\b'
+    - '\bbuilding\s+manager\b'
+    - '\boffice\s+manager\b'
+    - '\bworkplace\s+manager\b'
+    - '\bfacilities\s+coordinator\b'
+    - '\bgeneral\s+manager\b'
+    - '\bmaintenance\s+technician\b'
 
 context_suppressors:
-  - '\bdata\s*center\b|\bdatacenter\b'
+  - '\bdata\s*center\b|\bdatacenter\b|\bdc\s+(ops|operations|site)\b'

--- a/tests/fixtures/config/prefilter_rules.yaml
+++ b/tests/fixtures/config/prefilter_rules.yaml
@@ -95,4 +95,6 @@ hard_rejects:
     - '\bmaintenance\s+technician\b'
 
 context_suppressors:
-  - '\bdata\s*center\b|\bdatacenter\b|\bdc\s+(ops|operations|site)\b'
+  - '\bdata\s*center\b'
+  - '\bdatacenter\b'
+  - '\bdc\s+(ops|operations|site)\b'

--- a/tests/fixtures/config/prefilter_rules.yaml
+++ b/tests/fixtures/config/prefilter_rules.yaml
@@ -1,0 +1,12 @@
+# Test fixture — small but covers hard_rejects, grouping, and suppressors.
+hard_rejects:
+  software:
+    - '\bsoftware\s+engineer(ing)?\b'
+    - '\b(swe|sde)\b'
+  healthcare:
+    - '\bnurs(e|ing)\b'
+  sales:
+    - '\baccount\s+executive\b'
+
+context_suppressors:
+  - '\bdata\s*center\b|\bdatacenter\b'

--- a/tests/test_companies_of_interest_consumers.py
+++ b/tests/test_companies_of_interest_consumers.py
@@ -1,0 +1,30 @@
+"""Regression guard: sync_sheet and notify must consume companies_of_interest
+via the config_loader, not via the now-deleted _is_tier1 / TIER1 from the
+prefilter module.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text()
+
+
+def test_sync_sheet_uses_is_company_of_interest():
+    src = _read("scripts/sync_sheet.py")
+    assert "from findajob.config_loader import is_company_of_interest" in src
+    assert "is_company_of_interest(" in src
+    assert "_is_tier1" not in src
+    assert "from findajob.scorer_prefilter import TIER1" not in src
+
+
+def test_notify_uses_is_company_of_interest():
+    src = _read("scripts/notify.py")
+    assert "from findajob.config_loader import is_company_of_interest" in src
+    assert "is_company_of_interest(" in src
+    assert "from findajob.scorer_prefilter import TIER1" not in src
+    assert "_is_tier1" not in src

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from findajob import config_loader
 from findajob.config_loader import (
     is_company_of_interest,
     load_companies_of_interest,
@@ -49,3 +50,35 @@ class TestIsCompanyOfInterest:
     def test_none(self):
         # Typed as str but guard handles falsy
         assert is_company_of_interest(None) is False  # type: ignore[arg-type]
+
+
+class TestLoadHardRejectRules:
+    def test_returns_two_regexes(self):
+        reject_re, suppressor_re = config_loader.load_hard_reject_rules()
+        assert reject_re.search("Software Engineer") is not None
+        assert suppressor_re is not None  # fixture has suppressors
+
+    def test_matches_across_categories(self):
+        reject_re, _ = config_loader.load_hard_reject_rules()
+        # software category
+        assert reject_re.search("Senior Software Engineer") is not None
+        assert reject_re.search("SWE II") is not None
+        # healthcare category
+        assert reject_re.search("Registered Nurse") is not None
+        # sales category
+        assert reject_re.search("Enterprise Account Executive") is not None
+
+    def test_no_match_for_in_domain_title(self):
+        reject_re, _ = config_loader.load_hard_reject_rules()
+        assert reject_re.search("Data Center Operations Engineer") is None
+
+    def test_suppressor_compiled(self):
+        _, suppressor_re = config_loader.load_hard_reject_rules()
+        assert suppressor_re.search("Data Center Security Analyst") is not None
+        assert suppressor_re.search("Datacenter NOC") is not None
+        assert suppressor_re.search("Security Analyst") is None  # no DC context
+
+    def test_caches_result(self):
+        r1 = config_loader.load_hard_reject_rules()
+        r2 = config_loader.load_hard_reject_rules()
+        assert r1 is r2  # cache hit returns same tuple

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,53 @@
+"""Tests for findajob.config_loader."""
+
+from __future__ import annotations
+
+import pytest
+
+from findajob import config_loader
+from findajob.config_loader import (
+    ConfigError,
+    is_company_of_interest,
+    load_companies_of_interest,
+)
+
+
+class TestLoadCompaniesOfInterest:
+    def test_loads_from_fixture(self):
+        result = load_companies_of_interest()
+        assert isinstance(result, frozenset)
+        assert "meta" in result
+        assert "google" in result
+        assert "openai" in result
+
+    def test_lowercases_entries(self):
+        result = load_companies_of_interest()
+        assert all(c == c.lower() for c in result)
+
+    def test_caches_result(self):
+        result1 = load_companies_of_interest()
+        result2 = load_companies_of_interest()
+        assert result1 is result2  # same object — cache hit
+
+
+class TestIsCompanyOfInterest:
+    @pytest.mark.parametrize(
+        "company",
+        ["Meta", "meta", "META", "Meta Platforms, Inc.", "Google Cloud", "OpenAI Research"],
+    )
+    def test_positive_substring_clear(self, company):
+        assert is_company_of_interest(company) is True
+
+    @pytest.mark.parametrize(
+        "company",
+        ["Walmart", "Starbucks", "Acme Corp", "Random Startup LLC"],
+    )
+    def test_negative(self, company):
+        assert is_company_of_interest(company) is False
+
+    def test_empty_string(self):
+        assert is_company_of_interest("") is False
+
+    def test_none(self):
+        # Typed as str but guard handles falsy
+        assert is_company_of_interest(None) is False  # type: ignore[arg-type]

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -6,6 +6,7 @@ import pytest
 
 from findajob import config_loader
 from findajob.config_loader import (
+    ConfigError,
     is_company_of_interest,
     load_companies_of_interest,
 )
@@ -107,3 +108,89 @@ class TestLoadInDomainRules:
         r1 = config_loader.load_in_domain_rules()
         r2 = config_loader.load_in_domain_rules()
         assert r1 is r2
+
+
+class TestMissingFiles:
+    def test_missing_rules_file_returns_never_match(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_RULES_PATH", tmp_path / "does-not-exist.yaml")
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="prefilter_rules.yaml missing"):
+            reject_re, suppressor_re = config_loader.load_hard_reject_rules()
+        assert reject_re.search("Software Engineer") is None
+        assert reject_re is config_loader._NEVER_MATCH
+        assert suppressor_re is None
+
+    def test_missing_in_domain_file_returns_never_match(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_IN_DOMAIN_PATH", tmp_path / "does-not-exist.yaml")
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="in_domain_patterns.yaml missing"):
+            in_domain_re, poison_re = config_loader.load_in_domain_rules()
+        assert in_domain_re.search("Data Center Operations") is None
+        assert poison_re is None
+
+    def test_missing_companies_file_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_COMPANIES_PATH", tmp_path / "does-not-exist.txt")
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="companies_of_interest.txt missing"):
+            result = config_loader.load_companies_of_interest()
+        assert result == frozenset()
+        assert config_loader.is_company_of_interest("Meta") is False
+
+    def test_empty_rules_file(self, monkeypatch, tmp_path):
+        empty = tmp_path / "prefilter_rules.yaml"
+        empty.write_text("")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", empty)
+        config_loader._reset_cache()
+        with pytest.warns(UserWarning, match="prefilter_rules.yaml is empty"):
+            reject_re, _ = config_loader.load_hard_reject_rules()
+        assert reject_re.search("anything") is None
+
+
+class TestMalformedFiles:
+    def test_bad_yaml_raises_config_error(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects: {unclosed")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="YAML parse error"):
+            config_loader.load_hard_reject_rules()
+
+    def test_top_level_list_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("- just\n- a\n- list\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="top level must be a mapping"):
+            config_loader.load_hard_reject_rules()
+
+    def test_hard_rejects_as_list_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects:\n  - '\\bfoo\\b'\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="'hard_rejects' must be a mapping"):
+            config_loader.load_hard_reject_rules()
+
+    def test_bad_regex_raises_with_pattern(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects:\n  broken:\n    - '(unclosed'\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match=r"invalid regex.*\(unclosed"):
+            config_loader.load_hard_reject_rules()
+
+    def test_non_string_pattern_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("hard_rejects:\n  bad:\n    - 42\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="pattern in 'bad' is not a string"):
+            config_loader.load_hard_reject_rules()
+
+    def test_in_domain_positive_as_dict_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "in_domain_patterns.yaml"
+        bad.write_text("positive:\n  nested: value\n")
+        monkeypatch.setattr(config_loader, "_IN_DOMAIN_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="'positive' must be a list"):
+            config_loader.load_in_domain_rules()

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from findajob import config_loader
 from findajob.config_loader import (
-    ConfigError,
     is_company_of_interest,
     load_companies_of_interest,
 )

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -82,3 +82,28 @@ class TestLoadHardRejectRules:
         r1 = config_loader.load_hard_reject_rules()
         r2 = config_loader.load_hard_reject_rules()
         assert r1 is r2  # cache hit returns same tuple
+
+
+class TestLoadInDomainRules:
+    def test_positive_matches(self):
+        in_domain_re, _ = config_loader.load_in_domain_rules()
+        assert in_domain_re.search("Data Center Operations Engineer") is not None
+        assert in_domain_re.search("NPI Manager") is not None
+        assert in_domain_re.search("Operational Readiness Lead") is not None
+
+    def test_positive_misses_out_of_domain(self):
+        in_domain_re, _ = config_loader.load_in_domain_rules()
+        assert in_domain_re.search("Software Engineer") is None
+        assert in_domain_re.search("Account Executive") is None
+
+    def test_poison_compiled(self):
+        _, poison_re = config_loader.load_in_domain_rules()
+        assert poison_re is not None
+        assert poison_re.search("Data Center Workplace Services Manager") is not None
+        assert poison_re.search("Custodial Lead") is not None
+        assert poison_re.search("Data Center Operations") is None  # no poison term
+
+    def test_caches_result(self):
+        r1 = config_loader.load_in_domain_rules()
+        r2 = config_loader.load_in_domain_rules()
+        assert r1 is r2

--- a/tests/test_scorer_prefilter.py
+++ b/tests/test_scorer_prefilter.py
@@ -2,68 +2,7 @@
 
 import pytest
 
-from findajob.scorer_prefilter import _hard_reject_match, _in_domain_match, _is_tier1, prefilter_score
-
-# ── _is_tier1 ────────────────────────────────────────────────────────────────
-
-
-class TestIsTier1:
-    """Tier 1 company detection (case-insensitive substring match)."""
-
-    @pytest.mark.parametrize(
-        "company",
-        [
-            "Meta",
-            "meta",
-            "META",
-            "Google",
-            "OpenAI",
-            "CoreWeave",
-            "Anthropic",
-            "Amazon",
-            "AWS",
-            "Microsoft",
-            "xAI",
-            "Cerebras",
-            "Groq",
-            "Tenstorrent",
-            "SambaNova",
-            "Nebius",
-            "Crusoe",
-            "Etched",
-            "Nscale",
-            "Astera Labs",  # substring: "astera" matches
-        ],
-    )
-    def test_positive(self, company):
-        assert _is_tier1(company) is True
-
-    @pytest.mark.parametrize(
-        "company",
-        [
-            "Walmart",
-            "Starbucks",
-            "Acme Corp",
-            "Initech",
-            "Random Startup LLC",
-        ],
-    )
-    def test_negative(self, company):
-        assert _is_tier1(company) is False
-
-    def test_empty_string(self):
-        assert _is_tier1("") is False
-
-    def test_none(self):
-        # company param typed as str but guard handles falsy
-        assert _is_tier1(None) is False
-
-    def test_substring_match(self):
-        """Tier 1 check uses substring, so 'Google Cloud' still matches."""
-        assert _is_tier1("Google Cloud") is True
-        assert _is_tier1("Meta Platforms, Inc.") is True
-        assert _is_tier1("Amazon Web Services") is True
-
+from findajob.scorer_prefilter import _hard_reject_match, _in_domain_match, prefilter_score
 
 # ── _hard_reject_match ────────────────────────────────────────────────────────
 
@@ -349,16 +288,8 @@ class TestPrefilterScore:
         assert result is None
         assert reason is None
 
-    def test_stage2_in_domain_no_jd_tier1(self):
-        """In-domain title, no JD, Tier 1 company -> score 6."""
-        result, reason = prefilter_score("Data Center Operations Manager", "Google", jd_usable=False)
-        assert result is not None
-        assert result["relevance_score"] == 6
-        assert result["interview_likelihood"] == 5
-        assert "Tier 1" in reason
-
-    def test_stage2_in_domain_no_jd_non_tier1(self):
-        """In-domain title, no JD, non-Tier 1 -> score 5."""
+    def test_stage2_in_domain_no_jd(self):
+        """In-domain title, no JD -> score 5."""
         result, reason = prefilter_score("Data Center Operations Manager", "Acme Corp", jd_usable=False)
         assert result is not None
         assert result["relevance_score"] == 5


### PR DESCRIPTION
## Summary

Closes #10 (items 1–3 of the issue; items 4–5 deferred to a follow-up).

- Externalizes `scorer_prefilter.py`'s hardcoded rule literals into gitignored YAML/txt configs loaded via a new `src/findajob/config_loader.py`.
- Drops the Tier-1 prefilter bonus (score 5 instead of 6 at the in-domain/no-JD floor). The "companies I care about" concept survives as `config/companies_of_interest.txt`, consumed by `sync_sheet.py` (archival exception) and `notify.py` (mis-score health check) — but not by the prefilter.
- Ships `.example` templates for all three new configs, with multi-field commentary (tech / healthcare / teaching / social work) per the generalization rules in CLAUDE.md.

Design doc: `docs/superpowers/specs/2026-04-17-generalize-prefilter-config-design.md`
Implementation plan: `docs/superpowers/plans/2026-04-17-generalize-prefilter-config.md`

## What changed

| Component | Before | After |
|---|---|---|
| Hard-reject patterns | ~150 regex hardcoded in `scorer_prefilter.py` | `config/prefilter_rules.yaml` (gitignored), grouped by category, loaded via `config_loader` |
| In-domain + poison patterns | Hardcoded lists | `config/in_domain_patterns.yaml` with `positive:` and `poison:` keys |
| `TIER1` frozenset + `_is_tier1()` | Public in `scorer_prefilter.py` | Removed; prefilter no longer consults any company list |
| Stage-2 in-domain/no-JD bonus | Score 6 at Tier-1, 5 elsewhere | Always score 5 |
| `sync_sheet.py` archival exception | Filtered by `_is_tier1` | Filtered by `is_company_of_interest` reading `config/companies_of_interest.txt` |
| `notify.py` mis-score health check | Iterated `TIER1` | Calls `is_company_of_interest` |

## Config file shapes

`config/prefilter_rules.yaml`:
```yaml
hard_rejects:
  <category>:
    - '<regex>'
context_suppressors:   # optional
  - '<regex>'
```

`config/in_domain_patterns.yaml`:
```yaml
positive:
  - '<regex>'
poison:                # optional
  - '<regex>'
```

`config/companies_of_interest.txt` — one company per line, comments allowed.

Missing files → graceful no-op with `UserWarning`; malformed files → `ConfigError` naming the file and pattern.

## Test plan

- [x] `pytest tests/` — 437 pass, no regressions
- [x] `ruff check src/ scripts/ tests/` — clean
- [x] Parity check: 500 recent jobs run through old vs. new prefilter — 0 unexpected diffs; 2 intentional 6→5 (Tier-1 bonus drops)
- [x] `test_config_loader.py` (34 tests) covers happy path, missing files, empty files, malformed YAML, bad regex, wrong top-level shape, non-string patterns
- [x] `test_companies_of_interest_consumers.py` regression-guards `sync_sheet` and `notify` against re-introducing `_is_tier1` / `TIER1`
- [ ] Post-merge: run one full pipeline cycle on Brock's LXC and verify triage, scoring, and notify all still fire as expected

## Follow-up

Items 4 and 5 of #10 (prompt-level neutralization: `job_scorer.md` hard-reject enumerations + engineer calibration → `profile.md`) are deferred to a separate issue because they change LLM behavior and need their own validation loop.

## Known quirks

- The test suite is 52 tests smaller than Brock's local machine because three recent test files (`test_notify_feedback_review.py`, `test_notify_systemd_check.py`, `test_poll_flags_orphan_recovery.py`) exist in local squash-merge ancestry but not in this branch's base. Unrelated to #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)