### PR TITLE
Fix 3 invalid notify.py subcommands in ops/crontab (#74)

### DIFF
--- a/ops/crontab
+++ b/ops/crontab
@@ -18,11 +18,11 @@ PYTHONUNBUFFERED=1
 
 # ── Notifications ────────────────────────────────────────────────────────────
 0    6   *  *  *        python3 /app/scripts/notify.py apply-reminder
-15   6   *  *  *        python3 /app/scripts/notify.py stats
+15   6   *  *  *        python3 /app/scripts/notify.py daily-stats
 0    7   *  *  *        python3 /app/scripts/notify.py health-check
-0    8   *  *  1,3,5    python3 /app/scripts/notify.py issues
+0    8   *  *  1,3,5    python3 /app/scripts/notify.py issues-ping
 30   8   *  *  1        python3 /app/scripts/notify.py scoreboard
-0    8   *  *  0        python3 /app/scripts/notify.py feedback
+0    8   *  *  0        python3 /app/scripts/notify.py feedback-review
 
 # ── RAG rebuild (Sunday 03:00) ───────────────────────────────────────────────
 0    3   *  *  0   /usr/local/bin/aichat-ng --rag job_search_rag --rebuild-rag

--- a/tests/test_crontab_notify_alignment.py
+++ b/tests/test_crontab_notify_alignment.py
@@ -1,0 +1,70 @@
+"""Regression guard (#74): every notify.py subcommand in ops/crontab must be
+a valid key in scripts/notify.py's COMMANDS dispatcher.
+
+PR #72 shipped three invalid invocations — `stats`, `issues`, `feedback` —
+that silently failed at runtime because supercronic fires the command, the
+process prints a usage line, and exits 1 with no operator-visible signal.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CRONTAB = REPO_ROOT / "ops" / "crontab"
+NOTIFY = REPO_ROOT / "scripts" / "notify.py"
+
+_CRON_NOTIFY_RE = re.compile(r"notify\.py\s+([a-z0-9-]+)")
+
+
+def _notify_commands() -> set[str]:
+    """Parse scripts/notify.py and return the keys of the top-level COMMANDS dict."""
+    tree = ast.parse(NOTIFY.read_text())
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "COMMANDS"
+            and isinstance(node.value, ast.Dict)
+        ):
+            keys: set[str] = set()
+            for k in node.value.keys:
+                assert isinstance(k, ast.Constant) and isinstance(k.value, str)
+                keys.add(k.value)
+            return keys
+    raise AssertionError("COMMANDS dict not found in scripts/notify.py")
+
+
+def _crontab_notify_subcommands() -> list[str]:
+    """Extract every `notify.py <subcmd>` invocation from non-comment crontab lines."""
+    subs: list[str] = []
+    for line in CRONTAB.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        subs.extend(m.group(1) for m in _CRON_NOTIFY_RE.finditer(line))
+    return subs
+
+
+def test_notify_commands_dict_is_parseable():
+    cmds = _notify_commands()
+    assert cmds, "COMMANDS dict is empty or missing"
+    for expected in {"daily-stats", "health-check", "issues-ping", "apply-reminder", "feedback-review"}:
+        assert expected in cmds, f"Expected COMMANDS to contain '{expected}'"
+
+
+def test_crontab_extracts_notify_subcommands():
+    subs = _crontab_notify_subcommands()
+    assert subs, "No notify.py invocations found in ops/crontab"
+
+
+def test_every_crontab_notify_subcommand_is_valid():
+    valid = _notify_commands()
+    invoked = _crontab_notify_subcommands()
+    unknown = [s for s in invoked if s not in valid]
+    assert not unknown, (
+        f"ops/crontab invokes notify.py subcommands not in COMMANDS: {unknown}. Valid subcommands: {sorted(valid)}"
+    )


### PR DESCRIPTION
## Summary

Three scheduled notifications were silently disabled on every Docker deploy since PR #72 shipped: supercronic fires the commands, `notify.py` prints the usage line, process exits 1. See [#74](https://github.com/brockamer/findajob/issues/74) for the full analysis.

Fix:

| crontab was | crontab is now |
|---|---|
| `notify.py stats` | `notify.py daily-stats` |
| `notify.py issues` | `notify.py issues-ping` |
| `notify.py feedback` | `notify.py feedback-review` |

Adds `tests/test_crontab_notify_alignment.py` — three tests that AST-parse `scripts/notify.py`'s `COMMANDS` dict and regex-extract every `notify.py <subcmd>` invocation from `ops/crontab`, asserting every invocation resolves. Verified the core assertion catches the bug by temporarily reverting the crontab fix before re-applying.

## Test plan

- [x] `pytest tests/` → **448 passed** (445 pre-PR + 3 new).
- [x] `ruff format` + `ruff check` on the new test file → clean.
- [x] Reverted `stats` temporarily and confirmed the regression test fails with the expected message before re-applying the fix.
- [ ] CI `lint-and-test` + `docker-build-smoke` pass after push.

## Closes

- Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)