### PR TITLE
v0.1.0 doc audit: README + onboarding sweep (#73)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A self-hosted, AI-powered job search pipeline. Fetches leads from LinkedIn, Indeed, Greenhouse, and Gmail, scores them with an LLM, surfaces high-quality matches in a Google Sheet, and on demand generates a full application package: tailored resume, cover letter, company briefing, and network outreach drafts.
 
-Runs daily via systemd user timers. No cloud infrastructure. No subscription. Costs ~$0.50–2/day in API usage depending on job volume.
+Deploys as a Docker container via Compose. Native systemd install remains documented as a fallback. No cloud infrastructure. No subscription. Costs ~$0.50–2/day in API usage depending on job volume.
 
 ---
 
@@ -28,7 +28,7 @@ Runs daily via systemd user timers. No cloud infrastructure. No subscription. Co
 | Job sources | RapidAPI jobs-api14, Gmail OAuth2, Greenhouse JSON API | Broad coverage |
 | Notifications | ntfy.sh | Free, cross-platform push |
 | File sync | rclone bisync | Google Drive sync for prep folders |
-| Scheduler | systemd user timers | Native, no extra daemons |
+| Scheduler | supercronic (Docker) / systemd (native) | supercronic runs the crontab inside the image; systemd is the fallback on native installs |
 
 ---
 
@@ -45,36 +45,27 @@ Runs daily via systemd user timers. No cloud infrastructure. No subscription. Co
 
 ## Quick Start
 
+findajob ships as a Docker image pulled from GHCR and deployed via Docker Compose.
+
 ```bash
-git clone https://github.com/yourname/findajob ~/findajob
-cd ~/findajob
+# On your Docker host — replace <you> with a short tag (brock, amy, etc.)
+sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng}
+sudo chown -R $(id -u):$(id -g) /opt/stacks/findajob-<you>/
+cd /opt/stacks/findajob-<you>
 
-# Create your personal config files from templates
-cp candidate_context/profile.md.example candidate_context/profile.md
-cp config/jsearch_queries.txt.example config/jsearch_queries.txt
-cp config/feed_urls.txt.example config/feed_urls.txt
-cp config/target_companies.md.example config/target_companies.md
-cp CLAUDE.local.md.example CLAUDE.local.md
-cp config/paths.env.example config/paths.env  # fill in your binary paths
+curl -fsSL -o compose.yaml https://raw.githubusercontent.com/brockamer/findajob/main/ops/compose.yaml.example
+curl -fsSL -o .env         https://raw.githubusercontent.com/brockamer/findajob/main/ops/stack.env.example
 
-# Create required directories
-mkdir -p logs companies/data
-
-# Install Python dependencies
-pip3 install --break-system-packages google-api-python-client google-auth-httplib2 \
-  google-auth-oauthlib requests jsonschema
-
-# Set up secrets
-cp data/.env.example data/.env
-chmod 600 data/.env
-# Edit data/.env and fill in all API keys
-
-# Initialize DB
-python3 scripts/init_db.py
-
-# Full setup walkthrough
-# See docs/setup/install-linux.md
+# Populate state/ with API keys, personal config, and candidate profile —
+# see the install guide for each file's purpose and template.
+docker compose up -d
 ```
+
+Full walkthrough (API keys, Gmail OAuth, Google Sheets, Drive sync) →
+[`docs/setup/install-docker.md`](docs/setup/install-docker.md).
+
+Running on a Linux host without Docker is still supported — see
+[`docs/setup/install-linux.md`](docs/setup/install-linux.md).
 
 ---
 
@@ -84,7 +75,8 @@ python3 scripts/init_db.py
 |---|---|
 | [docs/architecture.md](docs/architecture.md) | System design, data flow, component map |
 | [docs/setup/prerequisites.md](docs/setup/prerequisites.md) | API keys, accounts, tools you need |
-| [docs/setup/install-linux.md](docs/setup/install-linux.md) | Ubuntu + systemd setup |
+| [docs/setup/install-docker.md](docs/setup/install-docker.md) | **Docker Compose setup (recommended)** |
+| [docs/setup/install-linux.md](docs/setup/install-linux.md) | Ubuntu + systemd setup (native fallback) |
 | [docs/setup/configure.md](docs/setup/configure.md) | Profile, resume, queries, Google Sheets |
 | [docs/setup/state-migration.md](docs/setup/state-migration.md) | Moving an existing pipeline to a new machine |
 | [docs/operations.md](docs/operations.md) | Day-to-day use, monitoring, common tasks |
@@ -127,6 +119,8 @@ findajob/
 │   └── diag/                   # diagnostic scripts (run manually)
 ├── companies/                  # Generated prep folders (gitignored)
 ├── logs/                       # Pipeline logs (gitignored)
+├── ops/                        # Docker deploy: crontab, compose example, entrypoint
+├── Dockerfile                  # findajob image build (published to ghcr.io/brockamer/findajob)
 └── CLAUDE.md                   # Claude Code session context
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Runs daily via systemd user timers. No cloud infrastructure. No subscription. Co
 
 | Component | Choice | Why |
 |---|---|---|
-| Job scoring | [aichat-ng](https://github.com/sigoden/aichat) + DeepSeek v3 via OpenRouter | Fast, cheap, accurate for structured JSON output |
+| Job scoring | [aichat-ng](https://github.com/blob42/aichat-ng) + DeepSeek v3 via OpenRouter | Fast, cheap, accurate for structured JSON output |
 | Resume / cover letter | Claude Opus 4.6 (thinking mode) | Best writing quality at cost |
 | Company research | Perplexity Sonar Pro | Real-time web access |
 | Database | SQLite | Zero-config, ACID, queryable |
@@ -35,7 +35,7 @@ Runs daily via systemd user timers. No cloud infrastructure. No subscription. Co
 ## Prerequisites
 
 - Python 3.11+
-- [aichat-ng](https://github.com/sigoden/aichat) (`aichat-ng` binary, not `aichat`)
+- [aichat-ng](https://github.com/blob42/aichat-ng) (`aichat-ng` binary, not `aichat`)
 - pandoc
 - rclone (optional — only needed for Google Drive sync)
 - API keys: Anthropic, OpenRouter (DeepSeek), Perplexity, Google Gemini, RapidAPI

--- a/data/.env.example
+++ b/data/.env.example
@@ -1,5 +1,7 @@
 # data/.env — API keys and secrets
 # Copy to data/.env and fill in your values.
+# Under a Docker deploy this file lives at state/data/.env and is
+# bind-mounted to /app/data/.env inside the container.
 # chmod 600 data/.env
 # This file is gitignored. Never commit your actual .env.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,12 +1,18 @@
 # Architecture
 
+> **Docker users:** This document describes system design using native-install
+> terminology. Pipeline structure is identical under Docker; the scheduler is
+> supercronic reading `ops/crontab` rather than systemd timers. A
+> Docker-specific refresh is tracked as a separate follow-up issue.
+>
+
 ## Overview
 
 Two distinct workflows, both scheduler-driven:
 
 | Workflow | Trigger | Duration | Output |
 |---|---|---|---|
-| **Daily Triage** | 7:00 AM via scheduler | 30–60 min | 100–500 jobs scored and written to SQLite |
+| **Daily Triage** | 00:00 daily via scheduler | 30–60 min | 100–500 jobs scored and written to SQLite |
 | **Prep** | User flags a job in the Dashboard | 5–10 min | Folder with resume, cover letter, briefing, outreach drafts |
 
 Everything between them is mediated by SQLite. The Google Sheet is a synced view — not the source of truth.
@@ -17,7 +23,7 @@ Everything between them is mediated by SQLite. The Google Sheet is a synced view
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                    triage.py (7:00 AM)                  │
+│                    triage.py (00:00 daily)              │
 └──────────────────────┬──────────────────────────────────┘
                        │
           ┌────────────┴────────────┐

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,8 @@
 
 > **Docker users:** This document describes system design using native-install
 > terminology. Pipeline structure is identical under Docker; the scheduler is
-> supercronic reading `ops/crontab` rather than systemd timers. A
-> Docker-specific refresh is tracked as a separate follow-up issue.
+> supercronic reading `ops/crontab` rather than systemd timers.
+> Docker-specific refresh tracked in #76.
 >
 
 ## Overview

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -24,7 +24,7 @@ Push notifications via [ntfy.sh](https://ntfy.sh) — free, open source, cross-p
 All notifications sent by `scripts/notify.py`. Pass the subcommand as the argument.
 
 ### `daily-stats` — Morning Summary
-**Default schedule:** 7:05 AM daily (5 min after triage starts)
+**Default schedule:** 06:15 daily (15 min after triage completes window)
 
 Content:
 - Number of jobs currently in the actionable queue (score ≥ 7, not rejected)
@@ -35,7 +35,7 @@ Content:
 ---
 
 ### `health-check` — Pipeline Health
-**Default schedule:** 9:10 AM daily (2h+ after 7:00 AM triage start, to give triage time to complete)
+**Default schedule:** 07:00 daily (triage runs at 00:00, so 7h later gives the run comfortable headroom to complete)
 
 Content:
 - Whether triage completed in the last 25h (looks for `pipeline_complete` event in logs)
@@ -59,7 +59,7 @@ Only fires if there are open issues. Silent if the list is clean.
 ---
 
 ### `apply-reminder` — Daily Nudge
-**Default schedule:** 5:00 AM daily
+**Default schedule:** 06:00 daily
 
 Content:
 - Rotating motivational quip (changes daily by day-of-year index)
@@ -81,6 +81,13 @@ To review manually:
 sqlite3 -csv data/pipeline.db \
   "SELECT reject_reason, count(*) as n FROM feedback_log GROUP BY reject_reason ORDER BY n DESC;"
 ```
+
+---
+
+### `scoreboard` — Weekly Pipeline Funnel
+**Default schedule:** Monday 08:30
+
+Updates issue #31 (Pipeline Scoreboard) with funnel metrics from the last 7 days: triage throughput, apply rate, interview rate, LLM spend, and low-signal feed diagnostics. Pinned issue — no user action required.
 
 ---
 
@@ -107,15 +114,17 @@ Checks the latest GitHub Actions CI run. If it failed, sends a high-priority not
 
 | Notification | Schedule |
 |---|---|
-| `daily-stats` | 7:05 AM daily |
-| `health-check` | 9:10 AM daily |
-| `apply-reminder` | 5:00 AM daily |
-| `issues-ping` | Mon/Wed/Fri 8:00 AM |
-| `feedback-review` | Sunday 8:00 AM |
+| `apply-reminder` | 06:00 daily |
+| `daily-stats` | 06:15 daily |
+| `health-check` | 07:00 daily |
+| `issues-ping` | Mon/Wed/Fri 08:00 |
+| `scoreboard` | Monday 08:30 |
+| `feedback-review` | Sunday 08:00 |
 | `send-raw` | Manual only |
 | `ci-check` | Manual / on-push |
 
-Schedules are defined in systemd unit files at `~/.config/systemd/user/findajob-notify-*.timer`.
+Schedules are defined in `ops/crontab` (Docker, canonical for v0.1.0) and
+mirrored 1:1 in `~/.config/systemd/user/findajob-notify-*.timer` on native installs.
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,5 +1,11 @@
 # Operations
 
+> **Docker users:** This document describes the native-install workflow.
+> Prefix pipeline commands with `docker compose exec scheduler` to run them
+> inside a Compose stack (e.g., `docker compose exec scheduler python3 scripts/triage.py`).
+> A Docker-specific rewrite of this document is tracked as a separate follow-up issue.
+>
+
 Day-to-day use of the pipeline.
 
 ---

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3,7 +3,7 @@
 > **Docker users:** This document describes the native-install workflow.
 > Prefix pipeline commands with `docker compose exec scheduler` to run them
 > inside a Compose stack (e.g., `docker compose exec scheduler python3 scripts/triage.py`).
-> A Docker-specific rewrite of this document is tracked as a separate follow-up issue.
+> Docker-specific rewrite tracked in #76.
 >
 
 Day-to-day use of the pipeline.

--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -1,8 +1,8 @@
 # Scripts Reference
 
 > **Docker users:** Invocations shown are for the native install. Prefix with
-> `docker compose exec scheduler` to run inside a Compose stack. A
-> Docker-specific rewrite of this document is tracked as a separate follow-up issue.
+> `docker compose exec scheduler` to run inside a Compose stack.
+> Docker-specific rewrite tracked in #76.
 >
 
 All scripts live in `scripts/`. Diag scripts live in `scripts/diag/` and are run manually only.

--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -1,5 +1,10 @@
 # Scripts Reference
 
+> **Docker users:** Invocations shown are for the native install. Prefix with
+> `docker compose exec scheduler` to run inside a Compose stack. A
+> Docker-specific rewrite of this document is tracked as a separate follow-up issue.
+>
+
 All scripts live in `scripts/`. Diag scripts live in `scripts/diag/` and are run manually only.
 
 All scripts import `BASE`, `AICHAT`, `PANDOC`, and/or `RCLONE` from `findajob.paths` (`src/findajob/paths.py`).

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -162,6 +162,25 @@ rag_reranker_model: ~
 
 ---
 
+## Path differences under Docker
+
+When running from the `ghcr.io/brockamer/findajob` image, user-editable files
+live under your Dockge stack's `state/` directory rather than the repo root.
+The pipeline itself sees them at `/app/…` inside the container via bind mounts:
+
+| What | Native host path | Docker host path | In-container path |
+|---|---|---|---|
+| API keys | `data/.env` | `state/data/.env` | `/app/data/.env` |
+| aichat-ng config | `~/.config/aichat_ng/config.yaml` | `state/aichat_ng/config.yaml` | `/root/.config/aichat_ng/config.yaml` |
+| Personal config | `config/*.yaml\|.txt\|.json` | `state/config/*` | `/app/config/*` |
+| Candidate profile | `candidate_context/profile.md` | `state/candidate_context/profile.md` | `/app/candidate_context/profile.md` |
+
+Where this doc says "edit `data/.env`" or "place file in `config/`," Docker
+users should substitute the corresponding `state/…` path on the host. Content
+and format are identical.
+
+---
+
 ## CLAUDE.local.md
 
 Personal context for Claude Code sessions. Created from `CLAUDE.local.md.example`. Never committed to git.

--- a/docs/setup/install-linux.md
+++ b/docs/setup/install-linux.md
@@ -28,20 +28,28 @@ rclone version
 
 ---
 
-## 2. Install Rust and aichat-ng
+## 2. Install aichat-ng (prebuilt from blob42/aichat-ng)
+
+The Docker image and this native install both use the same prebuilt musl binary
+from the `blob42/aichat-ng` fork. No Rust toolchain required.
 
 ```bash
-# Install Rust
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source ~/.cargo/env
+AICHAT_NG_VERSION=v0.31.0
+AICHAT_NG_ARCH=x86_64-unknown-linux-musl
+AICHAT_NG_SHA256=8e1f5a9cf09ae651168f2a425de20b2f6e8702072d47a7052c6229fa366aa57b
 
-# Build aichat-ng
-git clone https://github.com/sigoden/aichat /tmp/aichat-ng-build
-cd /tmp/aichat-ng-build
-cargo build --release
-sudo cp target/release/aichat /usr/local/bin/aichat-ng
-aichat-ng --version
+curl -fsSL -o /tmp/aichat-ng.tar.gz \
+    "https://github.com/blob42/aichat-ng/releases/download/${AICHAT_NG_VERSION}/aichat-ng-${AICHAT_NG_VERSION}-${AICHAT_NG_ARCH}.tar.gz"
+echo "${AICHAT_NG_SHA256}  /tmp/aichat-ng.tar.gz" | sha256sum -c -
+tar -xzf /tmp/aichat-ng.tar.gz -C /tmp
+sudo install -m 0755 /tmp/aichat-ng /usr/local/bin/aichat-ng
+rm -f /tmp/aichat-ng.tar.gz /tmp/aichat-ng
+/usr/local/bin/aichat-ng --version
 ```
+
+For a different architecture (arm64, etc.) or newer upstream version, check
+[blob42/aichat-ng releases](https://github.com/blob42/aichat-ng/releases)
+and update `AICHAT_NG_VERSION`, `AICHAT_NG_ARCH`, and `AICHAT_NG_SHA256`.
 
 ---
 

--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -93,24 +93,37 @@ Used by: `prep_application.py`, `poll_flags.py` — file sync to Google Drive
 
 ### Installing aichat-ng
 
-**Important:** This pipeline uses `aichat-ng`, not the original `aichat`. They are different binaries.
+> **Docker users can skip this subsection** — `aichat-ng` is baked into the
+> `ghcr.io/brockamer/findajob` image.
+
+**Important:** This pipeline uses `aichat-ng` (the `blob42/aichat-ng` fork),
+not the original `aichat`. They are different binaries.
 
 ```bash
 # Check if already installed
 /usr/local/bin/aichat-ng --version
 
-# Build from source (recommended — gets latest features)
-git clone https://github.com/sigoden/aichat /tmp/aichat-ng-build
-cd /tmp/aichat-ng-build
-cargo build --release
-sudo cp target/release/aichat /usr/local/bin/aichat-ng
+# Install from the blob42 prebuilt release tarball (no Rust toolchain needed)
+AICHAT_NG_VERSION=v0.31.0
+AICHAT_NG_ARCH=x86_64-unknown-linux-musl
+AICHAT_NG_SHA256=8e1f5a9cf09ae651168f2a425de20b2f6e8702072d47a7052c6229fa366aa57b
+
+curl -fsSL -o /tmp/aichat-ng.tar.gz \
+    "https://github.com/blob42/aichat-ng/releases/download/${AICHAT_NG_VERSION}/aichat-ng-${AICHAT_NG_VERSION}-${AICHAT_NG_ARCH}.tar.gz"
+echo "${AICHAT_NG_SHA256}  /tmp/aichat-ng.tar.gz" | sha256sum -c -
+tar -xzf /tmp/aichat-ng.tar.gz -C /tmp
+sudo install -m 0755 /tmp/aichat-ng /usr/local/bin/aichat-ng
+rm -f /tmp/aichat-ng.tar.gz /tmp/aichat-ng
 ```
 
-Requires Rust (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
+For a different architecture or newer upstream version, check the
+[blob42/aichat-ng releases](https://github.com/blob42/aichat-ng/releases)
+page and update the three variables.
 
 ### Configuring aichat-ng
 
-aichat-ng config lives at `~/.config/aichat_ng/config.yaml`.
+aichat-ng config lives at `~/.config/aichat_ng/config.yaml` (native install)
+or `state/aichat_ng/config.yaml` (Docker install, mounted into the container).
 
 See [configure.md](configure.md) for the full config template.
 

--- a/docs/setup/state-migration.md
+++ b/docs/setup/state-migration.md
@@ -1,5 +1,11 @@
 # State Migration
 
+> **Note:** This guide covers **native → native** migration (moving a systemd
+> install between Linux hosts). For Docker deploys, migration is simpler:
+> `rsync` the stack directory's `state/` folder to the new host and bring
+> the stack up there. See [`install-docker.md`](install-docker.md).
+>
+
 How to move a running findajob pipeline from one machine to another without losing data.
 
 This guide assumes:

--- a/docs/superpowers/plans/2026-04-18-v0.1.0-doc-audit.md
+++ b/docs/superpowers/plans/2026-04-18-v0.1.0-doc-audit.md
@@ -1,0 +1,1206 @@
+# v0.1.0 Doc Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sweep the user-facing onboarding docs so a fresh reader following v0.1.0 lands on Docker as the recommended deploy path, never installs the wrong tool (`sigoden/aichat` under a `aichat-ng` filename), and sees schedule tables that match `ops/crontab`.
+
+**Architecture:** Single branch `feat/73-v0.1.0-doc-audit` (already exists, spec committed). One PR with commits grouped by file-cluster. Execution on a Linux machine with `ripgrep`, `curl`, and the existing pytest/ruff toolchain.
+
+**Tech Stack:** Markdown edits; one `ops/crontab` cross-reference for the schedule table; existing pytest infra for verification helpers if needed.
+
+**Spec:** [`docs/superpowers/specs/2026-04-17-v0.1.0-doc-audit-design.md`](../specs/2026-04-17-v0.1.0-doc-audit-design.md)
+
+**Issue:** [#73](https://github.com/brockamer/findajob/issues/73)
+
+---
+
+## File structure
+
+Files modified (in-scope per spec § 1):
+
+```
+README.md                                                (rewrite Quick Start; fix link; fix Tech Stack row; retitle docs index entries; append ops/ + Dockerfile to repo tree)
+docs/setup/prerequisites.md                              (swap sigoden/aichat cargo-build block → blob42 prebuilt tarball; add "Docker users skip" callout)
+docs/setup/install-linux.md                              (same aichat-ng swap as prerequisites.md)
+docs/setup/configure.md                                  (add "Path differences under Docker" callout)
+docs/setup/state-migration.md                            (add top-of-file banner)
+docs/notifications.md                                    (reconcile schedule table to ops/crontab; fix L117 systemd-only sentence)
+docs/operations.md                                       (one-line banner at top)
+docs/architecture.md                                     (one-line banner at top; fix "triage.py (7:00 AM)" → "(00:00 daily)")
+docs/scripts-reference.md                                (one-line banner at top)
+docs/superpowers/specs/2026-04-17-docker-compose-design.md   (append "Decisions made during implementation" subsection)
+data/.env.example                                        (add one-line "Under Docker → state/data/.env" comment)
+```
+
+Files reviewed and potentially left unchanged (review-and-decide cluster):
+
+```
+docs/learnings.md                                        (expected: no edits)
+candidate_context/profile.md.example                     (expected: no edits; verify domain-neutral)
+```
+
+---
+
+## Task 1 — Fix sigoden/aichat install bug in README + setup docs
+
+**Why first:** This is the only *functional* bug in the plan. Native users following the existing prereqs install `sigoden/aichat` and rename the binary. Landing this first keeps the fix cleanly cherry-pickable if anything else in the PR needs to be sliced off.
+
+**Files:**
+- Modify: `README.md:23` and `README.md:38` (two aichat-ng project links)
+- Modify: `docs/setup/install-linux.md:29-45` (Step 2 "Install Rust and aichat-ng")
+- Modify: `docs/setup/prerequisites.md:94-116` ("Installing aichat-ng" section)
+
+- [ ] **Step 1: Fix the two README links.**
+
+In `README.md`, change the two aichat-ng links to point to the `blob42/aichat-ng` fork.
+
+Old (L23):
+```
+| Job scoring | [aichat-ng](https://github.com/sigoden/aichat) + DeepSeek v3 via OpenRouter | Fast, cheap, accurate for structured JSON output |
+```
+New:
+```
+| Job scoring | [aichat-ng](https://github.com/blob42/aichat-ng) + DeepSeek v3 via OpenRouter | Fast, cheap, accurate for structured JSON output |
+```
+
+Old (L38):
+```
+- [aichat-ng](https://github.com/sigoden/aichat) (`aichat-ng` binary, not `aichat`)
+```
+New:
+```
+- [aichat-ng](https://github.com/blob42/aichat-ng) (`aichat-ng` binary, not `aichat`)
+```
+
+- [ ] **Step 2: Replace install-linux.md Step 2 with the prebuilt tarball flow.**
+
+Current `docs/setup/install-linux.md:29-45` is:
+
+```markdown
+---
+
+## 2. Install Rust and aichat-ng
+
+```bash
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+
+# Build aichat-ng
+git clone https://github.com/sigoden/aichat /tmp/aichat-ng-build
+cd /tmp/aichat-ng-build
+cargo build --release
+sudo cp target/release/aichat /usr/local/bin/aichat-ng
+aichat-ng --version
+```
+```
+
+Replace with:
+
+```markdown
+---
+
+## 2. Install aichat-ng (prebuilt from blob42/aichat-ng)
+
+The Docker image and this native install both use the same prebuilt musl binary
+from the `blob42/aichat-ng` fork. No Rust toolchain required.
+
+```bash
+AICHAT_NG_VERSION=v0.31.0
+AICHAT_NG_ARCH=x86_64-unknown-linux-musl
+AICHAT_NG_SHA256=8e1f5a9cf09ae651168f2a425de20b2f6e8702072d47a7052c6229fa366aa57b
+
+curl -fsSL -o /tmp/aichat-ng.tar.gz \
+    "https://github.com/blob42/aichat-ng/releases/download/${AICHAT_NG_VERSION}/aichat-ng-${AICHAT_NG_VERSION}-${AICHAT_NG_ARCH}.tar.gz"
+echo "${AICHAT_NG_SHA256}  /tmp/aichat-ng.tar.gz" | sha256sum -c -
+tar -xzf /tmp/aichat-ng.tar.gz -C /tmp
+sudo install -m 0755 /tmp/aichat-ng /usr/local/bin/aichat-ng
+rm -f /tmp/aichat-ng.tar.gz /tmp/aichat-ng
+/usr/local/bin/aichat-ng --version
+```
+
+For a different architecture (arm64, etc.) or newer upstream version, check
+[blob42/aichat-ng releases](https://github.com/blob42/aichat-ng/releases)
+and update `AICHAT_NG_VERSION`, `AICHAT_NG_ARCH`, and `AICHAT_NG_SHA256`.
+```
+
+- [ ] **Step 3: Replace prerequisites.md aichat-ng section with the same flow.**
+
+Current `docs/setup/prerequisites.md:94-116` is:
+
+```markdown
+### Installing aichat-ng
+
+**Important:** This pipeline uses `aichat-ng`, not the original `aichat`. They are different binaries.
+
+```bash
+# Check if already installed
+/usr/local/bin/aichat-ng --version
+
+# Build from source (recommended — gets latest features)
+git clone https://github.com/sigoden/aichat /tmp/aichat-ng-build
+cd /tmp/aichat-ng-build
+cargo build --release
+sudo cp target/release/aichat /usr/local/bin/aichat-ng
+```
+
+Requires Rust (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
+
+### Configuring aichat-ng
+
+aichat-ng config lives at `~/.config/aichat_ng/config.yaml`.
+
+See [configure.md](configure.md) for the full config template.
+```
+
+Replace with:
+
+```markdown
+### Installing aichat-ng
+
+> **Docker users can skip this subsection** — `aichat-ng` is baked into the
+> `ghcr.io/brockamer/findajob` image.
+
+**Important:** This pipeline uses `aichat-ng` (the `blob42/aichat-ng` fork),
+not the original `aichat`. They are different binaries.
+
+```bash
+# Check if already installed
+/usr/local/bin/aichat-ng --version
+
+# Install from the blob42 prebuilt release tarball (no Rust toolchain needed)
+AICHAT_NG_VERSION=v0.31.0
+AICHAT_NG_ARCH=x86_64-unknown-linux-musl
+AICHAT_NG_SHA256=8e1f5a9cf09ae651168f2a425de20b2f6e8702072d47a7052c6229fa366aa57b
+
+curl -fsSL -o /tmp/aichat-ng.tar.gz \
+    "https://github.com/blob42/aichat-ng/releases/download/${AICHAT_NG_VERSION}/aichat-ng-${AICHAT_NG_VERSION}-${AICHAT_NG_ARCH}.tar.gz"
+echo "${AICHAT_NG_SHA256}  /tmp/aichat-ng.tar.gz" | sha256sum -c -
+tar -xzf /tmp/aichat-ng.tar.gz -C /tmp
+sudo install -m 0755 /tmp/aichat-ng /usr/local/bin/aichat-ng
+rm -f /tmp/aichat-ng.tar.gz /tmp/aichat-ng
+```
+
+For a different architecture or newer upstream version, check the
+[blob42/aichat-ng releases](https://github.com/blob42/aichat-ng/releases)
+page and update the three variables.
+
+### Configuring aichat-ng
+
+aichat-ng config lives at `~/.config/aichat_ng/config.yaml` (native install)
+or `state/aichat_ng/config.yaml` (Docker install, mounted into the container).
+
+See [configure.md](configure.md) for the full config template.
+```
+
+- [ ] **Step 4: Verify no `sigoden/aichat` remains in tracked onboarding docs.**
+
+Run (from repo root):
+
+```bash
+rg -n 'sigoden/aichat' README.md docs/setup/
+```
+
+Expected: **no matches**. If any line prints, the substitution missed that location — fix it before committing.
+
+Also verify historical references are still present (they must stay):
+
+```bash
+rg -n 'sigoden/aichat' CHANGELOG.md docs/superpowers/plans/
+```
+
+Expected: matches in `CHANGELOG.md`, `docs/superpowers/plans/2026-04-14-lxc-migration.md`, `docs/superpowers/plans/2026-04-17-docker-compose.md`. These are historical records — leave them.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add README.md docs/setup/install-linux.md docs/setup/prerequisites.md
+git commit -m "$(cat <<'EOF'
+docs: switch aichat-ng install to blob42 prebuilt tarball (#73)
+
+Native install steps in install-linux.md and prerequisites.md cloned
+sigoden/aichat and renamed the resulting binary to /usr/local/bin/aichat-ng,
+which is not the fork this pipeline targets. Replace with the same blob42
+prebuilt tarball flow the Dockerfile uses, removing the Rust toolchain
+dependency from the native install. Fix the two README aichat-ng project
+links accordingly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2 — Rewrite README Quick Start; frame Docker as recommended
+
+**Files:**
+- Modify: `README.md:5` (tagline)
+- Modify: `README.md:31` (Tech Stack Scheduler row)
+- Modify: `README.md:46-77` (Quick Start section)
+- Modify: `README.md:83-94` (Documentation index table)
+- Modify: `README.md:100-131` (Repository Structure tree)
+
+- [ ] **Step 1: Fix the tagline (L5).**
+
+Old:
+```
+Runs daily via systemd user timers. No cloud infrastructure. No subscription. Costs ~$0.50–2/day in API usage depending on job volume.
+```
+New:
+```
+Deploys as a Docker container via Compose. Native systemd install remains documented as a fallback. No cloud infrastructure. No subscription. Costs ~$0.50–2/day in API usage depending on job volume.
+```
+
+- [ ] **Step 2: Fix the Tech Stack Scheduler row (L31).**
+
+Old:
+```
+| Scheduler | systemd user timers | Native, no extra daemons |
+```
+New:
+```
+| Scheduler | supercronic (Docker) / systemd (native) | supercronic runs the crontab inside the image; systemd is the fallback on native installs |
+```
+
+- [ ] **Step 3: Replace Quick Start (L46-77).**
+
+Current block (from `## Quick Start` through the closing fence, inclusive) is:
+
+```markdown
+## Quick Start
+
+```bash
+git clone https://github.com/yourname/findajob ~/findajob
+cd ~/findajob
+
+# Create your personal config files from templates
+cp candidate_context/profile.md.example candidate_context/profile.md
+cp config/jsearch_queries.txt.example config/jsearch_queries.txt
+cp config/feed_urls.txt.example config/feed_urls.txt
+cp config/target_companies.md.example config/target_companies.md
+cp CLAUDE.local.md.example CLAUDE.local.md
+cp config/paths.env.example config/paths.env  # fill in your binary paths
+
+# Create required directories
+mkdir -p logs companies/data
+
+# Install Python dependencies
+pip3 install --break-system-packages google-api-python-client google-auth-httplib2 \
+  google-auth-oauthlib requests jsonschema
+
+# Set up secrets
+cp data/.env.example data/.env
+chmod 600 data/.env
+# Edit data/.env and fill in all API keys
+
+# Initialize DB
+python3 scripts/init_db.py
+
+# Full setup walkthrough
+# See docs/setup/install-linux.md
+```
+```
+
+Replace with:
+
+```markdown
+## Quick Start
+
+findajob ships as a Docker image pulled from GHCR and deployed via Docker Compose.
+
+```bash
+# On your Docker host — replace <you> with a short tag (brock, amy, etc.)
+sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng}
+sudo chown -R $(id -u):$(id -g) /opt/stacks/findajob-<you>/
+cd /opt/stacks/findajob-<you>
+
+curl -fsSL -o compose.yaml https://raw.githubusercontent.com/brockamer/findajob/main/ops/compose.yaml.example
+curl -fsSL -o .env         https://raw.githubusercontent.com/brockamer/findajob/main/ops/stack.env.example
+
+# Populate state/ with API keys, personal config, and candidate profile —
+# see the install guide for each file's purpose and template.
+docker compose up -d
+```
+
+Full walkthrough (API keys, Gmail OAuth, Google Sheets, Drive sync) →
+[`docs/setup/install-docker.md`](docs/setup/install-docker.md).
+
+Running on a Linux host without Docker is still supported — see
+[`docs/setup/install-linux.md`](docs/setup/install-linux.md).
+```
+
+- [ ] **Step 4: Reorder the Documentation index table (L83-94).**
+
+The current block in `README.md` between `## Documentation` and the next `---` separator is:
+
+```markdown
+## Documentation
+
+| Doc | Contents |
+|---|---|
+| [docs/architecture.md](docs/architecture.md) | System design, data flow, component map |
+| [docs/setup/prerequisites.md](docs/setup/prerequisites.md) | API keys, accounts, tools you need |
+| [docs/setup/install-linux.md](docs/setup/install-linux.md) | Ubuntu + systemd setup |
+| [docs/setup/configure.md](docs/setup/configure.md) | Profile, resume, queries, Google Sheets |
+| [docs/setup/state-migration.md](docs/setup/state-migration.md) | Moving an existing pipeline to a new machine |
+| [docs/operations.md](docs/operations.md) | Day-to-day use, monitoring, common tasks |
+| [docs/scripts-reference.md](docs/scripts-reference.md) | Every script documented |
+| [docs/google-sheets.md](docs/google-sheets.md) | Sheet layout, Dashboard workflow |
+| [docs/notifications.md](docs/notifications.md) | ntfy.sh setup and notification schedule |
+| [docs/claude-code.md](docs/claude-code.md) | Using Claude Code as a pipeline operator |
+```
+
+Replace with:
+
+```markdown
+## Documentation
+
+| Doc | Contents |
+|---|---|
+| [docs/architecture.md](docs/architecture.md) | System design, data flow, component map |
+| [docs/setup/prerequisites.md](docs/setup/prerequisites.md) | API keys, accounts, tools you need |
+| [docs/setup/install-docker.md](docs/setup/install-docker.md) | **Docker Compose setup (recommended)** |
+| [docs/setup/install-linux.md](docs/setup/install-linux.md) | Ubuntu + systemd setup (native fallback) |
+| [docs/setup/configure.md](docs/setup/configure.md) | Profile, resume, queries, Google Sheets |
+| [docs/setup/state-migration.md](docs/setup/state-migration.md) | Moving an existing pipeline to a new machine |
+| [docs/operations.md](docs/operations.md) | Day-to-day use, monitoring, common tasks |
+| [docs/scripts-reference.md](docs/scripts-reference.md) | Every script documented |
+| [docs/google-sheets.md](docs/google-sheets.md) | Sheet layout, Dashboard workflow |
+| [docs/notifications.md](docs/notifications.md) | ntfy.sh setup and notification schedule |
+| [docs/claude-code.md](docs/claude-code.md) | Using Claude Code as a pipeline operator |
+```
+
+- [ ] **Step 5: Append `ops/` and `Dockerfile` to the Repository Structure tree (L100-131).**
+
+In `README.md`, the tree currently ends before `companies/`:
+
+```
+├── companies/                  # Generated prep folders (gitignored)
+├── logs/                       # Pipeline logs (gitignored)
+└── CLAUDE.md                   # Claude Code session context
+```
+
+Add two new entries immediately before `└── CLAUDE.md`, so the tree ends:
+
+```
+├── companies/                  # Generated prep folders (gitignored)
+├── logs/                       # Pipeline logs (gitignored)
+├── ops/                        # Docker deploy: crontab, compose example, entrypoint
+├── Dockerfile                  # findajob image build (published to ghcr.io/brockamer/findajob)
+└── CLAUDE.md                   # Claude Code session context
+```
+
+- [ ] **Step 6: Verify.**
+
+```bash
+rg -n 'systemd user timers' README.md
+```
+
+Expected: no hit on README.md L5. (The phrase may appear elsewhere in the repo — only README.md L5 matters for this step.)
+
+```bash
+rg -n 'sigoden' README.md
+```
+
+Expected: no hits.
+
+```bash
+rg -n 'install-docker\.md|install-linux\.md' README.md
+```
+
+Expected: at least one hit per file name in the Quick Start section or Documentation table, with `install-docker.md` appearing first/higher.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs: rewrite README Quick Start around Docker; demote native (#73)
+
+Leads with docker compose pull/up as the recommended path, keeps native
+systemd install as a single linked fallback. Updates the Tech Stack
+scheduler row and tagline to reflect supercronic-in-container; adds
+install-docker.md to the Documentation index and relabels install-linux.md
+as the native fallback. Appends ops/ + Dockerfile to the repo structure.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — Reconcile notifications.md schedule; add Docker-path callouts to setup docs
+
+**Files:**
+- Modify: `docs/notifications.md` (schedule table L106-118 + systemd-only sentence L117)
+- Modify: `docs/setup/configure.md` (add Docker-path callout)
+- Modify: `docs/setup/state-migration.md` (add top-of-file banner)
+
+- [ ] **Step 1: Reconcile `docs/notifications.md` schedule table against `ops/crontab`.**
+
+The canonical schedule is `ops/crontab` (in TZ set by stack .env). Known mismatches to fix:
+
+| Notification | docs/notifications.md currently | `ops/crontab` canonical |
+|---|---|---|
+| `daily-stats` | 7:05 AM | 06:15 |
+| `health-check` | 9:10 AM | 07:00 |
+| `apply-reminder` | 5:00 AM | 06:00 |
+| `issues-ping` | Mon/Wed/Fri 8:00 AM | Mon/Wed/Fri 08:00 (match) |
+| `feedback-review` | Sunday 8:00 AM | Sunday 08:00 (match) |
+| `scoreboard` | not in table | Monday 08:30 |
+
+Also: per-notification "Default schedule" callouts inside the body need the same updates.
+
+Apply the following edits to `docs/notifications.md`:
+
+a) In the `daily-stats` subsection (around L28), change:
+```
+**Default schedule:** 7:05 AM daily (5 min after triage starts)
+```
+to:
+```
+**Default schedule:** 06:15 daily (15 min after triage completes window)
+```
+
+b) In the `health-check` subsection (around L38), change:
+```
+**Default schedule:** 9:10 AM daily (2h+ after 7:00 AM triage start, to give triage time to complete)
+```
+to:
+```
+**Default schedule:** 07:00 daily (triage runs at 00:00, so 7h later gives the run comfortable headroom to complete)
+```
+
+c) In the `apply-reminder` subsection (around L62), change:
+```
+**Default schedule:** 5:00 AM daily
+```
+to:
+```
+**Default schedule:** 06:00 daily
+```
+
+d) The Schedule Summary table (L106-118) — replace the whole block, starting at `## Schedule Summary` through the closing sentence before the next `---`, with:
+
+```markdown
+## Schedule Summary
+
+| Notification | Schedule |
+|---|---|
+| `apply-reminder` | 06:00 daily |
+| `daily-stats` | 06:15 daily |
+| `health-check` | 07:00 daily |
+| `issues-ping` | Mon/Wed/Fri 08:00 |
+| `scoreboard` | Monday 08:30 |
+| `feedback-review` | Sunday 08:00 |
+| `send-raw` | Manual only |
+| `ci-check` | Manual / on-push |
+
+Schedules are defined in `ops/crontab` (Docker, canonical for v0.1.0) and
+mirrored 1:1 in `~/.config/systemd/user/findajob-notify-*.timer` on native installs.
+```
+
+e) Add a new `scoreboard` subsection just above `send-raw` so the in-body notification list matches the Schedule Summary. Insert the following immediately after the `feedback-review` subsection:
+
+```markdown
+### `scoreboard` — Weekly Pipeline Funnel
+**Default schedule:** Monday 08:30
+
+Updates issue #31 (Pipeline Scoreboard) with funnel metrics from the last 7 days: triage throughput, apply rate, interview rate, LLM spend, and low-signal feed diagnostics. Pinned issue — no user action required.
+
+---
+```
+
+- [ ] **Step 2: Add Docker-path callout to `docs/setup/configure.md`.**
+
+Insert a new section immediately after the `## aichat-ng config.yaml` section (before `## CLAUDE.local.md`):
+
+```markdown
+---
+
+## Path differences under Docker
+
+When running from the `ghcr.io/brockamer/findajob` image, user-editable files
+live under your Dockge stack's `state/` directory rather than the repo root.
+The pipeline itself sees them at `/app/…` inside the container via bind mounts:
+
+| What | Native host path | Docker host path | In-container path |
+|---|---|---|---|
+| API keys | `data/.env` | `state/data/.env` | `/app/data/.env` |
+| aichat-ng config | `~/.config/aichat_ng/config.yaml` | `state/aichat_ng/config.yaml` | `/root/.config/aichat_ng/config.yaml` |
+| Personal config | `config/*.yaml\|.txt\|.json` | `state/config/*` | `/app/config/*` |
+| Candidate profile | `candidate_context/profile.md` | `state/candidate_context/profile.md` | `/app/candidate_context/profile.md` |
+
+Where this doc says "edit `data/.env`" or "place file in `config/`," Docker
+users should substitute the corresponding `state/…` path on the host. Content
+and format are identical.
+```
+
+- [ ] **Step 3: Add top-of-file banner to `docs/setup/state-migration.md`.**
+
+At the very top of the file, immediately after the title line `# State Migration` and its blank line, insert:
+
+```markdown
+> **Note:** This guide covers **native → native** migration (moving a systemd
+> install between Linux hosts). For Docker deploys, migration is simpler:
+> `rsync` the stack directory's `state/` folder to the new host and bring
+> the stack up there. See [`install-docker.md`](install-docker.md).
+>
+```
+
+- [ ] **Step 4: Verify.**
+
+```bash
+# Schedule table cross-check: extract all `notify.py <subcmd>` schedules from ops/crontab
+# and confirm each appears in the Schedule Summary table.
+rg '^\s*[0-9*,/-]+\s+[0-9*,/-]+\s+[0-9*,/-]+\s+[0-9*,/-]+\s+[0-9*,/-]+\s+.*notify\.py' ops/crontab
+```
+
+Expected: 6 lines (apply-reminder, daily-stats, health-check, issues-ping, scoreboard, feedback-review).
+
+```bash
+# No remaining references to the old incorrect schedule values.
+rg -n '7:05 AM|9:10 AM|5:00 AM daily' docs/notifications.md
+```
+
+Expected: no hits.
+
+```bash
+# Configure-docker callout is present.
+rg -n 'Path differences under Docker' docs/setup/configure.md
+```
+
+Expected: 1 hit.
+
+```bash
+# State-migration banner is present.
+head -5 docs/setup/state-migration.md
+```
+
+Expected: title line, blank line, `> **Note:** This guide covers …`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add docs/notifications.md docs/setup/configure.md docs/setup/state-migration.md
+git commit -m "$(cat <<'EOF'
+docs: reconcile notifications.md schedule + Docker paths in setup (#73)
+
+Cross-checked docs/notifications.md against ops/crontab — the canonical
+schedule for v0.1.0 — and corrected three stale default-schedule values
+(daily-stats, health-check, apply-reminder). Added the scoreboard entry
+that was previously missing from the Schedule Summary and body list.
+
+Added a "Path differences under Docker" section to configure.md so a
+Docker user reading the setup guide knows state/data/.env maps to
+/app/data/.env inside the container. Added a top-of-file banner to
+state-migration.md clarifying it's native→native; Docker migration is
+a separate (much simpler) flow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — Banner notes on operations / architecture / scripts-reference; fix architecture schedule
+
+**Files:**
+- Modify: `docs/operations.md` (top-of-file banner)
+- Modify: `docs/architecture.md` (top-of-file banner + schedule fix L21)
+- Modify: `docs/scripts-reference.md` (top-of-file banner)
+
+The banner is intentionally identical across the three files so a reader jumping between them gets consistent framing. Deep rewrite is out of #73's scope — see Task 7 for the follow-up issue.
+
+- [ ] **Step 1: Add banner to `docs/operations.md`.**
+
+Immediately after the title line `# Operations` and its blank line, insert:
+
+```markdown
+> **Docker users:** This document describes the native-install workflow.
+> Prefix pipeline commands with `docker compose exec scheduler` to run them
+> inside a Compose stack (e.g., `docker compose exec scheduler python3 scripts/triage.py`).
+> A Docker-specific rewrite of this document is tracked as a separate follow-up issue.
+>
+```
+
+- [ ] **Step 2: Add the same banner to `docs/architecture.md` and fix the stale triage schedule.**
+
+Immediately after the title line `# Architecture` and its blank line, insert the same banner as Step 1 (replace `operations.md` framing wording with architecture if it reads odd — otherwise use verbatim):
+
+```markdown
+> **Docker users:** This document describes system design using native-install
+> terminology. Pipeline structure is identical under Docker; the scheduler is
+> supercronic reading `ops/crontab` rather than systemd timers. A
+> Docker-specific refresh is tracked as a separate follow-up issue.
+>
+```
+
+Then, in the Daily Triage Pipeline diagram near L21, change:
+
+```
+│                    triage.py (7:00 AM)                  │
+```
+
+to:
+
+```
+│                    triage.py (00:00 daily)              │
+```
+
+- [ ] **Step 3: Add banner to `docs/scripts-reference.md`.**
+
+Immediately after the title line (first non-blank line of the file) and its blank line, insert:
+
+```markdown
+> **Docker users:** Invocations shown are for the native install. Prefix with
+> `docker compose exec scheduler` to run inside a Compose stack. A
+> Docker-specific rewrite of this document is tracked as a separate follow-up issue.
+>
+```
+
+- [ ] **Step 4: Verify.**
+
+```bash
+rg -n '^> \*\*Docker users:\*\*' docs/operations.md docs/architecture.md docs/scripts-reference.md
+```
+
+Expected: exactly one hit per file.
+
+```bash
+rg -n '7:00 AM' docs/architecture.md
+```
+
+Expected: no hits.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add docs/operations.md docs/architecture.md docs/scripts-reference.md
+git commit -m "$(cat <<'EOF'
+docs: add Docker-context banner to operations/architecture/scripts-reference (#73)
+
+These three deep-dive docs use native-install command examples throughout.
+Rewriting them for Docker is out of #73's scope; add a consistent banner at
+the top of each pointing Docker users at 'docker compose exec scheduler'
+as the escape hatch, and fix an unrelated stale schedule reference in
+architecture.md (triage runs at midnight, not 7 AM).
+
+Deep Docker rewrite tracked as a follow-up issue.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — Backfill "Decisions made during implementation" in docker-compose spec
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-17-docker-compose-design.md`
+
+Plan conventions (`docs/plan-conventions.md`) say: "When a plan reveals a flaw in the spec, fix the spec in the same PR (often via a 'Decisions made during implementation' subsection appended to the spec doc). Don't let the plan and spec drift."
+
+Four divergences landed between the original spec and PR #72 / PR #75:
+
+1. aichat-ng tarball extraction path is flat, not nested (fixed in commit `e3b0e04`).
+2. supercronic has no `-version` flag; replaced with `-test` probe (fixed in commit `a4586bc`).
+3. `scripts/gmail_auth.py` shipped with 8 tests, not 6 — two added after code review flagged gaps in 0600 token mode and device-polling loop coverage.
+4. `ops/crontab` shipped with three notify.py subcommand names that didn't exist in `COMMANDS` (fixed in PR #75 for #74, after the spec was signed off).
+
+- [ ] **Step 1: Append the subsection to the spec.**
+
+At the very end of `docs/superpowers/specs/2026-04-17-docker-compose-design.md`, append:
+
+```markdown
+
+---
+
+## Decisions made during implementation
+
+Captured post-PR-#72 per `docs/plan-conventions.md`. These deltas do not
+invalidate the spec; they correct small details that shook out during build.
+
+1. **aichat-ng tarball layout.** The spec assumed the `blob42/aichat-ng` v0.31.0
+   release tarball wrapped the binary in `aichat-ng-${VERSION}-${ARCH}/`. The
+   tarball is actually flat (`tar -tzf` lists only `aichat-ng`). Dockerfile
+   extracts to `/tmp` and installs from there. Fixed in commit `e3b0e04`.
+
+2. **supercronic version probe.** supercronic v0.2.29 has no `-version` flag.
+   Build-time healthcheck replaced with `-test` against a no-op crontab, which
+   proves both binary executability and crontab-parsing capability. SHA1
+   verification is preserved. Fixed in commit `a4586bc`.
+
+3. **gmail_auth.py test count.** Spec called for 6 tests; shipped 8. The two
+   extra tests cover 0600 token-file mode enforcement and device-polling loop
+   coverage, added after in-PR code review flagged the gaps.
+
+4. **ops/crontab notify.py subcommand mismatches.** The shipped crontab used
+   three notify.py subcommand names (`stats`, `issues`, `feedback`) that the
+   dispatcher does not accept — the correct names are `daily-stats`,
+   `issues-ping`, `feedback-review`. Each invocation fired at its scheduled
+   time, printed the usage line, and exited 1 — silently disabling three
+   notifications on every Docker deploy. Fixed in PR #75 (issue #74) with a
+   pytest regression guard that AST-parses `notify.COMMANDS` and cross-checks
+   every `notify.py <subcmd>` invocation in `ops/crontab`.
+```
+
+- [ ] **Step 2: Verify.**
+
+```bash
+rg -n '## Decisions made during implementation' docs/superpowers/specs/2026-04-17-docker-compose-design.md
+```
+
+Expected: 1 hit.
+
+```bash
+tail -40 docs/superpowers/specs/2026-04-17-docker-compose-design.md
+```
+
+Expected: the four numbered divergences.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add docs/superpowers/specs/2026-04-17-docker-compose-design.md
+git commit -m "$(cat <<'EOF'
+docs: backfill decisions-made-during-implementation in #13 spec (#73)
+
+Per plan-conventions.md, captures the four deltas between the original
+docker-compose spec and what shipped across PRs #72 and #75: flat tarball
+layout, supercronic -test probe, gmail_auth.py extra tests, ops/crontab
+subcommand-mismatch bug.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6 — Review-and-decide cluster (learnings, .env.example, profile example)
+
+**Files (review only, edit only if needed):**
+- Review: `docs/learnings.md`
+- Modify (trivially): `data/.env.example`
+- Review: `candidate_context/profile.md.example`
+
+- [ ] **Step 1: Review `docs/learnings.md`.**
+
+Read the file. Expected outcome: no edits. It's a historical observations doc (job-source quality, scorer behavior, prefilter design) not tied to the deploy path. If a factual claim has been invalidated by the containerization PR, flag it — otherwise record the check in the commit message and move on.
+
+Decision-flag check (run these greps; if any return a hit, evaluate the hit for correctness):
+
+```bash
+rg -n 'systemd|cron|supercronic|Docker|container' docs/learnings.md
+```
+
+Expected: one hit for the `systemd OnUnitActiveSec` line in the Infrastructure section, which describes a real historical quirk of systemd timers and is still true. Leave it.
+
+- [ ] **Step 2: Add Docker-path comment to `data/.env.example`.**
+
+Immediately after line 2 (`# Copy to data/.env and fill in your values.`) and before line 3, insert:
+
+```
+# Under a Docker deploy this file lives at state/data/.env and is
+# bind-mounted to /app/data/.env inside the container.
+```
+
+After the edit, the file header should read:
+
+```
+# data/.env — API keys and secrets
+# Copy to data/.env and fill in your values.
+# Under a Docker deploy this file lives at state/data/.env and is
+# bind-mounted to /app/data/.env inside the container.
+# chmod 600 data/.env
+# This file is gitignored. Never commit your actual .env.
+```
+
+- [ ] **Step 3: Review `candidate_context/profile.md.example`.**
+
+Read the file. Expected outcome: no edits. It should be domain-neutral (per the PII / generalization rules in `CLAUDE.md`). If any section names a specific industry, city, or employer, flag it — this is out of #73's scope but worth capturing as a separate issue.
+
+Run:
+
+```bash
+rg -ni 'meta|google|openai|anthropic|los angeles|LA\b|data center|NPI|\bRTP\b' candidate_context/profile.md.example
+```
+
+Expected: no hits. If any hit, stop and ask the user how to handle it before committing (this would be a PII-policy violation in a tracked file, not a doc-audit concern).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add data/.env.example
+git commit -m "$(cat <<'EOF'
+docs: note Docker path in .env.example; confirm learnings / profile clean (#73)
+
+Single-line comment pointing Docker users at state/data/.env. Reviewed
+docs/learnings.md (no edits — historical observations still accurate) and
+candidate_context/profile.md.example (no edits — confirmed domain-neutral
+per CLAUDE.md PII rules).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7 — File the follow-up issue for the deep-dive doc rewrite
+
+**Files:** none (creates a GitHub issue and adds it to the project board).
+
+- [ ] **Step 1: Create the follow-up issue.**
+
+Run:
+
+```bash
+gh issue create \
+  --title "Docs: refresh operations/architecture/scripts-reference for Docker deploy" \
+  --label documentation,open-source \
+  --body "$(cat <<'BODY'
+## Why
+
+#73 added a short Docker-context banner to \`docs/operations.md\`, \`docs/architecture.md\`,
+and \`docs/scripts-reference.md\`. The full rewrite was intentionally deferred — \`#73\`'s
+charter was README + onboarding docs only.
+
+These three docs still use native-install terminology and command examples throughout.
+Once v0.1.0 dogfood telemetry shows the install guide is solid, refresh them to treat
+the Docker deploy as the primary path.
+
+## Scope
+
+- \`docs/operations.md\` — convert the Systemd Operations section into a parallel
+  Docker Operations + Native Operations structure. Update command examples.
+- \`docs/architecture.md\` — add a supercronic/Compose block to the data-flow diagrams.
+  Reference \`ops/crontab\` as the canonical schedule source.
+- \`docs/scripts-reference.md\` — each script section gains a "How to run" row with
+  both \`docker compose exec scheduler …\` and native equivalents.
+
+## Non-goals
+
+- Retiring the native-install documentation entirely.
+- Rewriting \`docs/notifications.md\` (already reconciled in #73).
+
+## Dependencies
+
+- v0.1.0 must be tagged and at least one dogfooder must be running the Docker deploy.
+- \`docs/setup/install-docker.md\` full guide under #69 should land first.
+
+## Priority
+
+Medium. Not blocking v0.1.0; the banners added in #73 carry users through the dogfood window.
+
+## Work stream
+
+Generalization.
+BODY
+)"
+```
+
+Record the new issue number (it will print as the last line of output; copy it). Call it `$NEW_ISSUE` below.
+
+- [ ] **Step 2: Add the new issue to the project board and set fields.**
+
+```bash
+# Replace $NEW_ISSUE with the actual number from Step 1.
+gh project item-add 1 --owner brockamer --url https://github.com/brockamer/findajob/issues/$NEW_ISSUE
+
+# Get the new item's ID
+NEW_ITEM_ID=$(gh project item-list 1 --owner brockamer --format json --limit 200 \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); n=int(sys.argv[1]); print([i['id'] for i in d['items'] if i.get('content',{}).get('number')==n][0])" $NEW_ISSUE)
+
+# Priority=Medium, Work Stream=Generalization, Status stays Backlog
+gh project item-edit --project-id PVT_kwHOAgGulc4BUtxZ --id "$NEW_ITEM_ID" \
+    --field-id PVTSSF_lAHOAgGulc4BUtxZzhCWZ08 --single-select-option-id 4e8ef0ac
+gh project item-edit --project-id PVT_kwHOAgGulc4BUtxZ --id "$NEW_ITEM_ID" \
+    --field-id PVTSSF_lAHOAgGulc4BUtxZzhCWa0Y --single-select-option-id 506d8256
+```
+
+- [ ] **Step 3: Back-reference the new issue from the banners.**
+
+Each banner added in Task 4 says "tracked as a separate follow-up issue" without a number. Now that the issue exists, patch each banner to include the number. In each of the three files, change:
+
+```
+A Docker-specific rewrite of this document is tracked as a separate follow-up issue.
+```
+
+to:
+
+```
+Docker-specific rewrite tracked in #$NEW_ISSUE.
+```
+
+(Similar variants for architecture.md's "refresh" wording — reword to `Docker-specific refresh tracked in #$NEW_ISSUE.`)
+
+Verify:
+
+```bash
+rg -n "tracked in #" docs/operations.md docs/architecture.md docs/scripts-reference.md
+```
+
+Expected: one hit per file, all pointing at the same issue number.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add docs/operations.md docs/architecture.md docs/scripts-reference.md
+git commit -m "$(cat <<'EOF'
+docs: link deep-rewrite banners to follow-up issue (#73)
+
+The Docker-context banners added in the previous commit referenced an
+unnumbered follow-up issue. Now that the issue is filed, patch each
+banner to cite it by number.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8 — Verification gate and PR
+
+**Files:** none (runs the acceptance checks from the spec and opens the PR).
+
+- [ ] **Step 1: Run the spec's verification gate.**
+
+a) `sigoden/aichat` reference audit:
+
+```bash
+rg -n 'sigoden/aichat' README.md docs/setup/ data/ candidate_context/
+```
+
+Expected: no matches.
+
+```bash
+rg -n 'sigoden/aichat' CHANGELOG.md docs/superpowers/plans/
+```
+
+Expected: matches in `CHANGELOG.md`, `2026-04-14-lxc-migration.md`, `2026-04-17-docker-compose.md`. These are historical records and must remain.
+
+b) `systemd` as recommended path check:
+
+```bash
+rg -n 'systemd user (timers|services)' README.md docs/setup/
+```
+
+Expected: hits in `install-linux.md` only (as the fallback reference). No hits in README.md or install-docker.md as *the* recommended path.
+
+c) Schedule table matches ops/crontab:
+
+```bash
+python3 - <<'PY'
+import re, pathlib
+crontab = pathlib.Path("ops/crontab").read_text()
+notif = pathlib.Path("docs/notifications.md").read_text()
+# Subcommands in crontab
+cron_subs = set(re.findall(r"notify\.py\s+([a-z0-9-]+)", crontab))
+# Subcommands listed in the Schedule Summary table
+table = re.search(r"## Schedule Summary(.+?)(?=^##|^---|\Z)", notif, re.M | re.S).group(1)
+doc_subs = set(re.findall(r"`([a-z0-9-]+)`", table))
+missing = cron_subs - doc_subs
+extra = doc_subs - cron_subs - {"send-raw", "ci-check"}  # these two are manual-only, allowed in table
+assert not missing, f"docs/notifications.md table is missing scheduled subcommands: {missing}"
+assert not extra, f"docs/notifications.md table lists non-scheduled subcommands: {extra}"
+print("OK — notifications.md Schedule Summary covers every ops/crontab notify.py subcommand.")
+PY
+```
+
+Expected: `OK — notifications.md Schedule Summary covers every ops/crontab notify.py subcommand.`
+
+d) Link resolution (relative links): simple existence check over `README.md` and `docs/setup/*.md`:
+
+```bash
+python3 - <<'PY'
+import pathlib, re, sys
+
+root = pathlib.Path(".")
+files = [root / "README.md"] + sorted(root.glob("docs/setup/*.md"))
+link_re = re.compile(r"\[[^\]]+\]\(([^)#]+?)(#[^)]+)?\)")
+bad = []
+for f in files:
+    text = f.read_text()
+    for m in link_re.finditer(text):
+        url = m.group(1).strip()
+        if url.startswith("http://") or url.startswith("https://") or url.startswith("mailto:"):
+            continue
+        # Resolve relative to the file's parent
+        target = (f.parent / url).resolve()
+        if not target.exists():
+            bad.append((str(f), url))
+if bad:
+    for f, u in bad:
+        print(f"BROKEN: {f} → {u}")
+    sys.exit(1)
+print(f"OK — {len(files)} files checked, all relative links resolve.")
+PY
+```
+
+Expected: `OK — N files checked, all relative links resolve.` If any BROKEN line prints, fix the link (usually a renamed file or missing anchor) and re-run.
+
+e) Full test suite still green:
+
+```bash
+python3 -m pytest tests/ 2>&1 | tail -3
+```
+
+Expected: all tests passing (was 448 at start of #73; no new tests expected unless a helper test was added — still should be green).
+
+f) Ruff clean on anything touched:
+
+```bash
+ruff check . 2>&1 | tail -5
+ruff format --check . 2>&1 | tail -5
+```
+
+Expected: `All checks passed!` and no reformat-needed files.
+
+- [ ] **Step 2: Acceptance-criteria trace.**
+
+Run `gh issue view 73 --json body -q '.body' | rg "^- \[ \]"` to list the checkboxes, and confirm each is implemented. Expected mapping:
+
+| Acceptance | Implementing commit |
+|---|---|
+| README leads with Docker | Task 2 |
+| Tech Stack reflects scheduler + aichat-ng fork | Task 1 (link), Task 2 (row) |
+| Quick Start copy-pasteable against GHCR image | Task 2 |
+| Every link in README + docs/setup/*.md resolves | Task 8 Step 1d |
+| learnings/notifications/configure/state-migration reviewed | Tasks 3 + 6 |
+| Spec backfill for docker-compose-design.md | Task 5 |
+| No systemd as recommended path | Tasks 1 + 2 + Task 8 Step 1b |
+
+- [ ] **Step 3: Push and open the PR.**
+
+```bash
+git push -u origin feat/73-v0.1.0-doc-audit
+```
+
+Then:
+
+```bash
+gh pr create --title "v0.1.0 doc audit: README + onboarding sweep (#73)" --body "$(cat <<'BODY'
+## Summary
+
+Pre-v0.1.0 sweep of user-facing entry-point docs. Leads README with Docker Compose as the recommended deploy, demotes native to a linked fallback, and repairs a latent functional bug where native install guides cloned sigoden/aichat and renamed the binary to aichat-ng. Reconciles docs/notifications.md schedule against ops/crontab; adds Docker-path callouts and banners to key setup and deep-dive docs; backfills decisions-made-during-implementation into the docker-compose spec.
+
+**Spec:** \`docs/superpowers/specs/2026-04-17-v0.1.0-doc-audit-design.md\`
+**Plan:** \`docs/superpowers/plans/2026-04-18-v0.1.0-doc-audit.md\`
+
+## What's in this PR
+
+Commits grouped by file cluster:
+
+1. \`docs: switch aichat-ng install to blob42 prebuilt tarball\` — functional fix (native installs no longer install the wrong tool)
+2. \`docs: rewrite README Quick Start around Docker; demote native\`
+3. \`docs: reconcile notifications.md schedule + Docker paths in setup\`
+4. \`docs: add Docker-context banner to operations/architecture/scripts-reference\`
+5. \`docs: backfill decisions-made-during-implementation in #13 spec\`
+6. \`docs: note Docker path in .env.example; confirm learnings / profile clean\`
+7. \`docs: link deep-rewrite banners to follow-up issue\` (follow-up issue filed in-branch)
+
+## Follow-up
+
+- Deep Docker rewrite of operations/architecture/scripts-reference tracked in the newly-filed issue (see final commit for the number).
+
+## Test plan
+
+- [x] Full pytest suite green locally
+- [x] ruff clean
+- [x] Custom schedule cross-check (notifications.md ↔ ops/crontab) — all subcommands present
+- [x] Custom link-resolution check — every relative link in README + docs/setup/*.md resolves
+- [x] No 'sigoden/aichat' in tracked onboarding docs; historical plans unchanged
+- [ ] CI green after push
+
+## Closes
+
+- Closes #73
+- Closes #70 (sigoden→blob42 link fix rolled into this sweep)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 4: Capture the PR URL and verify CI.**
+
+The `gh pr create` output prints the PR URL. Check CI status:
+
+```bash
+gh pr view <NEW_PR_NUMBER> --json state,mergeable,statusCheckRollup
+```
+
+Expected: `state: OPEN`, `mergeable: MERGEABLE`, both `lint-and-test` and `docker-build-smoke` eventually `SUCCESS`.
+
+If any check fails, read the failure, fix the root cause, commit, and push. Do not use `--no-verify`.
+
+- [ ] **Step 5: Hand off to user for review.**
+
+Report the PR URL back to the user with a 1-2 line summary ("Spec/plan committed, 7 commits on the branch, CI green, ready for review").
+
+---
+
+## Documentation Impact
+
+Every deliverable in this plan *is* a documentation change. Breakdown:
+
+- **README.md** — Quick Start, Tech Stack, Documentation index, repo structure, two aichat-ng links (Tasks 1, 2).
+- **docs/setup/install-linux.md** — Step 2 aichat-ng install (Task 1).
+- **docs/setup/prerequisites.md** — aichat-ng install subsection + Docker-skip callout (Task 1).
+- **docs/setup/configure.md** — new "Path differences under Docker" section (Task 3).
+- **docs/setup/state-migration.md** — top-of-file banner (Task 3).
+- **docs/notifications.md** — schedule reconciliation + scoreboard entry + L117 wording (Task 3).
+- **docs/operations.md** — top-of-file banner (Tasks 4 and 7).
+- **docs/architecture.md** — top-of-file banner + triage midnight fix (Tasks 4 and 7).
+- **docs/scripts-reference.md** — top-of-file banner (Tasks 4 and 7).
+- **docs/superpowers/specs/2026-04-17-docker-compose-design.md** — "Decisions made during implementation" subsection appended (Task 5).
+- **data/.env.example** — one-line Docker-path comment (Task 6).
+- **candidate_context/profile.md.example** — reviewed, expected no edits (Task 6).
+- **docs/learnings.md** — reviewed, expected no edits (Task 6).
+- **CHANGELOG.md** — *intentionally unchanged*. The `[0.1.0] — TBD` entry already references that doc cleanup is part of #70 (which rolls into this PR via the aichat-ng fix). Writing-plans for #69 will move this entry from TBD to a dated release and may edit the Changed/Deprecated subsections to reflect the doc sweep as well.
+- **CLAUDE.md** — *intentionally unchanged*. The Container Context section added in PR #72 already describes the image's path layout.
+- **In-code docstrings** — none changed (no code edits in this PR).
+
+## Verification gate
+
+See Task 8, Step 1 — five concrete checks:
+
+1. No `sigoden/aichat` in tracked onboarding docs; historical docs unchanged.
+2. No `systemd user timers/services` framing as the recommended path in README or install-docker.md.
+3. `docs/notifications.md` Schedule Summary covers every scheduled `notify.py` subcommand in `ops/crontab` (Python cross-check).
+4. Every relative link in `README.md` and `docs/setup/*.md` resolves to an existing file (Python script).
+5. Full pytest suite and ruff checks green.
+
+Whole-feature acceptance: all seven boxes in the issue body mapped to implementing commits (Task 8 Step 2).
+
+## Self-review checklist
+
+Spec coverage — every spec section implemented by at least one task:
+
+| Spec section | Implementing task(s) |
+|---|---|
+| Goal / Non-goals | Entire plan respects the README + onboarding scope |
+| Design decisions 1–6 | Tasks 1, 2, 3, 4 |
+| In-scope: README.md | Task 2 |
+| In-scope: prerequisites.md | Task 1 |
+| In-scope: install-linux.md | Task 1 |
+| In-scope: configure.md | Task 3 |
+| In-scope: state-migration.md | Task 3 |
+| In-scope: notifications.md | Task 3 |
+| In-scope: docker-compose spec | Task 5 |
+| Banner-only | Tasks 4 + 7 |
+| Review-and-decide cluster | Task 6 |
+| Out-of-scope follow-up issue | Task 7 |
+| Acceptance-criteria map | Task 8 Step 2 |
+| Verification gate | Task 8 Step 1 |
+
+Placeholder scan — none (every step has concrete commands or exact replacement text).
+
+Type/contract consistency — file paths referenced consistently (`state/data/.env`, `state/config/`, `state/aichat_ng/`); banner wording unified across operations/architecture/scripts-reference.

--- a/docs/superpowers/specs/2026-04-17-docker-compose-design.md
+++ b/docs/superpowers/specs/2026-04-17-docker-compose-design.md
@@ -328,3 +328,33 @@ None at design time. All resolved during brainstorming 2026-04-17.
 8. Gmail: device flow only in v0.1.0; local callback flow in code but unused until v0.2.0's reverse-proxy routing
 9. Dockge-managed stacks under `/opt/stacks/findajob-<user>/`; per-stack bridge networks; Synology reverse proxy terminates TLS at `<user>.brockbot.com`
 10. TZ per tenant via stack `.env`, not a repo-wide default
+
+---
+
+## Decisions made during implementation
+
+Captured post-PR-#72 per `docs/plan-conventions.md`. These deltas do not
+invalidate the spec; they correct small details that shook out during build.
+
+1. **aichat-ng tarball layout.** The spec assumed the `blob42/aichat-ng` v0.31.0
+   release tarball wrapped the binary in `aichat-ng-${VERSION}-${ARCH}/`. The
+   tarball is actually flat (`tar -tzf` lists only `aichat-ng`). Dockerfile
+   extracts to `/tmp` and installs from there. Fixed in commit `e3b0e04`.
+
+2. **supercronic version probe.** supercronic v0.2.29 has no `-version` flag.
+   Build-time healthcheck replaced with `-test` against a no-op crontab, which
+   proves both binary executability and crontab-parsing capability. SHA1
+   verification is preserved. Fixed in commit `a4586bc`.
+
+3. **gmail_auth.py test count.** Spec called for 6 tests; shipped 8. The two
+   extra tests cover 0600 token-file mode enforcement and device-polling loop
+   coverage, added after in-PR code review flagged the gaps.
+
+4. **ops/crontab notify.py subcommand mismatches.** The shipped crontab used
+   three notify.py subcommand names (`stats`, `issues`, `feedback`) that the
+   dispatcher does not accept — the correct names are `daily-stats`,
+   `issues-ping`, `feedback-review`. Each invocation fired at its scheduled
+   time, printed the usage line, and exited 1 — silently disabling three
+   notifications on every Docker deploy. Fixed in PR #75 (issue #74) with a
+   pytest regression guard that AST-parses `notify.COMMANDS` and cross-checks
+   every `notify.py <subcmd>` invocation in `ops/crontab`.

--- a/docs/superpowers/specs/2026-04-17-v0.1.0-doc-audit-design.md
+++ b/docs/superpowers/specs/2026-04-17-v0.1.0-doc-audit-design.md
@@ -1,0 +1,132 @@
+# v0.1.0 Doc Audit — Design
+
+**Issue:** [#73](https://github.com/brockamer/findajob/issues/73)
+**Status:** Design (brainstormed 2026-04-17)
+
+## Goal
+
+Before tagging `v0.1.0` and letting external users (Amy via #20, plus dogfooders) pull the GHCR image, sweep the user-facing onboarding surface so a fresh reader isn't led down the retired systemd-native path. The containerized deploy is now the recommended path; the docs must reflect that without retiring the native fallback.
+
+Also: repair a set of latent install bugs in the native-install guides that clone `sigoden/aichat` (wrong fork) and rename the resulting binary to `aichat-ng`. This is the actual tool we're using — not `sigoden/aichat` under a different filename.
+
+## Non-goals
+
+- Full `install-docker.md` rewrite — owned by #69.
+- Full Docker rewrite of `operations.md`, `architecture.md`, `scripts-reference.md` — out of #73's "README + onboarding only" charter; filed as a follow-up issue.
+- Release process doc (`release-process.md`) — owned by #69.
+- `install-linux.md` retirement — stays as the native reference for advanced users.
+- Role prompts, candidate-facing examples beyond a sanity check, `GENERALIZATION.md`, `refactor_recommendations.md`, `claude-code.md`, `google-sheets.md`.
+
+## Design decisions (from brainstorming)
+
+1. **Docker is the recommended install, native is a fallback.** Quick Start leads with Docker. Docs table puts `install-docker.md` above `install-linux.md`; the latter is relabeled "native (fallback)".
+2. **README Quick Start is thin** (~8 lines): `curl` compose template + stack env, fill `.env`, `docker compose up -d`, point at `install-docker.md` for everything else. Native install demoted to a single link. The full walkthrough belongs in `install-docker.md` and is authored under #69.
+3. **aichat-ng comes from `blob42/aichat-ng` prebuilt tarball** for both Docker and native installs. The Dockerfile already does this; `install-linux.md` and `prerequisites.md` are converted to the same flow, removing the Rust toolchain from native prerequisites entirely.
+4. **Deep-dive docs get a one-line banner, not a rewrite.** `operations.md`, `architecture.md`, `scripts-reference.md` each get a short note at the top pointing Docker users at #69's forthcoming install guide and offering the `docker compose exec scheduler` escape hatch. Deep rewrite is filed as a follow-up.
+5. **Stale facts that surface during the sweep get fixed inline.** Specifically: `architecture.md:21` "triage.py (7:00 AM)" → midnight; `notifications.md` schedule table cross-checked against `ops/crontab`. Neither is Docker-specific but both are stale and would confuse a fresh reader.
+6. **Single PR, layered commits** grouped by file-cluster, so each commit reviews cleanly on its own. See the plan for the task breakdown.
+
+## In-scope changes by file
+
+### `README.md`
+
+| Line(s) | Current | Target |
+|---|---|---|
+| 5 | "Runs daily via systemd user timers." | "Deploys as a Docker container via Compose. Native systemd install is documented as a fallback." |
+| 23 | `aichat-ng` link → `github.com/sigoden/aichat` | → `github.com/blob42/aichat-ng` |
+| 31 | Scheduler = "systemd user timers" | "supercronic (Docker) / systemd (native)" |
+| 38 | `aichat-ng` link → `sigoden/aichat` | → `blob42/aichat-ng` |
+| 46–77 | 30-line native Quick Start | ~8-line Docker Quick Start + link to `install-docker.md`; native install is a single line at the end: "Native install: see `docs/setup/install-linux.md`." |
+| 83–94 | Docs table | Add `install-docker.md` above `install-linux.md`; relabel linux entry to "native (fallback)" |
+| 100–131 | Repo structure tree | Add `ops/` (compose + crontab + entrypoint) and `Dockerfile` line |
+
+### `docs/setup/prerequisites.md`
+
+- L96–109 — the "Installing aichat-ng" section currently clones `sigoden/aichat` and builds with cargo, copying the binary to `aichat-ng`. Replace with the `blob42/aichat-ng` prebuilt tarball install (same flow as the Dockerfile).
+- Add a "Docker users can skip this section — aichat-ng is baked into the image" callout at the top of the aichat-ng subsection.
+- Verify Python dependency list still matches `pyproject.toml`; no change expected.
+
+### `docs/setup/install-linux.md`
+
+- Replace Step 2 (L31–44, cargo build + `sigoden/aichat` clone) with the prebuilt tarball install. Remove the Rust toolchain step; native no longer needs Rust.
+- Keep the existing banner pointing at `install-docker.md` as the recommended path.
+
+### `docs/setup/configure.md`
+
+- Add a short "Path differences under Docker" callout noting `~/.config/aichat_ng/` → `state/aichat_ng/` and `data/.env` → `state/data/.env`. Light touch, ≤10 lines.
+- Pre-commit hook section unchanged (hook lives in `.git/hooks/`, works identically under both deploys).
+
+### `docs/setup/state-migration.md`
+
+- Add a banner at the top: "This guide covers native→native migration. For Docker, copy the `state/` directory between hosts and bring the stack up; see `install-docker.md`."
+- Otherwise unchanged — state-migration.md deep rewrite for Docker is not in scope.
+
+### `docs/notifications.md`
+
+- Cross-check the schedule table (L106–118) against `ops/crontab` (the canonical schedule for v0.1.0). Correct any mismatches inline.
+  - Known mismatches: `daily-stats` 7:05→06:15 per crontab; `health-check` 9:10→07:00; `apply-reminder` 5:00→06:00.
+- L117 — replace the systemd-only "Schedules are defined in systemd unit files…" sentence with: "Schedules are defined in `ops/crontab` (Docker) or `~/.config/systemd/user/findajob-notify-*.timer` (native)."
+- Verify the subcommand names in the table match `notify.py` (e.g., `daily-stats` vs `stats`). Reconcile to what `notify.py` actually accepts.
+
+### `docs/superpowers/specs/2026-04-17-docker-compose-design.md`
+
+Append a "Decisions made during implementation" section documenting every divergence between the original spec and what shipped in PR #72. Known items:
+
+1. **aichat-ng tarball extraction path is flat, not nested.** The blob42 release tarball unpacks `aichat-ng` directly (no `aichat-ng-${VERSION}-${ARCH}/` wrapper directory). Dockerfile fixed in commit `e3b0e04`.
+2. **supercronic has no `-version` flag.** v0.2.29 supports `-test`, `-debug`, `-json`, etc., but no version probe. Build-time healthcheck replaced with `-test` against a no-op crontab. Dockerfile fixed in commit `a4586bc`.
+3. Any further divergences I find on a re-read of the merged Dockerfile and entrypoint vs. the original spec get appended during implementation.
+
+## Banner-only changes (per Q1 design decision 4)
+
+Each of these gets the same short note at the top:
+
+> **Note (v0.1.0):** This document describes the native-install workflow. For Docker-deployed installs, prefix commands with `docker compose exec scheduler`. A Docker-specific rewrite of this document is tracked under a separate follow-up issue.
+
+Files: `docs/operations.md`, `docs/architecture.md`, `docs/scripts-reference.md`.
+
+Also inside `architecture.md`: fix the stale "triage.py (7:00 AM)" reference (L21) to match the actual midnight schedule in `ops/crontab`.
+
+## Review-and-decide cluster
+
+Files to read and decide in the implementing session whether the change is trivial-in-scope or defer-as-follow-up:
+
+| File | Expected outcome |
+|---|---|
+| `docs/learnings.md` | No edits — historical observations, not user-facing onboarding. Record the check in the commit message. |
+| `data/.env.example` | Add a one-line comment: "Under Docker, this file lives at `state/data/.env`." |
+| `candidate_context/profile.md.example` | Verify domain-neutral (per `CLAUDE.md` PII/generalization rules). No edits expected. |
+
+If any of the three requires more than a trivial edit, file a follow-up issue and reference it from the plan.
+
+## Out-of-scope / follow-ups to file
+
+- **Docker rewrite of operations + architecture + scripts-reference.** Single new issue, Medium priority, work stream Generalization.
+- (Anything else surfaced during implementation gets filed with the same pattern.)
+
+## Acceptance criteria → implementation map
+
+Traced from issue #73:
+
+| Acceptance criterion | Implementing change |
+|---|---|
+| README leads with Docker | README Quick Start rewrite + Docs table reordering |
+| Tech Stack table reflects scheduler + correct aichat-ng fork | README L23, L31, L38 edits |
+| Quick Start copy-pasteable against GHCR image | ~8-line Docker-first Quick Start |
+| Every link in README + docs/setup/*.md resolves | Verification gate: scripted link check |
+| learnings/notifications/configure/state-migration reviewed | Review-and-decide cluster + inline edits |
+| Spec backfill for `docker-compose-design.md` | "Decisions made during implementation" section |
+| No systemd as *recommended* path | README + install-linux.md + prerequisites.md banners and wording |
+
+## Verification gate
+
+Per `docs/plan-conventions.md`, distinct from per-task checks:
+
+1. `grep -r 'sigoden/aichat'` across tracked files — only historical plan docs and CHANGELOG entry may match.
+2. Every markdown link in `README.md` and `docs/setup/*.md` resolves (relative file exists, or HTTP 200 for external).
+3. No occurrence of "systemd user timers" or "systemd user services" in onboarding docs as the *recommended* path. Native fallback references are fine.
+4. `ops/crontab` schedule values match `docs/notifications.md` schedule table.
+5. Acceptance-criteria map above: every row ticked.
+
+## Documentation Impact
+
+This spec IS the documentation impact section for this work — the deliverable is entirely documentation. The plan's Documentation Impact section will restate these changes as numbered task-level outputs for reviewability.


### PR DESCRIPTION
## Summary

Pre-v0.1.0 sweep of user-facing entry-point docs. Leads README with Docker Compose as the recommended deploy, demotes native to a linked fallback, and repairs a latent functional bug where native install guides cloned sigoden/aichat and renamed the binary to aichat-ng. Reconciles docs/notifications.md schedule against ops/crontab; adds Docker-path callouts and banners to key setup and deep-dive docs; backfills decisions-made-during-implementation into the docker-compose spec.

**Spec:** `docs/superpowers/specs/2026-04-17-v0.1.0-doc-audit-design.md`
**Plan:** `docs/superpowers/plans/2026-04-18-v0.1.0-doc-audit.md`

## What's in this PR

Commits grouped by file cluster:

1. `docs: switch aichat-ng install to blob42 prebuilt tarball` — functional fix (native installs no longer install the wrong tool)
2. `docs: rewrite README Quick Start around Docker; demote native`
3. `docs: reconcile notifications.md schedule + Docker paths in setup`
4. `docs: add Docker-context banner to operations/architecture/scripts-reference`
5. `docs: backfill decisions-made-during-implementation in #13 spec`
6. `docs: note Docker path in .env.example; confirm learnings / profile clean`
7. `docs: link deep-rewrite banners to follow-up issue` — #76 filed in-branch

## Follow-ups

- #76 — Deep Docker rewrite of operations/architecture/scripts-reference (tracked, Medium/Generalization).
- `README.md` "Prerequisites" section (L35-42) still reads native-only. Noted by implementer during Task 2 self-review; out of plan scope, can be addressed in a small fix-up PR or rolled into the #76 rewrite.

## Test plan

- [x] Full pytest suite green locally
- [x] ruff clean on Python files
- [x] Custom schedule cross-check (notifications.md ↔ ops/crontab) — all subcommands present
- [x] Custom link-resolution check — every relative link in README + docs/setup/*.md resolves
- [x] No 'sigoden/aichat' in tracked onboarding docs; historical plans unchanged
- [ ] CI green after push

## Closes

- Closes #73
- Closes #70 (sigoden→blob42 link fix rolled into this sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
