### PR TITLE
Release management process + Docker install guide (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 
 ### Deprecated
 - systemd user services for the pipeline scheduler — replaced by supercronic
-  inside the container. Existing systemd units stay archived on Daniel's LXC
-  during the observation window. (#13)
+  inside the container. Existing systemd units stay archived on the maintainer's
+  LXC during the observation window. (#13)
 
 ### Notes
 - Release management process is documented in `docs/release-process.md` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+- `docs/release-process.md` — Claude-facing release orchestration runbook: 48h dogfood gate, CHANGELOG workflow, tag cut mechanics, post-tag verification, rollback (#69)
+- `docs/setup/install-docker.md` — full external-user Docker install + operations guide replacing the stub (#69)
+- `migration-required` GitHub label for PRs needing post-pull manual steps; auto-surfaced by `create-release.yml` in "Action required" section of release notes (#69)
+- `CLAUDE.md` "Release Management" subsection pointing future sessions at the runbook (#69)
+
 ## [0.1.0] — TBD
 
 First containerized release. Ships the pipeline as a Docker image pulled
@@ -39,8 +45,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
   during the observation window. (#13)
 
 ### Notes
-- Release management process itself is tracked in #69; once that ships, the
-  process doc lives at `docs/release-process.md`.
+- Release management process is documented in `docs/release-process.md` and
+  followed for this cut (#69).
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,7 +322,7 @@ A plan without Documentation Impact is incomplete — push back rather than exec
 
 ## Release Management
 
-Docker image releases follow [`docs/release-process.md`](docs/release-process.md). Claude owns orchestration (dogfood gate, CHANGELOG drafting, tag cut, post-tag verification, rollback); Daniel reviews and approves the proposed cut. The dogfood gate is a binary 48h window on `:latest` — six observable signals must all be clean before any `v*.*.*` tag is pushed. PRs containing schema/config/crontab/mount/compose-down changes get the `migration-required` label at PR-open time so that release notes surface them for external users.
+Docker image releases follow [`docs/release-process.md`](docs/release-process.md). Claude owns orchestration (dogfood gate, CHANGELOG drafting, tag cut, post-tag verification, rollback); the user reviews and approves the proposed cut. The dogfood gate is a binary 48h window on `:latest` — six observable signals must all be clean before any `v*.*.*` tag is pushed. PRs containing schema/config/crontab/mount/compose-down changes get the `migration-required` label at PR-open time so that release notes surface them for external users.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,10 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 <repo>/companies/_rejected/                  # rejected job folders (with marker files)
 <repo>/logs/pipeline.jsonl                  # structured event log
 
+# ── Operations ──────────────────────────────────────────────────────────────
+<repo>/docs/release-process.md              # Claude's release orchestration runbook — dogfood gate, tag cut, rollback
+<repo>/docs/setup/install-docker.md         # external-user Docker install + operations guide
+
 # ── Quality ─────────────────────────────────────────────────────────────────
 <repo>/pyproject.toml                       # deps, pytest, ruff, mypy config
 <repo>/tests/                               # 430 unit tests (pytest)
@@ -313,6 +317,12 @@ Implementation plans live in `docs/superpowers/plans/`. Conventions are document
 - A self-review checklist mapping every spec section to its implementing task(s)
 
 A plan without Documentation Impact is incomplete — push back rather than execute it.
+
+---
+
+## Release Management
+
+Docker image releases follow [`docs/release-process.md`](docs/release-process.md). Claude owns orchestration (dogfood gate, CHANGELOG drafting, tag cut, post-tag verification, rollback); Daniel reviews and approves the proposed cut. The dogfood gate is a binary 48h window on `:latest` — six observable signals must all be clean before any `v*.*.*` tag is pushed. PRs containing schema/config/crontab/mount/compose-down changes get the `migration-required` label at PR-open time so that release notes surface them for external users.
 
 ---
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -3,7 +3,7 @@
 This is the runbook Claude follows when cutting a release of the findajob pipeline's
 Docker image. Claude orchestrates the release end-to-end — proposing the cut, drafting
 the CHANGELOG, running the dogfood gate, writing notes, pushing the tag, verifying the
-outcome, and owning any rollback. Daniel reviews and approves the proposed cut but does
+outcome, and owning any rollback. The user reviews and approves the proposed cut but does
 not author any of the release artifacts. This split is codified in the
 `feedback_release_management.md` memory.
 
@@ -23,10 +23,9 @@ entries from the merged PRs in the range, running the full 48-hour dogfood gate,
 flagging migration markers on PRs as they come in (or retroactively if a trigger was
 missed), writing the release notes content, executing `git tag` and `git push origin
 vX.Y.Z`, running post-tag verification against GitHub Actions and GHCR, and owning
-rollback if anything goes wrong. Daniel's role is review-only: he looks at the
-proposed cut, confirms the dogfood signals, and approves or requests changes. He
-does not write CHANGELOG bullets, does not author the notes, and does not run the
-tag commands. If the release breaks something, Claude owns the recovery.
+rollback if anything goes wrong. The user's role is review-only: they look at the
+proposed cut, confirm the dogfood signals, and approve or request changes. They
+do not write CHANGELOG bullets, author the notes, or run the tag commands. If the release breaks something, Claude owns the recovery.
 
 ## Version scheme
 
@@ -49,7 +48,7 @@ The image tag taxonomy — which determines what a user pulling from GHCR actual
 
 | Tag | Type | Who pushes | Purpose |
 |---|---|---|---|
-| `:latest` | moving | `build-image.yml` on every `main` push | dogfood track — bleeding edge, what Daniel's LXC runs |
+| `:latest` | moving | `build-image.yml` on every `main` push | dogfood track — bleeding edge, what the maintainer's LXC runs |
 | `:main-<sha>` | immutable | `build-image.yml` on every `main` push | bisecting, precise pinning for diagnosis |
 | `:v0.1.0` | immutable | `build-image.yml` on `v*.*.*` tag push | pinned release, never moves |
 | `:v0.1` | moving | `build-image.yml` on `v*.*.*` tag push | auto-advances to the latest `v0.1.x` — the recommended user pin |
@@ -60,7 +59,7 @@ version when Claude explicitly cuts a new minor.
 
 ## Pre-release checklist
 
-Before proposing the cut, Claude runs through this list and reports results to Daniel.
+Before proposing the cut, Claude runs through this list and reports results to the user.
 
 First, confirm the CHANGELOG is ready. The `[Unreleased]` block at the top of
 `CHANGELOG.md` should have an entry for every PR that has merged since the last tag.
@@ -93,7 +92,7 @@ reference the new tag, the file is inconsistent — fix before cutting.
 ## Dogfood gate
 
 This is a hard binary gate. All six signals below must be clean across a continuous
-48-hour window on `:latest` running on Daniel's LXC at `findajob.lan`. If any signal
+48-hour window on `:latest` running on the maintainer's LXC at `findajob.lan`. If any signal
 fails at any point in the window, the clock restarts after the fix lands on `main`
 and `:latest` rebuilds. No averaging, no "mostly green" — the point is to catch
 regressions that only surface after multiple scheduler cycles.
@@ -124,7 +123,7 @@ ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs
 Expected: many `poll_flags` invocations, zero `Traceback` lines. Supercronic prints
 each job's exit code — every `poll_flags` exit should be `0`.
 
-**3. 07:00 UTC daily health-check notify fired on Daniel's phone.** The
+**3. 07:00 UTC daily health-check notify fired on the maintainer's phone.** The
 `notify.py health-check` line fires daily at 07:00 UTC. The phone confirmation is
 the authoritative check (the notification actually reached ntfy). As a secondary
 scheduler-side check:
@@ -135,7 +134,7 @@ ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs
 ```
 
 Expected: at least two `health-check` invocations with exit code 0 in the last 48h,
-and Daniel confirms the phone notification landed.
+and the maintainer confirms the phone notification landed.
 
 **4. Sheet syncs landed on two consecutive cycles.** Sheet1, Dashboard, and Applied
 tab writes are driven by `sync_sheet.py`. Two consecutive healthy cycles is enough
@@ -171,12 +170,12 @@ ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs
 Expected: `0`.
 
 If and only if all six signals pass across the continuous 48h window, the gate is
-cleared and Claude may propose the cut to Daniel.
+cleared and Claude may propose the cut to the user.
 
 ## migration-required label criteria
 
 Claude applies the `migration-required` label at PR-open time when the PR contains
-any of the triggers below. Daniel can challenge the call in review if it looks
+any of the triggers below. The user can challenge the call in review if it looks
 wrong. The label drives the "Action required before upgrade" section at the top of
 the release notes — mislabeling is low-stakes because the label is editable
 post-merge.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -130,11 +130,11 @@ the authoritative check (the notification actually reached ntfy). As a secondary
 scheduler-side check:
 
 ```bash
-ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 24h' \
+ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 48h' \
   | grep 'health-check'
 ```
 
-Expected: at least one `health-check` invocation with exit code 0 in the last 24h,
+Expected: at least two `health-check` invocations with exit code 0 in the last 48h,
 and Daniel confirms the phone notification landed.
 
 **4. Sheet syncs landed on two consecutive cycles.** Sheet1, Dashboard, and Applied
@@ -247,6 +247,8 @@ After the CHANGELOG commit is on `main` and `:latest` has rebuilt off of it, Cla
 cuts the tag. Set `VERSION` locally (e.g. `VERSION=0.1.0`) before running:
 
 ```bash
+VERSION=0.1.0
+MAJOR_MINOR="${VERSION%.*}"  # e.g., 0.1 — used in Section 9 Rollback
 cd /home/brockamer/Code/findajob
 git fetch origin
 git checkout main
@@ -315,8 +317,9 @@ the prior image on their next `docker compose pull`.
 2. Re-point the moving alias. This requires being logged in to GHCR with a PAT
    that has package-write scope:
 
+   **Prerequisite:** You must be logged into GHCR with a personal access token that has `write:packages` scope. If not already logged in, run `echo $GHCR_PAT | docker login ghcr.io -u brockamer --password-stdin` first.
+
    ```bash
-   # One-time: echo $GHCR_PAT | docker login ghcr.io -u brockamer --password-stdin
    docker pull ghcr.io/brockamer/findajob:v${VERSION_PREV}
    docker tag ghcr.io/brockamer/findajob:v${VERSION_PREV} ghcr.io/brockamer/findajob:v${MAJOR_MINOR}
    docker push ghcr.io/brockamer/findajob:v${MAJOR_MINOR}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,342 @@
+# Release Process
+
+This is the runbook Claude follows when cutting a release of the findajob pipeline's
+Docker image. Claude orchestrates the release end-to-end — proposing the cut, drafting
+the CHANGELOG, running the dogfood gate, writing notes, pushing the tag, verifying the
+outcome, and owning any rollback. Daniel reviews and approves the proposed cut but does
+not author any of the release artifacts. This split is codified in the
+`feedback_release_management.md` memory.
+
+Two GitHub Actions workflows do the mechanical work once a tag is pushed.
+[`.github/workflows/build-image.yml`](../.github/workflows/build-image.yml) builds the
+image and pushes the three tags (`:vX.Y.Z`, `:vX.Y`, `:latest`) to GHCR.
+[`.github/workflows/create-release.yml`](../.github/workflows/create-release.yml)
+generates the GitHub Release page, using GitHub's auto-generated notes and prepending
+an "Action required before upgrade" section that surfaces any PRs labeled
+`migration-required` in the range. Everything in this doc assumes those two workflows
+remain in place; if they change, update this doc in the same commit.
+
+## Ownership
+
+Claude drives every release. That means proposing when to cut, drafting the CHANGELOG
+entries from the merged PRs in the range, running the full 48-hour dogfood gate,
+flagging migration markers on PRs as they come in (or retroactively if a trigger was
+missed), writing the release notes content, executing `git tag` and `git push origin
+vX.Y.Z`, running post-tag verification against GitHub Actions and GHCR, and owning
+rollback if anything goes wrong. Daniel's role is review-only: he looks at the
+proposed cut, confirms the dogfood signals, and approves or requests changes. He
+does not write CHANGELOG bullets, does not author the notes, and does not run the
+tag commands. If the release breaks something, Claude owns the recovery.
+
+## Version scheme
+
+Until the pipeline hits `1.0`, all `0.x` releases are considered unstable and the
+regular semver guarantees do not apply. Within that window, the versioning discipline
+is still meaningful — it tells users whether they can pull blindly or whether they
+need to read the notes.
+
+A **minor bump** (`0.1.0` → `0.2.0`) signals a breaking change. Examples that qualify:
+a SQLite schema change that needs a migration, a removed config key that existing
+stacks still reference, a crontab semantic change (not a bugfix to a broken line, but
+a genuine shift in when a job fires or what it does), or any change that forces
+existing users to edit their bind mounts or `.env` before pulling the new image.
+
+A **patch bump** (`0.1.0` → `0.1.1`) is for bugfixes and non-breaking additions.
+A user pinned to `:v0.1` can pull and restart without reading anything.
+
+The image tag taxonomy — which determines what a user pulling from GHCR actually gets
+— is set by [`build-image.yml`](../.github/workflows/build-image.yml):
+
+| Tag | Type | Who pushes | Purpose |
+|---|---|---|---|
+| `:latest` | moving | `build-image.yml` on every `main` push | dogfood track — bleeding edge, what Daniel's LXC runs |
+| `:main-<sha>` | immutable | `build-image.yml` on every `main` push | bisecting, precise pinning for diagnosis |
+| `:v0.1.0` | immutable | `build-image.yml` on `v*.*.*` tag push | pinned release, never moves |
+| `:v0.1` | moving | `build-image.yml` on `v*.*.*` tag push | auto-advances to the latest `v0.1.x` — the recommended user pin |
+
+The recommended user pin is `:vMAJOR.MINOR` (e.g. `:v0.1`). It gets bugfixes
+automatically on `docker compose pull` and only moves to a potentially breaking
+version when Claude explicitly cuts a new minor.
+
+## Pre-release checklist
+
+Before proposing the cut, Claude runs through this list and reports results to Daniel.
+
+First, confirm the CHANGELOG is ready. The `[Unreleased]` block at the top of
+`CHANGELOG.md` should have an entry for every PR that has merged since the last tag.
+To enumerate merged PRs in the range:
+
+```bash
+gh pr list --state merged \
+  --search "merged:>$(git log -1 --format=%cI <last-tag>)" \
+  --json number,title
+```
+
+Cross-reference the output against the `[Unreleased]` block. Any PR in the list
+without a CHANGELOG entry should either get one (drafted now, committed as part of
+the release PR) or be deliberately omitted as internal-only — but that call is rare
+and should be justified.
+
+Second, walk each merged PR in the range and check the diff for triggers that warrant
+the `migration-required` label. The triggers are enumerated in the *migration-required
+label criteria* section below. Anything that forces a manual step on the user's side
+before `docker compose pull && up -d` needs the label. If a PR that merged without
+the label should have had it, apply it retroactively — the release notes generator
+queries labels at release time, so a late label still surfaces in the notes.
+
+Third, sanity-check the CHANGELOG's version cross-reference links at the bottom of
+the file. They should follow the existing pattern: `[Unreleased]` compares the latest
+tag against `HEAD`, and each released version links to its tag page. If the latest
+release added a new link and the previous `[Unreleased]` line wasn't updated to
+reference the new tag, the file is inconsistent — fix before cutting.
+
+## Dogfood gate
+
+This is a hard binary gate. All six signals below must be clean across a continuous
+48-hour window on `:latest` running on Daniel's LXC at `findajob.lan`. If any signal
+fails at any point in the window, the clock restarts after the fix lands on `main`
+and `:latest` rebuilds. No averaging, no "mostly green" — the point is to catch
+regressions that only surface after multiple scheduler cycles.
+
+The checks target the supercronic scheduler container running from
+`/opt/stacks/findajob-brock/compose.yaml`. The service is named `scheduler`.
+
+**1. At least two full triage runs completed.** Triage runs once daily at 00:00 PT,
+which is 07:00 UTC in PDT or 08:00 UTC in PST. Across a 48h window there should be
+at least two completions.
+
+```bash
+ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 48h' \
+  | grep pipeline_complete
+```
+
+Expected: at least 2 `pipeline_complete` events.
+
+**2. poll_flags cycles firing every 10 min without exception rows.** `poll_flags.py`
+runs on a `*/10` supercronic line, so a 2h sample is enough to confirm it's healthy
+right now — but the 48h gate above catches intermittent failures.
+
+```bash
+ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 2h' \
+  | grep -E 'poll_flags|Traceback'
+```
+
+Expected: many `poll_flags` invocations, zero `Traceback` lines. Supercronic prints
+each job's exit code — every `poll_flags` exit should be `0`.
+
+**3. 07:00 UTC daily health-check notify fired on Daniel's phone.** The
+`notify.py health-check` line fires daily at 07:00 UTC. The phone confirmation is
+the authoritative check (the notification actually reached ntfy). As a secondary
+scheduler-side check:
+
+```bash
+ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 24h' \
+  | grep 'health-check'
+```
+
+Expected: at least one `health-check` invocation with exit code 0 in the last 24h,
+and Daniel confirms the phone notification landed.
+
+**4. Sheet syncs landed on two consecutive cycles.** Sheet1, Dashboard, and Applied
+tab writes are driven by `sync_sheet.py`. Two consecutive healthy cycles is enough
+to establish the Google Sheets path is working.
+
+```bash
+ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 2h' \
+  | grep sync_sheet
+```
+
+Expected: at least two `sync_sheet` invocations, zero non-zero exit codes in that
+window.
+
+**5. form-ingest runs clean.** `ingest_form.py` runs every 30 min; in a 24h window
+there should be roughly 48 invocations.
+
+```bash
+ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 24h' \
+  | grep -E 'ingest_form|Traceback'
+```
+
+Expected: many `ingest_form` invocations (every 30 min), zero tracebacks.
+
+**6. No stack traces in scheduler logs across the 48h window.** This is the
+belt-and-suspenders check — if any of the per-job checks above missed something,
+a `Traceback` count will catch it.
+
+```bash
+ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 48h' \
+  | grep -c Traceback
+```
+
+Expected: `0`.
+
+If and only if all six signals pass across the continuous 48h window, the gate is
+cleared and Claude may propose the cut to Daniel.
+
+## migration-required label criteria
+
+Claude applies the `migration-required` label at PR-open time when the PR contains
+any of the triggers below. Daniel can challenge the call in review if it looks
+wrong. The label drives the "Action required before upgrade" section at the top of
+the release notes — mislabeling is low-stakes because the label is editable
+post-merge.
+
+Triggers:
+
+- **SQLite schema changes** — new tables, new columns, new indexes on existing
+  tables, type changes, or dropped columns. Anything that changes the shape of
+  `data/pipeline.db`.
+- **New required env keys.** A new key in `state/data/.env` that the pipeline
+  depends on. Optional overrides and new feature toggles that default off are
+  *not* triggers — they ship without forcing user action.
+- **Moves or renames of files in `state/config/`** that break existing stacks.
+  If a user's current config layout won't work after pulling the new image,
+  label it.
+- **Crontab schedule changes.** A genuine shift in when a timer fires or what
+  it runs — not a bugfix to a broken cronline. #75 (fixing three broken
+  `notify.py` subcommands) was a correction, not a schedule change. Moving
+  triage from 00:00 to 03:00, or adding a new scheduled job, *is* a change.
+- **Bind-mount layout changes in `ops/compose.yaml.example`.** If the user's
+  existing compose file needs editing before pulling, label it.
+- **Changes that require `docker compose down` before `pull && up -d`.**
+  Network config changes, removing and re-adding a service, or anything else
+  where a rolling pull-and-restart won't cut it.
+
+If unsure, don't apply the label. Re-labeling post-merge works — the release
+notes generator picks up the label whenever it's set, so a late add still
+surfaces in the "Action required before upgrade" section.
+
+## CHANGELOG workflow
+
+When cutting `vX.Y.Z`, the CHANGELOG moves from the `[Unreleased]` scratch pad to
+a named version block. The format follows Keep-a-Changelog and matches the current
+state of `CHANGELOG.md` — don't diverge from the existing convention.
+
+The steps, in order:
+
+1. Under `## [Unreleased]`, Claude drafts the entries into their destination block,
+   grouping by Keep-a-Changelog category (`Added`, `Changed`, `Deprecated`,
+   `Removed`, `Fixed`, `Security`). Every entry references its PR with `(#NNN)`.
+   If the PR introduced a migration trigger, the entry mentions that in plain
+   prose — the label surfacing is separate from the prose and both are valuable.
+
+2. Replace the `## [Unreleased]` header with `## [X.Y.Z] — YYYY-MM-DD`. The date
+   is ISO 8601 in Pacific Time. Convert from server UTC by subtracting 7 hours
+   in PDT or 8 hours in PST, per the `feedback_pt_user_calendar.md` convention.
+
+3. Insert a fresh empty `## [Unreleased]` block at the top of the file, above
+   the newly-named version. Future changes land there.
+
+4. At the bottom of the file, add the version cross-reference link:
+   `[X.Y.Z]: https://github.com/brockamer/findajob/releases/tag/vX.Y.Z`. Update
+   the existing `[Unreleased]` line to point at the new tag:
+   `[Unreleased]: https://github.com/brockamer/findajob/compare/vX.Y.Z...HEAD`.
+
+5. Commit with `docs: move [Unreleased] → [X.Y.Z] in CHANGELOG (#69 process)`.
+   Open this as a PR — it should not land directly on main.
+
+6. Wait for the PR to merge, then wait for `:latest` to finish rebuilding off the
+   CHANGELOG commit before moving on to the tag cut. This ordering matters: the
+   tag is applied to the commit whose CHANGELOG *describes itself*, so the
+   image identified by `:vX.Y.Z` literally *is* the code the release notes
+   describe.
+
+## Tag cut mechanics
+
+After the CHANGELOG commit is on `main` and `:latest` has rebuilt off of it, Claude
+cuts the tag. Set `VERSION` locally (e.g. `VERSION=0.1.0`) before running:
+
+```bash
+cd /home/brockamer/Code/findajob
+git fetch origin
+git checkout main
+git pull
+# Sanity-check that CHANGELOG.md is current:
+grep -c "## \[${VERSION}\]" CHANGELOG.md   # Expected: 1
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+```
+
+That single push triggers both workflows: `build-image.yml` pushes the three tags
+(`:v${VERSION}`, `:v${MAJOR_MINOR}`, `:latest`) to GHCR, and `create-release.yml`
+generates the GitHub Release page with auto-generated notes, prepending the
+"Action required before upgrade" section if any merged PRs in the range carry the
+`migration-required` label.
+
+## Post-tag verification
+
+Within roughly ten minutes of the tag push, Claude verifies the release landed
+cleanly.
+
+1. Open the GitHub Release page at
+   `https://github.com/brockamer/findajob/releases/tag/v${VERSION}`. The title
+   should be `v${VERSION}`. If any PRs in the range were labeled
+   `migration-required`, the "⚠️ Action required before upgrade" section must
+   appear at the top with those PRs listed. If the section is missing and should
+   be there, the label was applied after the workflow ran — re-run
+   `create-release.yml` manually.
+
+2. Confirm the release workflow succeeded:
+
+   ```bash
+   gh run list --workflow=create-release.yml --limit 1
+   ```
+
+   Status `completed`, conclusion `success`.
+
+3. Confirm the image build workflow succeeded:
+
+   ```bash
+   gh run list --workflow=build-image.yml --limit 1
+   ```
+
+   Status `completed`, conclusion `success`.
+
+4. Verify the image is pullable from the LXC:
+
+   ```bash
+   ssh findajob.lan "docker pull ghcr.io/brockamer/findajob:v${VERSION}"
+   ```
+
+   Expected: clean pull, no 401 (auth) or 404 (tag missing).
+
+If any of steps 1–4 fail, either re-run the failing workflow job from the GitHub
+Actions UI or move to the rollback procedure in the next section.
+
+## Rollback
+
+If post-tag verification fails or a regression is reported after the release is
+out in the wild, Claude rolls back by re-pointing the moving `:vMAJOR.MINOR`
+alias back to the prior immutable tag. Users pinned to `:v0.1` will then pull
+the prior image on their next `docker compose pull`.
+
+1. Identify the last-known-good immutable tag, e.g. `v${VERSION_PREV}`.
+
+2. Re-point the moving alias. This requires being logged in to GHCR with a PAT
+   that has package-write scope:
+
+   ```bash
+   # One-time: echo $GHCR_PAT | docker login ghcr.io -u brockamer --password-stdin
+   docker pull ghcr.io/brockamer/findajob:v${VERSION_PREV}
+   docker tag ghcr.io/brockamer/findajob:v${VERSION_PREV} ghcr.io/brockamer/findajob:v${MAJOR_MINOR}
+   docker push ghcr.io/brockamer/findajob:v${MAJOR_MINOR}
+   ```
+
+3. The immutable `:v${VERSION}` tag for the bad release stays pinned. Anyone who
+   specifically pinned to it keeps the broken image — that's intentional, because
+   the immutable tag is the audit trail. If a user is on that tag and reports a
+   bug, Claude can reproduce exactly what they're running.
+
+4. Document the rollback in `CHANGELOG.md` by adding a `## [Reverted] — YYYY-MM-DD`
+   block near the top of the file (above `[Unreleased]`, below any intervening
+   entries) naming the bad tag and stating the reason in a sentence or two.
+
+5. Notify external users (Amy and any future beta testers) via whatever channel
+   is active at the time.
+
+**First-release note (v0.1.0 specifically).** There is no prior tag to roll back
+to. If `v0.1.0` ships broken, the only path is "stop recommending the release,
+fix forward on `main`, cut `v0.1.1` as soon as the dogfood gate clears again."
+Do not attempt to revive an older `:latest` by ad-hoc re-tagging — the immutable
+`:main-<sha>` tags on every `main` push are the audit trail, and rewriting
+`:latest` breaks that.

--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -1,6 +1,6 @@
-# Docker Install (stub)
+# Docker Install
 
-> **Full deploy guide is being authored under #69.** This page documents just enough to stand up a stack today. When #69 ships, `docs/release-process.md` and a complete install walkthrough land here.
+This is the install + operations guide for external users running findajob from the prebuilt `ghcr.io/brockamer/findajob` image via Docker Compose. Claude's release orchestration runbook lives separately at [`docs/release-process.md`](../release-process.md).
 
 ## Who this is for
 
@@ -68,14 +68,55 @@ docker compose exec scheduler python3 /app/scripts/notify.py health-check
 # Sanity check: ntfy notification should land on your phone.
 ```
 
+## Tag pinning strategy
+
+`FINDAJOB_IMAGE_TAG` in your `.env` controls which image Docker Compose pulls. Pick based on how much change tolerance you want.
+
+| Value | Mutability | Recommended for |
+|---|---|---|
+| `v0.1` | moving (auto-advances to latest `v0.1.x` patch) | **Default.** Most users. Auto-accepts bugfixes; breaking changes require an explicit `.env` edit. |
+| `v0.1.0` | immutable | Pin exactly when you need a known-good version and can't afford surprises (e.g., during an active job-hunt push). |
+| `latest` | moving (tip of `main`) | Dogfood track. Daniel runs this on his LXC to exercise releases before tagging. May break. |
+| `main-<sha>` | immutable (one tag per commit on `main`) | Precise pinning or bisecting when diagnosing a regression. |
+
+Switching between tags is a one-line `.env` edit followed by `docker compose pull && docker compose up -d`.
+
 ## Updating
 
-```bash
-docker compose pull && docker compose up -d
-```
+Before running `docker compose pull && docker compose up -d`:
 
-Or click **Pull** + **Deploy** in Dockge.
+1. Check the [latest GitHub Release](https://github.com/brockamer/findajob/releases/latest) for an "⚠️ Action required before upgrade" section at the top of the notes.
+2. If the section is present, follow each linked PR's migration notes before pulling.
+3. If the section is absent, a straight pull-and-up is safe:
+   ```bash
+   cd /opt/stacks/findajob-<you>/
+   docker compose pull
+   docker compose up -d
+   ```
+   Or click **Pull** + **Deploy** in Dockge.
+
+The "Action required" section is driven by PRs labeled `migration-required` (see [`docs/release-process.md`](../release-process.md) for the criteria). If a release has no such PRs in its range, the section won't appear.
+
+## Rolling back locally
+
+If a pull broke your stack and you need to get back to a working state immediately:
+
+1. Edit `.env` to pin to a prior immutable tag, e.g.,
+   ```
+   FINDAJOB_IMAGE_TAG=v0.1.0
+   ```
+2. Re-deploy:
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+3. Report the regression via a GitHub issue so the shared `:v0.1` alias can be rolled back globally (Daniel's call — see [release-process.md Rollback section](../release-process.md#rollback)).
+
+A local rollback via `.env` pin doesn't affect other users on `:v0.1`.
 
 ## Troubleshooting
 
-See GitHub issues or open a new one at https://github.com/brockamer/findajob/issues.
+- Container fails to start: `docker compose logs scheduler` usually points at the issue.
+- Supercronic prints "schedule invalid": a crontab syntax error. Check `ops/crontab` for recent changes.
+- Gmail ingestion silently disabled: re-run `docker compose --profile setup run --rm gmail-auth` to refresh the token.
+- For anything else, open an issue at https://github.com/brockamer/findajob/issues.

--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -76,7 +76,7 @@ docker compose exec scheduler python3 /app/scripts/notify.py health-check
 |---|---|---|
 | `v0.1` | moving (auto-advances to latest `v0.1.x` patch) | **Default.** Most users. Auto-accepts bugfixes; breaking changes require an explicit `.env` edit. |
 | `v0.1.0` | immutable | Pin exactly when you need a known-good version and can't afford surprises (e.g., during an active job-hunt push). |
-| `latest` | moving (tip of `main`) | Dogfood track. Daniel runs this on his LXC to exercise releases before tagging. May break. |
+| `latest` | moving (tip of `main`) | Dogfood track. The upstream maintainer runs this to exercise releases before tagging. May break. |
 | `main-<sha>` | immutable (one tag per commit on `main`) | Precise pinning or bisecting when diagnosing a regression. |
 
 Switching between tags is a one-line `.env` edit followed by `docker compose pull && docker compose up -d`.
@@ -110,7 +110,7 @@ If a pull broke your stack and you need to get back to a working state immediate
    docker compose pull
    docker compose up -d
    ```
-3. Report the regression via a GitHub issue so the shared `:v0.1` alias can be rolled back globally (Daniel's call — see [release-process.md Rollback section](../release-process.md#rollback)).
+3. Report the regression via a GitHub issue so the shared `:v0.1` alias can be rolled back globally (the upstream maintainer's call — see [release-process.md Rollback section](../release-process.md#rollback)).
 
 A local rollback via `.env` pin doesn't affect other users on `:v0.1`.
 

--- a/docs/superpowers/plans/2026-04-18-release-management.md
+++ b/docs/superpowers/plans/2026-04-18-release-management.md
@@ -42,21 +42,21 @@ Expected output: empty (no existing label).
 
 - [ ] **Step 2: Create the label**
 
-Run:
+Run (note: GitHub enforces a 100-char max on label descriptions — the original spec phrasing is shortened):
 ```bash
 gh label create migration-required \
   --repo brockamer/findajob \
   --color BF5700 \
-  --description "Changes require a manual step (schema, config, crontab, mount layout, docker compose down) before pulling"
+  --description "Manual step required (schema/config/crontab/mount/compose-down) before docker compose pull"
 ```
-Expected output: `https://github.com/brockamer/findajob/labels/migration-required`
+Expected: no error output on success.
 
 - [ ] **Step 3: Verify the label**
 
-Run: `gh label list --repo brockamer/findajob --search migration-required --json name,color,description`
-Expected output:
-```json
-[{"color":"BF5700","description":"Changes require a manual step (schema, config, crontab, mount layout, docker compose down) before pulling","name":"migration-required"}]
+Run: `gh label list --repo brockamer/findajob | grep migration-required`
+Expected output (tab-separated):
+```
+migration-required	Manual step required (schema/config/crontab/mount/compose-down) before docker compose pull	#BF5700
 ```
 
 - [ ] **Step 4: No commit** — label creation is a GitHub side effect. Note in the PR description that Task 1 ran successfully.

--- a/docs/superpowers/plans/2026-04-18-release-management.md
+++ b/docs/superpowers/plans/2026-04-18-release-management.md
@@ -1,0 +1,777 @@
+# Release Management Implementation Plan (#69)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the release-management process documentation (`docs/release-process.md`), the external-user Docker install guide (rewrite of `docs/setup/install-docker.md`), the `migration-required` GitHub label, and supporting updates to `CLAUDE.md` and `CHANGELOG.md` — so that the first real release (`v0.1.0` from #13) can be cut post-merge using a written runbook.
+
+**Architecture:** Docs-only PR. Automation already exists in `.github/workflows/create-release.yml` (auto-generated notes + `migration-required` surfacing) and `.github/workflows/build-image.yml` (tag pushing). This plan fills the process + documentation layer on top.
+
+**Tech Stack:** Markdown, `gh` CLI (for label creation), git.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-release-management-design.md`
+
+**Branch:** `feat/69-release-management` (already created off `origin/main`, spec doc already committed as `714741f`)
+
+---
+
+## File Structure
+
+New / modified files, each with a single clear responsibility:
+
+| File | Responsibility |
+|---|---|
+| `docs/release-process.md` (**new**) | Claude's release orchestration runbook — dogfood gate, tag mechanics, verification, rollback. 9 sections. |
+| `docs/setup/install-docker.md` (**rewrite**) | External-user Docker install + operations guide. Replaces current "(stub)" version. |
+| `CLAUDE.md` (**modify**) | Add release-process.md to "Key File Locations"; add "Release Management" subsection before "Working Style". |
+| `CHANGELOG.md` (**modify**) | Add `Added` entries under `[Unreleased]` for #69; update Notes line in `[0.1.0] — TBD` block. |
+| `migration-required` label (**create on GitHub**) | One-shot side effect via `gh label create`. Documented in release-process.md §5. |
+
+Two-file split of the meat: the **Claude-facing runbook** (`release-process.md`) and the **user-facing operations guide** (`install-docker.md`). They cross-reference each other but serve different audiences — separation prevents one file from trying to do both jobs.
+
+---
+
+## Task 1: Create `migration-required` GitHub label
+
+**Files:**
+- Side effect only — creates a GitHub label on the `brockamer/findajob` repo. No file changes in this task.
+
+- [ ] **Step 1: Check label doesn't already exist**
+
+Run: `gh label list --repo brockamer/findajob --search migration-required`
+Expected output: empty (no existing label).
+
+- [ ] **Step 2: Create the label**
+
+Run:
+```bash
+gh label create migration-required \
+  --repo brockamer/findajob \
+  --color BF5700 \
+  --description "Changes require a manual step (schema, config, crontab, mount layout, docker compose down) before pulling"
+```
+Expected output: `https://github.com/brockamer/findajob/labels/migration-required`
+
+- [ ] **Step 3: Verify the label**
+
+Run: `gh label list --repo brockamer/findajob --search migration-required --json name,color,description`
+Expected output:
+```json
+[{"color":"BF5700","description":"Changes require a manual step (schema, config, crontab, mount layout, docker compose down) before pulling","name":"migration-required"}]
+```
+
+- [ ] **Step 4: No commit** — label creation is a GitHub side effect. Note in the PR description that Task 1 ran successfully.
+
+---
+
+## Task 2: Author `docs/release-process.md`
+
+**Files:**
+- Create: `/home/brockamer/Code/findajob/docs/release-process.md`
+
+- [ ] **Step 1: Write the full runbook**
+
+Create `docs/release-process.md` with the 9-section structure below. Write fluent prose; do not include section numbering in headers (use the literal titles, not "§4 Dogfood gate").
+
+**Preamble** (3-5 sentences before the first heading):
+
+- What this doc is: the runbook Claude follows when cutting a release of the findajob pipeline's Docker image.
+- Who executes it: Claude orchestrates, Daniel reviews and approves the cut (reference `feedback_release_management.md` memory).
+- What automation handles: link out to `.github/workflows/create-release.yml` and `.github/workflows/build-image.yml` for the CI side.
+
+**Section 1: Ownership**
+
+One paragraph codifying the split:
+- Claude: proposes the cut, drafts CHANGELOG entries, runs the dogfood gate, flags migration markers, writes release notes, executes the tag push, runs post-tag verification, owns rollback.
+- Daniel: reviews the proposed cut, approves or requests changes. No authoring required.
+
+**Section 2: Version scheme**
+
+Until 1.0 (pipeline stabilizes), all 0.x releases are unstable. Discipline:
+- **Breaking change** → minor bump (0.1.0 → 0.2.0). Examples: schema change requiring DB migration; removed config key; crontab semantics changed.
+- **Bugfix / non-breaking addition** → patch bump (0.1.0 → 0.1.1).
+
+Tag taxonomy, explicitly mapped to `build-image.yml`'s push logic:
+
+| Tag | Type | Who pushes | Purpose |
+|---|---|---|---|
+| `:latest` | moving | `build-image.yml` on every `main` push | dogfood track |
+| `:main-<sha>` | immutable | `build-image.yml` on every `main` push | bisecting / precise pinning |
+| `:v0.1.0` | immutable | `build-image.yml` on `v*.*.*` tag | pinned release |
+| `:v0.1` | moving | `build-image.yml` on `v*.*.*` tag (auto-advances to latest v0.1.x) | recommended user pin |
+
+**Section 3: Pre-release checklist**
+
+Checklist Claude completes before proposing a cut:
+- `CHANGELOG.md` `[Unreleased]` block contains entries for every merged PR since the last tag. Verify with `gh pr list --state merged --search "merged:>$(git log -1 --format=%cI <last-tag>)" --json number,title`.
+- For each merged PR in that range: check the diff for schema changes, new required env keys, config file moves/renames, crontab schedule changes, bind-mount layout changes, or `docker compose down`-requiring changes. If any found, the `migration-required` label should be applied (see Section 5 criteria). Apply retroactively if missed; the release notes auto-surface labeled PRs regardless of when the label was set.
+- Verify `CHANGELOG.md`'s version cross-reference links at the bottom are intact and consistent.
+
+**Section 4: Dogfood gate (48h)**
+
+Binary gate. All six signals must be clean across a continuous 48h window on `:latest` running on Daniel's LXC. If any signal fails, restart the clock after the fix lands on `main` and `:latest` rebuilds.
+
+For each signal, show the command + expected result:
+
+1. **At least two full triage runs completed.** Triage runs once daily at 00:00 PT (07:00 UTC in PDT / 08:00 UTC in PST).
+   ```bash
+   ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 48h' | grep pipeline_complete
+   ```
+   Expected: at least 2 `pipeline_complete` events.
+
+2. **poll_flags cycles firing every 10 min without exception rows.**
+   ```bash
+   ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 2h' | grep -E 'poll_flags|Traceback'
+   ```
+   Expected: many `poll_flags` invocations, zero `Traceback` lines. Supercronic prints each job's exit code — all poll_flags exits should be 0.
+
+3. **07:00 UTC daily health-check notify fired on Daniel's phone.**
+   Manual: confirm via phone. Or check:
+   ```bash
+   ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 24h' | grep 'health-check'
+   ```
+   Expected: at least one health-check invocation with exit code 0 in the last 24h.
+
+4. **Sheet1 + Dashboard + Applied tab syncs landed on two consecutive cycles.**
+   ```bash
+   ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 2h' | grep sync_sheet
+   ```
+   Expected: at least two `sync_sheet` invocations, zero non-zero exit codes.
+
+5. **form-ingest runs clean.**
+   ```bash
+   ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 24h' | grep -E 'ingest_form|Traceback'
+   ```
+   Expected: many `ingest_form` invocations (every 30 min), zero tracebacks.
+
+6. **No stack traces in scheduler logs across the 48h window.**
+   ```bash
+   ssh findajob.lan 'docker compose -f /opt/stacks/findajob-brock/compose.yaml logs scheduler --since 48h' | grep -c Traceback
+   ```
+   Expected: `0`.
+
+If all six signals pass across the continuous 48h window, the gate is cleared and Claude may propose the cut.
+
+**Section 5: `migration-required` label criteria**
+
+Claude applies this label at PR-open time when the PR contains any of the following. Daniel can challenge in review if a label was applied incorrectly.
+
+Triggers (from the spec's Q2-B list):
+- SQLite schema changes (new tables, new columns, new indexes on existing tables, type changes, dropped columns).
+- New *required* `state/data/.env` keys — not optional overrides, not new feature toggles that default to off.
+- Moves/renames of files in `state/config/` that break existing stacks.
+- Crontab schedule changes that shift when a timer fires (a bugfix to a broken cronline like #75 is NOT a schedule change — it's a correction).
+- Changes to bind-mount layout in `ops/compose.yaml.example`.
+- Changes that require `docker compose down` before `docker compose pull && up -d` (e.g., network config change, removing a service and adding it back).
+
+If unsure: don't apply. Re-labeling post-merge works — the release notes generator picks up the label whenever it's set.
+
+**Section 6: CHANGELOG workflow**
+
+When cutting `v0.x.y`:
+
+1. Under `## [Unreleased]`, Claude drafts the moved entries to their destination block. Group by Keep-a-Changelog categories (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Reference PRs with `(#NNN)`.
+2. Replace the `## [Unreleased]` header with `## [x.y.z] — YYYY-MM-DD`. Date is ISO 8601, PT (convert server UTC to PT per `feedback_pt_user_calendar.md` — `-7h` PDT, `-8h` PST).
+3. Insert a fresh empty `## [Unreleased]` block at the top of the file.
+4. At the bottom, add the version cross-reference link: `[x.y.z]: https://github.com/brockamer/findajob/releases/tag/vx.y.z`. Update the existing `[Unreleased]` line to `[Unreleased]: https://github.com/brockamer/findajob/compare/vx.y.z...HEAD`.
+5. Commit with message `docs: move [Unreleased] → [x.y.z] in CHANGELOG (#69 process)`.
+6. Wait for the PR to merge, then for `:latest` to rebuild off the CHANGELOG commit before tagging — this ensures the tagged image *is* the code described in the notes.
+
+**Section 7: Tag cut mechanics**
+
+After the CHANGELOG commit is on `main` and `:latest` has rebuilt:
+
+```bash
+cd /home/brockamer/Code/findajob
+git fetch origin
+git checkout main
+git pull
+# Sanity-check that CHANGELOG.md is current:
+grep -c "## \[${VERSION}\]" CHANGELOG.md   # Expected: 1
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+```
+
+This triggers `build-image.yml` (pushes `:v${VERSION}`, `:v${MAJOR_MINOR}`, `:latest`) and `create-release.yml` (creates the GitHub Release).
+
+**Section 8: Post-tag verification**
+
+Within ~10 minutes of the tag push:
+
+1. Check the GitHub Release page at `https://github.com/brockamer/findajob/releases/tag/v${VERSION}`. Title is `v${VERSION}`. If any PRs in the range were labeled `migration-required`, the "⚠️ Action required before upgrade" section appears at the top.
+2. `gh run list --workflow=create-release.yml --limit 1` — status `completed`, conclusion `success`.
+3. `gh run list --workflow=build-image.yml --limit 1` — status `completed`, conclusion `success`.
+4. Verify the image is pullable from the LXC:
+   ```bash
+   ssh findajob.lan "docker pull ghcr.io/brockamer/findajob:v${VERSION}"
+   ```
+   Expected: clean pull, no 401/404.
+
+If any of 1-4 fail, see Section 9 (Rollback) or re-run failing workflow jobs manually.
+
+**Section 9: Rollback**
+
+If post-tag verification fails OR a regression is reported post-release:
+
+1. Identify the last-known-good immutable tag, e.g., `v${VERSION_PREV}`.
+2. Rollback via moving-alias re-point (users pinned to `:v${MAJOR_MINOR}` get the prior image on next `docker compose pull`):
+   ```bash
+   # Must have docker login to ghcr.io first: echo $GHCR_PAT | docker login ghcr.io -u brockamer --password-stdin
+   docker pull ghcr.io/brockamer/findajob:v${VERSION_PREV}
+   docker tag ghcr.io/brockamer/findajob:v${VERSION_PREV} ghcr.io/brockamer/findajob:v${MAJOR_MINOR}
+   docker push ghcr.io/brockamer/findajob:v${MAJOR_MINOR}
+   ```
+3. The immutable `:v${VERSION}` (bad) tag stays pinned — users who specifically pinned to it can be diagnosed.
+4. Document in `CHANGELOG.md` by adding a `## [Reverted] — YYYY-MM-DD` block near the top (above `[Unreleased]`, below any intervening entries) naming the bad tag and the reason.
+5. Notify external users (Amy, etc.) via whatever channel is active.
+
+**First-release note (for v0.1.0 specifically):**
+There is no prior tag to roll back to. If `v0.1.0` ships broken, the only recovery is "stop publishing; fix forward on main; cut v0.1.1 as soon as the dogfood gate clears." Don't attempt to revive an older `:latest` by ad-hoc re-tagging — the immutable `:main-<sha>` tags are the audit trail.
+
+- [ ] **Step 2: Verify the file renders and covers all 9 sections**
+
+Run:
+```bash
+grep -cE '^## ' docs/release-process.md
+```
+Expected: `9` (or `10` including a preamble-level H2 if the author chose to add one — acceptable as long as all 9 required sections exist).
+
+Run:
+```bash
+for section in "Ownership" "Version scheme" "Pre-release checklist" "Dogfood gate" "migration-required" "CHANGELOG workflow" "Tag cut mechanics" "Post-tag verification" "Rollback"; do
+  grep -c "$section" docs/release-process.md && echo "  ✓ $section" || echo "  ✗ $section MISSING"
+done
+```
+Expected: each section name appears at least once.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/release-process.md
+git commit -m "$(cat <<'EOF'
+docs: add release-process.md runbook (#69)
+
+Codifies the 48h dogfood gate (6 observable signals), the
+migration-required label criteria (schema/config/crontab/mount/compose-down
+triggers), the CHANGELOG [Unreleased]→[x.y.z] workflow, tag cut mechanics,
+post-tag verification, and rollback procedure.
+
+Claude owns release orchestration per feedback_release_management.md
+memory; Daniel reviews and approves the cut.
+EOF
+)"
+```
+
+---
+
+## Task 3: Rewrite `docs/setup/install-docker.md`
+
+**Files:**
+- Modify: `/home/brockamer/Code/findajob/docs/setup/install-docker.md`
+
+- [ ] **Step 1: Replace stub header and preamble**
+
+The current file starts with:
+```markdown
+# Docker Install (stub)
+
+> **Full deploy guide is being authored under #69.** This page documents just enough to stand up a stack today. When #69 ships, `docs/release-process.md` and a complete install walkthrough land here.
+```
+
+Replace with:
+```markdown
+# Docker Install
+
+This is the install + operations guide for external users running findajob from the prebuilt `ghcr.io/brockamer/findajob` image via Docker Compose. Claude's release orchestration runbook lives separately at [`docs/release-process.md`](../release-process.md).
+```
+
+- [ ] **Step 2: Keep existing sections 1-6 verbatim**
+
+Sections to preserve without changes:
+- "Who this is for"
+- "Prerequisites on the Docker host"
+- "Prerequisites for your Claude Code helper (for the admin)"
+- "1. Create the stack directory"
+- "2. Drop in the compose template and env"
+- "3. Populate `state/`"
+- "4. Initial auth: Gmail (optional)"
+- "5. Deploy"
+- "6. Verify"
+
+- [ ] **Step 3: Replace the current "Updating" and "Troubleshooting" sections with the new operations material**
+
+Remove the existing two sections:
+```markdown
+## Updating
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+Or click **Pull** + **Deploy** in Dockge.
+
+## Troubleshooting
+
+See GitHub issues or open a new one at https://github.com/brockamer/findajob/issues.
+```
+
+Insert the following three new sections before a preserved (shortened) Troubleshooting section:
+
+```markdown
+## Tag pinning strategy
+
+`FINDAJOB_IMAGE_TAG` in your `.env` controls which image Docker Compose pulls. Pick based on how much change tolerance you want.
+
+| Value | Mutability | Recommended for |
+|---|---|---|
+| `v0.1` | moving (auto-advances to latest `v0.1.x` patch) | **Default.** Most users. Auto-accepts bugfixes; breaking changes require an explicit `.env` edit. |
+| `v0.1.0` | immutable | Pin exactly when you need a known-good version and can't afford surprises (e.g., during an active job-hunt push). |
+| `latest` | moving (tip of `main`) | Dogfood track. Daniel runs this on his LXC to exercise releases before tagging. May break. |
+| `main-<sha>` | immutable (one tag per commit on `main`) | Precise pinning or bisecting when diagnosing a regression. |
+
+Switching between tags is a one-line `.env` edit followed by `docker compose pull && docker compose up -d`.
+
+## Updating
+
+Before running `docker compose pull && docker compose up -d`:
+
+1. Check the [latest GitHub Release](https://github.com/brockamer/findajob/releases/latest) for an "⚠️ Action required before upgrade" section at the top of the notes.
+2. If the section is present, follow each linked PR's migration notes before pulling.
+3. If the section is absent, a straight pull-and-up is safe:
+   ```bash
+   cd /opt/stacks/findajob-<you>/
+   docker compose pull
+   docker compose up -d
+   ```
+   Or click **Pull** + **Deploy** in Dockge.
+
+The "Action required" section is driven by PRs labeled `migration-required` (see [`docs/release-process.md`](../release-process.md) for the criteria). If a release has no such PRs in its range, the section won't appear.
+
+## Rolling back locally
+
+If a pull broke your stack and you need to get back to a working state immediately:
+
+1. Edit `.env` to pin to a prior immutable tag, e.g.,
+   ```
+   FINDAJOB_IMAGE_TAG=v0.1.0
+   ```
+2. Re-deploy:
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+3. Report the regression via a GitHub issue so the shared `:v0.1` alias can be rolled back globally (Daniel's call — see [release-process.md Rollback section](../release-process.md#rollback)).
+
+A local rollback via `.env` pin doesn't affect other users on `:v0.1`.
+
+## Troubleshooting
+
+- Container fails to start: `docker compose logs scheduler` usually points at the issue.
+- Supercronic prints "schedule invalid": a crontab syntax error. Check `ops/crontab` for recent changes.
+- Gmail ingestion silently disabled: re-run `docker compose --profile setup run --rm gmail-auth` to refresh the token.
+- For anything else, open an issue at https://github.com/brockamer/findajob/issues.
+```
+
+- [ ] **Step 4: Verify the rewrite**
+
+Run:
+```bash
+grep -c 'stub' docs/setup/install-docker.md
+```
+Expected: `0` (no stub references remain).
+
+Run:
+```bash
+for section in "Tag pinning strategy" "Updating" "Rolling back locally" "Troubleshooting"; do
+  grep -c "^## ${section}$" docs/setup/install-docker.md && echo "  ✓ $section" || echo "  ✗ $section MISSING"
+done
+```
+Expected: each returns 1.
+
+Run:
+```bash
+grep -c 'migration-required' docs/setup/install-docker.md
+```
+Expected: `≥ 1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/setup/install-docker.md
+git commit -m "$(cat <<'EOF'
+docs: rewrite install-docker.md for external users (#69)
+
+Replaces the stub with a full operations guide: tag pinning strategy
+(v0.1 default, v0.1.0 pin, latest dogfood, main-<sha> bisect), updating
+workflow anchored to the release-notes "Action required" section, and
+local rollback via .env tag pin.
+
+Claude's orchestration-side runbook lives separately at
+docs/release-process.md.
+EOF
+)"
+```
+
+---
+
+## Task 4: Update `CLAUDE.md`
+
+**Files:**
+- Modify: `/home/brockamer/Code/findajob/CLAUDE.md`
+
+- [ ] **Step 1: Add `docs/release-process.md` to "Key File Locations"**
+
+Locate the "Quality" block near the end of the "Key File Locations" fenced code block (around line 167-171, preceded by the `# ── Quality ──` comment line). Insert a new "Operations" block before it:
+
+Find this block:
+```
+# ── Quality ─────────────────────────────────────────────────────────────────
+<repo>/pyproject.toml                       # deps, pytest, ruff, mypy config
+<repo>/tests/                               # 430 unit tests (pytest)
+<repo>/.github/workflows/ci.yml            # CI: ruff + mypy + pytest on every push
+```
+
+Insert above it:
+```
+# ── Operations ──────────────────────────────────────────────────────────────
+<repo>/docs/release-process.md              # Claude's release orchestration runbook — dogfood gate, tag cut, rollback
+<repo>/docs/setup/install-docker.md         # external-user Docker install + operations guide
+
+```
+
+Resulting order: `Output & logs` → `Operations` → `Quality`.
+
+- [ ] **Step 2: Add a "Release Management" subsection before "Working Style"**
+
+Locate the `## Working Style` heading (around line 319). Immediately before it, insert:
+
+```markdown
+## Release Management
+
+Docker image releases follow [`docs/release-process.md`](docs/release-process.md). Claude owns orchestration (dogfood gate, CHANGELOG drafting, tag cut, post-tag verification, rollback); Daniel reviews and approves the proposed cut. The dogfood gate is a binary 48h window on `:latest` — six observable signals must all be clean before any `v*.*.*` tag is pushed. PRs containing schema/config/crontab/mount/compose-down changes get the `migration-required` label at PR-open time so that release notes surface them for external users.
+
+---
+
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+grep -c 'docs/release-process.md' CLAUDE.md
+```
+Expected: `≥ 2` (one in the file-locations block, one in the Release Management subsection).
+
+Run:
+```bash
+grep -c '^## Release Management$' CLAUDE.md
+```
+Expected: `1`.
+
+Run:
+```bash
+# Ensure Key File Locations structure is still well-formed
+grep -cE '^# ── ' CLAUDE.md
+```
+Expected: `≥ 7` (one more than before — should include the new "Operations" comment).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: add Release Management section + file-locations entry to CLAUDE.md (#69)
+
+Points future sessions at docs/release-process.md for the 48h dogfood
+gate, migration-required label criteria, and the CHANGELOG workflow.
+EOF
+)"
+```
+
+---
+
+## Task 5: Update `CHANGELOG.md`
+
+**Files:**
+- Modify: `/home/brockamer/Code/findajob/CHANGELOG.md`
+
+- [ ] **Step 1: Add `Added` entries under `[Unreleased]`**
+
+Locate the `## [Unreleased]` block (currently empty — line 11-12). Insert:
+
+Find:
+```markdown
+## [Unreleased]
+
+## [0.1.0] — TBD
+```
+
+Replace with:
+```markdown
+## [Unreleased]
+
+### Added
+- `docs/release-process.md` — Claude-facing release orchestration runbook: 48h dogfood gate, CHANGELOG workflow, tag cut mechanics, post-tag verification, rollback (#69)
+- `docs/setup/install-docker.md` — full external-user Docker install + operations guide replacing the stub (#69)
+- `migration-required` GitHub label for PRs needing post-pull manual steps; auto-surfaced by `create-release.yml` in "Action required" section of release notes (#69)
+- `CLAUDE.md` "Release Management" subsection pointing future sessions at the runbook (#69)
+
+## [0.1.0] — TBD
+```
+
+- [ ] **Step 2: Update the Notes line in `[0.1.0] — TBD`**
+
+Find this line in the existing `## [0.1.0] — TBD` block's "Notes" section:
+```markdown
+- Release management process itself is tracked in #69; once that ships, the
+  process doc lives at `docs/release-process.md`.
+```
+
+Replace with:
+```markdown
+- Release management process is documented in `docs/release-process.md` and
+  followed for this cut (#69).
+```
+
+- [ ] **Step 3: Verify CHANGELOG integrity**
+
+Run:
+```bash
+# Unreleased block has at least one Added entry
+awk '/^## \[Unreleased\]/,/^## \[0\.1\.0\]/' CHANGELOG.md | grep -c '^- '
+```
+Expected: `4` (the four Added bullets).
+
+Run:
+```bash
+# Version cross-reference links at bottom intact
+tail -5 CHANGELOG.md | grep -cE '^\[.+\]: https://github.com'
+```
+Expected: `2` (the `[Unreleased]` and `[0.1.0]` links).
+
+Run:
+```bash
+# No accidental double-header
+grep -c '^## \[Unreleased\]' CHANGELOG.md
+```
+Expected: `1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: log release-management additions in CHANGELOG (#69)
+
+Records the release-process.md runbook, the install-docker.md rewrite,
+the migration-required label, and the CLAUDE.md subsection under
+[Unreleased]. Updates the [0.1.0] — TBD Notes line to reflect that #69
+has shipped.
+EOF
+)"
+```
+
+---
+
+## Task 6: Whole-feature verification + runbook dry-run for v0.1.0
+
+**Files:**
+- No file changes. Produces a review artifact posted as a PR comment or in-session report.
+
+- [ ] **Step 1: Re-verify all six acceptance criteria from issue #69**
+
+Run each check and record the result:
+
+```bash
+# 1. CHANGELOG.md exists at repo root with Keep-a-Changelog format
+test -f CHANGELOG.md && head -10 CHANGELOG.md | grep -q 'Keep a Changelog' && echo "✓ (1)" || echo "✗ (1)"
+
+# 2. create-release.yml auto-creates a GitHub Release with notes + migration-required surfacing
+test -f .github/workflows/create-release.yml && grep -q 'migration-required' .github/workflows/create-release.yml && echo "✓ (2)" || echo "✗ (2)"
+
+# 3. docs/release-process.md covers dogfood gate, tag mechanics, verification, rollback
+test -f docs/release-process.md && \
+  grep -q 'Dogfood gate' docs/release-process.md && \
+  grep -q 'Tag cut mechanics' docs/release-process.md && \
+  grep -q 'Post-tag verification' docs/release-process.md && \
+  grep -q 'Rollback' docs/release-process.md && \
+  echo "✓ (3)" || echo "✗ (3)"
+
+# 4. docs/setup/install-docker.md covers pinning, updating, reading release notes
+test -f docs/setup/install-docker.md && \
+  grep -q 'Tag pinning strategy' docs/setup/install-docker.md && \
+  grep -q 'migration-required' docs/setup/install-docker.md && \
+  ! grep -q 'stub' docs/setup/install-docker.md && \
+  echo "✓ (4)" || echo "✗ (4)"
+
+# 5. migration-required GitHub label exists and is documented
+gh label list --repo brockamer/findajob --search migration-required --json name --jq '.[0].name' | grep -q '^migration-required$' && \
+  grep -q 'migration-required' docs/release-process.md && \
+  echo "✓ (5)" || echo "✗ (5)"
+
+# 6. First release (v0.1.0) cut using this process
+#    Acceptance criterion is satisfied POST-MERGE. At PR-open time this is a forward promise;
+#    flag it in the PR description and close #69 only after v0.1.0 is published.
+echo "⚠ (6) — satisfied post-merge; see Task 7 / post-merge step"
+```
+
+Expected: checks 1-5 print `✓`. Check 6 prints the reminder.
+
+- [ ] **Step 2: Runbook dry-run against pending v0.1.0**
+
+Execute Sections 1-6 of `docs/release-process.md` on paper. Produce a report (to be included in the PR description or posted as a comment):
+
+a. **Target tag:** `v0.1.0`.
+
+b. **PR range to summarize:** Since this is the first release, there is no prior tag. Pull the full list of merged PRs:
+```bash
+gh pr list --state merged --repo brockamer/findajob --limit 100 --json number,title,mergedAt --jq '.[] | "#\(.number) \(.title)"'
+```
+
+c. **Draft CHANGELOG diff — [Unreleased] → [0.1.0] — 2026-04-18:** Show the proposed rearrangement of entries (including #69's additions on top of #13's existing `[0.1.0] — TBD` block).
+
+d. **Migration-required PRs in range:**
+```bash
+gh pr list --state merged --label migration-required --limit 50 --json number,title --repo brockamer/findajob
+```
+Expected for v0.1.0: empty. This is the first release; there is no prior version to migrate from.
+
+e. **Proposed tag command:**
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+(Not executed in this task — executed only after PR merge + user approval. See Task #5 in the task list.)
+
+f. **Runbook coverage check:** For each of the 6 acceptance criteria from #69, point at the specific section of `docs/release-process.md` that implements it:
+- Criterion 1 (CHANGELOG format) → already satisfied by existing CHANGELOG.md; Section 6 (CHANGELOG workflow) documents the process.
+- Criterion 2 (CI auto-creates GH Release) → already satisfied by `create-release.yml`; Section 8 (Post-tag verification) documents how to confirm it ran.
+- Criterion 3 (release-process.md coverage) → Sections 4, 7, 8, 9 of release-process.md itself.
+- Criterion 4 (install-docker.md coverage) → Task 3 of this plan.
+- Criterion 5 (migration-required label) → Section 5 of release-process.md; Task 1 of this plan creates the label.
+- Criterion 6 (first release cut) → Task 5 of the overall session task list (post-merge).
+
+- [ ] **Step 3: No commit** — Task 6 is a verification step, not a code change. The dry-run report goes in the PR description.
+
+---
+
+## Task 7: Open the PR
+
+**Files:**
+- No file changes. GitHub-side action.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/brockamer/Code/findajob
+git push -u origin feat/69-release-management
+```
+
+- [ ] **Step 2: Open PR with a body that includes the dry-run report from Task 6**
+
+```bash
+gh pr create --title "Release management process + Docker install guide (#69)" --body "$(cat <<'EOF'
+## Summary
+- Adds `docs/release-process.md` — Claude's 48h-dogfood-gate release runbook (Sections: Ownership, Version scheme, Pre-release checklist, Dogfood gate, migration-required label criteria, CHANGELOG workflow, Tag cut mechanics, Post-tag verification, Rollback).
+- Rewrites `docs/setup/install-docker.md` for external users — adds Tag pinning strategy, Updating (with "Action required" guidance), Rolling back locally.
+- Creates the `migration-required` GitHub label and documents its criteria.
+- Adds a "Release Management" subsection and file-locations entry to `CLAUDE.md`.
+- Adds `Added` entries under `[Unreleased]` in `CHANGELOG.md` and updates the `[0.1.0] — TBD` Notes line.
+
+Closes #69 (after the v0.1.0 cut ships, which is a post-merge follow-up task).
+
+## Runbook dry-run for v0.1.0
+<paste the Task 6 Step 2 report here — including the full PR list, the draft CHANGELOG diff, the migration-required count (expected 0), and the proposed tag command>
+
+## Acceptance criteria (from #69)
+- [x] CHANGELOG.md exists at repo root with Keep-a-Changelog format
+- [x] CI workflow auto-creates a GitHub Release with notes + migration-required surfacing on `v*` tag push
+- [x] docs/release-process.md covers dogfood gate, tag mechanics, verification, rollback
+- [x] docs/setup/install-docker.md covers pinning, updating, reading release notes
+- [x] migration-required GitHub label exists and is documented
+- [ ] First real release (v0.1.0 from #13) cut using this process — **satisfied post-merge; Daniel approves before tag push**
+
+## Test plan
+- [ ] Review `docs/release-process.md` — does it tell a future Claude session enough to cut a release without improvising?
+- [ ] Review `docs/setup/install-docker.md` — would a stranger follow this to stand up a stack and update it safely?
+- [ ] Spot-check `CLAUDE.md` changes — file-locations entry + Release Management subsection fit the document's existing structure
+- [ ] Confirm the `migration-required` label exists via [the labels page](https://github.com/brockamer/findajob/labels/migration-required)
+- [ ] Approve the dry-run's proposed v0.1.0 CHANGELOG layout and tag command
+- [ ] After merge: trigger Task 5 from the session task list — Claude runs the runbook's dogfood gate + post-tag verification, user approves, Claude tags v0.1.0
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify PR creation**
+
+```bash
+gh pr view --json url,state,title --jq '"\(.title) [\(.state)] → \(.url)"'
+```
+Expected: single line with title, state `OPEN`, URL.
+
+- [ ] **Step 4: No commit** — PR creation is a GitHub side effect.
+
+---
+
+## Documentation Impact
+
+Per `docs/plan-conventions.md`, every doc surface this plan touches:
+
+- **`docs/release-process.md`** — NEW. Task 2.
+- **`docs/setup/install-docker.md`** — full rewrite. Task 3.
+- **`CLAUDE.md`** — Key File Locations entry + "Release Management" subsection. Task 4.
+- **`CHANGELOG.md`** — `[Unreleased]` entries + Notes line tweak in `[0.1.0] — TBD`. Task 5.
+- **`CLAUDE.local.md`** — not touched; no PII, no installation-specific state introduced.
+- **`README.md`** — not touched in this PR. Prerequisites L35–42 remain native-only; flagged in PR #77's description, folded into #76 or a future fix-up PR.
+- **Spec doc (`docs/superpowers/specs/2026-04-18-release-management-design.md`)** — already committed as `714741f`; no amendment expected from this plan. If implementation reveals a flaw in the spec, amend per plan-conventions.md §5.
+- **Role prompts / in-code docstrings** — none affected (docs-only PR).
+- **`docs/project-board.md`** — not touched. Release management is a separate workflow from board management.
+
+If a subagent discovers an additional surface during implementation (e.g., a README link that points to install-docker.md and would now need updating), add it to this list in the same commit as the fix.
+
+---
+
+## Whole-feature verification gate
+
+Distinct from per-task verification. Before opening the PR, all of the following must pass:
+
+1. `test -f docs/release-process.md && [ "$(wc -l < docs/release-process.md)" -gt 200 ]` — runbook exists and is substantive.
+2. All nine required sections present in `docs/release-process.md` (see Task 2 Step 2).
+3. `grep -c 'stub' docs/setup/install-docker.md` returns `0`.
+4. `gh label list --repo brockamer/findajob --search migration-required` returns the label.
+5. `grep -c '^## Release Management$' CLAUDE.md` returns `1`.
+6. `grep -cE '### Added' CHANGELOG.md` — at least 2 (one under `[Unreleased]`, one under `[0.1.0] — TBD`).
+7. All Task 2-5 commits are present on branch `feat/69-release-management`:
+   ```bash
+   git log --oneline origin/main..HEAD
+   ```
+   Expected: 5 commits total — the spec commit (`714741f`) plus one commit each for Tasks 2, 3, 4, 5. Tasks 1, 6, 7 are side effects and do not produce commits.
+
+---
+
+## Self-review checklist
+
+Spec-to-implementation coverage map. Every section of `docs/superpowers/specs/2026-04-18-release-management-design.md` maps to at least one plan task.
+
+| Spec section | Implemented by |
+|---|---|
+| Goal + In scope | Tasks 1-5 collectively |
+| Out of scope | Explicitly not implemented; noted in plan's Documentation Impact |
+| Component 1 (release-process.md) | Task 2 (9-section runbook) |
+| Component 2 (install-docker.md rewrite) | Task 3 |
+| Component 3 (migration-required label) | Task 1 (creation) + Task 2 Section 5 (documentation) |
+| Component 4 (CLAUDE.md update) | Task 4 |
+| Component 5 (CHANGELOG.md entries) | Task 5 |
+| Data flow (release lifecycle + rollback) | Task 2 Sections 3-9 |
+| Error handling & edge cases | Task 2 Section 4 (gate restart), Section 8 (workflow failures), Section 9 (rollback + first-release note) |
+| Acceptance (whole-feature verification) | Task 6 + this plan's "Whole-feature verification gate" section |
+| Ownership & workflow | Task 2 Section 1; Task 4's "Release Management" subsection references it |
+| Documentation Impact | This plan's Documentation Impact section (re-derived, not copied) |
+| Risks & mitigations | Runbook drift → addressed by "Documentation Sync Rule" memory; dogfood-gate skipping → addressed by Task 2 Section 4 ("binary gate"); install-docker.md staleness → Task 6 Step 1 check 4; label over/under-application → Task 2 Section 5 criteria |
+
+Placeholder scan: no TBDs, no TODOs, no "implement later" in this plan. Every step has concrete commands or full content.
+
+Type/contract consistency: N/A — docs-only plan. File paths match the spec. Section names in Task 2 Step 2's verification match the section names written in Task 2 Step 1.
+
+Scope check: single-PR sized. Six implementation tasks + one verification task + one PR-creation task. All doc-layer. No code, no tests, no schema.

--- a/docs/superpowers/specs/2026-04-18-release-management-design.md
+++ b/docs/superpowers/specs/2026-04-18-release-management-design.md
@@ -1,0 +1,252 @@
+# Release Management Process for Docker Image Distribution — Design
+
+**Issue:** [#69](https://github.com/brockamer/findajob/issues/69)
+**Date:** 2026-04-18
+**Author:** Claude (Opus 4.7) + Daniel Brock (review)
+
+## Goal
+
+Codify a release process for the containerized findajob pipeline so external users (Amy and future beta testers) can pull new versions without being hit by rolling breakages, and so Claude can execute releases consistently across sessions without improvising the procedure each time.
+
+The automation side of releases already ships in #13 — `build-image.yml` pushes immutable and moving tags on every `main` push and `v*.*.*` tag; `create-release.yml` auto-generates release notes and surfaces PRs labeled `migration-required` in a prominent "Action required" section. This spec covers the **process + documentation** layer that those workflows depend on: when to cut a release, how to verify it's safe, how to write its notes, how to roll back.
+
+## Scope
+
+### In scope
+
+- `docs/release-process.md` — the Claude-facing orchestration runbook. Structure, dogfood gate, migration-label criteria, CHANGELOG workflow, tag mechanics, post-tag verification, rollback.
+- `docs/setup/install-docker.md` — full rewrite of the current stub. External-user guide covering tag pinning, updates, reading release notes.
+- `migration-required` GitHub label — created on the repo, criteria documented in release-process.md.
+- `CLAUDE.md` — one-line addition to "Key File Locations" pointing to `docs/release-process.md`.
+- `CHANGELOG.md` — `[Unreleased]` gets a new *Added* entry for #69; the `[0.1.0] — TBD` "Notes" line gets "(#69 shipped)".
+- Whole-PR self-review confirms all six acceptance criteria from issue #69 are met.
+
+### Out of scope
+
+- **v0.1.0 cut itself** — executed post-merge per the new runbook, gated on Daniel's approval. Issue #69 closes only after the release is published on GitHub. Covered as a follow-up task after PR merges.
+- **Deep Docker operations/architecture rewrite** — owned by [#76](https://github.com/brockamer/findajob/issues/76).
+- **`README.md` "Prerequisites" native-only section (L35–42)** — noted in PR #77's description, folded into #76 or a future fix-up PR.
+- **Any CI changes** — `create-release.yml` and `build-image.yml` already implement the automation side.
+
+## Components
+
+### 1. `docs/release-process.md` (new, ~350–500 lines)
+
+Sections:
+
+1. **Ownership** — Claude drives release orchestration; Daniel reviews and approves the cut. Anchored to `feedback_release_management.md` memory.
+2. **Version scheme** — 0.x semver discipline: breaking changes → minor bump (0.1 → 0.2); bugfixes → patch bump (0.1.0 → 0.1.1). Immutable `v0.1.0` tag vs moving `v0.1` alias explained.
+3. **Pre-release checklist** — CHANGELOG `[Unreleased]` has entries for every merged PR since last tag; every such PR is checked for `migration-required` applicability.
+4. **Dogfood gate (48h) — the Q1-B checklist.** Exact commands + expected signals:
+   - At least two full triage runs completed with `pipeline_complete` event in `logs/pipeline.jsonl`
+   - poll_flags cycles firing every 10min without exception rows (verify via `docker compose logs scheduler --since 2h` on the LXC — supercronic prints each job's exit code; zero non-zero exits expected for poll_flags during the window)
+   - 07:00 UTC daily health-check notify fired on Daniel's phone
+   - Sheet1 + Dashboard + Applied tab syncs landed on two consecutive sync cycles
+   - form-ingest runs clean (no "duplicate submission" or API-error entries)
+   - `docker compose logs scheduler` shows no stack traces in the window
+5. **`migration-required` label criteria — the Q2-B list.** Applied by Claude at PR-open time, challengeable in review. Triggers:
+   - SQLite schema changes (new tables, new columns, new indexes on existing tables)
+   - New *required* `state/data/.env` keys (not optional overrides)
+   - Moves/renames of files in `state/config/` that break existing stacks
+   - Crontab schedule changes that shift when a timer fires
+   - Changes to bind-mount layout in compose.yaml.example
+   - Changes that require `docker compose down` before pulling (rather than plain `pull && up -d`)
+6. **CHANGELOG workflow** — how to move entries from `[Unreleased]` to `[x.y.z] — YYYY-MM-DD`. Version cross-reference link format at the bottom. Date format (ISO 8601, in PT per `feedback_pt_user_calendar.md`).
+7. **Tag cut mechanics** — `git fetch && git checkout main && git pull`, then `git tag v0.x.y && git push --tags`. Note: requires the CHANGELOG commit to be on `main` already and `:latest` to have rebuilt from it, so the tagged image *is* the code described in the release notes.
+8. **Post-tag verification**:
+   - GitHub Release page populated correctly (title, notes, migration-required section if any)
+   - `create-release.yml` run green
+   - `build-image.yml` run green; new tags visible at `ghcr.io/brockamer/findajob/pkgs/container/findajob`
+   - `docker pull ghcr.io/brockamer/findajob:v0.x.y` succeeds from Daniel's LXC
+9. **Rollback** — if post-tag verification or post-release regression requires reverting:
+   - Identify last-known-good immutable tag `v0.x.y-1`
+   - `docker pull ghcr.io/brockamer/findajob:v0.x.y-1`
+   - `docker tag ghcr.io/brockamer/findajob:v0.x.y-1 ghcr.io/brockamer/findajob:v0.x`
+   - `docker push ghcr.io/brockamer/findajob:v0.x`
+   - Add `## [Reverted] — YYYY-MM-DD` entry to CHANGELOG.md naming the bad tag and reason
+   - Note: immutable `v0.x.y` tag stays pinned so users who pinned specifically can be diagnosed
+
+### 2. `docs/setup/install-docker.md` (rewrite of stub)
+
+Replaces the current "(stub)" file. Sections:
+
+- **Who this is for** + **Prerequisites** — lightly edited from the stub.
+- **1. Create the stack directory** — unchanged.
+- **2. Drop in the compose template and env** — unchanged.
+- **3. Populate state/** — unchanged.
+- **4. Initial auth: Gmail (optional)** — unchanged.
+- **5. Deploy** — unchanged.
+- **6. Verify** — unchanged.
+- **Tag pinning strategy** *(new substantive section)* — when to pick each option:
+  - `FINDAJOB_IMAGE_TAG=v0.1` — **recommended default.** Moving minor alias. Auto-accepts patch bumps (v0.1.x) on next `docker compose pull`. Breaking changes don't auto-land.
+  - `FINDAJOB_IMAGE_TAG=v0.1.0` — immutable tag. Pin exactly when you need a known-good version (e.g., during an active job-hunt push where you can't afford surprises).
+  - `FINDAJOB_IMAGE_TAG=latest` — dogfood track. Tip of main, may break. Daniel runs this on his LXC to exercise releases before tagging.
+  - `FINDAJOB_IMAGE_TAG=main-<sha>` — immutable commit-sha tag. For precise pinning or bisecting when diagnosing a regression.
+- **Updating** *(new substantive section)* — before running `docker compose pull && up -d`, check the latest GitHub Release for the "⚠️ Action required before upgrade" section. If present, follow the linked PR's migration notes before pulling. If absent, a straight `pull && up -d` is safe.
+- **Rolling back locally** *(new section)* — edit `.env` to a prior immutable tag (`FINDAJOB_IMAGE_TAG=v0.1.0` if `v0.1.1` broke you) and `docker compose up -d`. This doesn't fix the shared `:v0.1` alias — that's Daniel's to roll back; report the regression so he can.
+- **Troubleshooting** — unchanged.
+
+### 3. `migration-required` GitHub label
+
+Created with:
+```bash
+gh label create migration-required \
+  --color BF5700 \
+  --description "Changes require a manual step (schema, config, crontab, mount layout, docker compose down) before pulling"
+```
+
+Documented in release-process.md §5.
+
+### 4. `CLAUDE.md` update
+
+Add a line under "Key File Locations" referencing `docs/release-process.md`. Existing structure has a "Quality" subsection near the bottom; add a short "Operations" block or append to an adjacent block.
+
+Also add a short subsection to the body of CLAUDE.md under an existing relevant heading (or a new "Release management" heading before "Working Style") that reads approximately:
+
+> ### Release management
+> Docker image releases follow `docs/release-process.md`. Claude owns orchestration; Daniel reviews and approves the cut. Dogfood gate is 48h on `:latest` before any `v*.*.*` tag push.
+
+### 5. `CHANGELOG.md`
+
+- Under `## [Unreleased]`, add:
+  ```markdown
+  ### Added
+  - `docs/release-process.md` — Claude-facing release orchestration runbook (#69)
+  - `docs/setup/install-docker.md` full external-user guide replacing the stub (#69)
+  - `migration-required` GitHub label for PRs needing post-pull manual steps (#69)
+  ```
+- In the existing `## [0.1.0] — TBD` "Notes" block, update the line that says "Release management process itself is tracked in #69" to "Release management process is documented in `docs/release-process.md` (#69)".
+
+## Data flow — the release lifecycle
+
+The runbook codifies this sequence. Every release is Claude executing it.
+
+```
+[Merged PRs accumulate on main]
+        │
+        │  build-image.yml pushes :latest, :main-<sha> on every main push (already shipped)
+        ▼
+[:latest on Daniel's LXC via FINDAJOB_IMAGE_TAG=latest]
+        │
+        │  Claude proposes release cut when changelog is substantive
+        ▼
+[Dogfood gate — 48h checklist (§4 of runbook)]
+        │    ✓ 2+ pipeline_complete events
+        │    ✓ poll_flags cycles clean
+        │    ✓ 07:00 UTC health-check notify fired
+        │    ✓ sheet syncs landed
+        │    ✓ form-ingest runs clean
+        │    ✓ no stack traces in scheduler logs
+        │
+        ├── Fail → fix forward on main, restart gate when clean
+        │
+        ▼
+[Claude drafts release cut proposal]
+        │    – Which tag (v0.x.y)
+        │    – CHANGELOG diff from [Unreleased] → [x.y.z]
+        │    – List of migration-required PRs in the range
+        │
+        ▼
+[Daniel reviews proposal, approves or requests changes]
+        │
+        ▼
+[Claude commits CHANGELOG update on main → merges → waits for :latest rebuild]
+        │
+        ▼
+[Claude tags: git tag v0.x.y && git push --tags]
+        │
+        │  build-image.yml pushes :v0.x.y, :v0.x, :latest
+        │  create-release.yml creates GH release with auto-generated notes
+        │  + migration-required surfacing (already shipped)
+        ▼
+[Claude verifies post-tag (§8 of runbook)]
+        │    ✓ GitHub Release page looks right
+        │    ✓ Both workflows green
+        │    ✓ `docker pull ghcr.io/brockamer/findajob:v0.x.y` succeeds from LXC
+        │
+        ▼
+[Users on :v0.x auto-pull on their next `docker compose pull`]
+```
+
+**Rollback path** (from post-tag if verification fails or regression reported):
+
+```
+[Claude identifies last-known-good tag v0.x.y-1]
+        │
+        ▼
+[docker pull ghcr.io/brockamer/findajob:v0.x.y-1 from LXC]
+        │
+        ▼
+[docker tag + docker push to overwrite :v0.x alias pointer]
+        │
+        ▼
+[CHANGELOG gets a "## [Reverted]" note naming the bad tag and why]
+        │
+        ▼
+[Users on :v0.x get the prior image on next `docker compose pull`]
+```
+
+## Error handling & edge cases
+
+- **Dogfood gate fails partway through** — restart the 48h clock after the fix lands on `main` and `:latest` rebuilds. No "it was fine for 40 hours, close enough." The gate is binary.
+- **Post-tag workflows fail** — release-process.md §8 documents diagnostics: check `create-release.yml` run logs, check `build-image.yml` tag-push job, manual re-trigger via `gh workflow run`. If the image push succeeded but release-notes failed, re-run that job alone; don't delete and re-push the tag.
+- **User review finds a CHANGELOG mistake after tag is pushed** — don't re-tag. Open a correction PR against `[Unreleased]` for future releases; the GitHub Release itself can be edited in-place via `gh release edit v0.x.y --notes-file`.
+- **`migration-required` label missed on a PR that needed it** — after merge, label can still be applied; subsequent release notes for the inclusive range will pick it up.
+- **Bad release ships** — run the rollback flow. `:v0.x` alias re-pointed; immutable `:v0.x.y` stays pinned so users on the bad tag can be diagnosed.
+- **Two releases within 48h** — the gate starts over for each. If a critical bugfix needs to ship inside the window, it's a patch release on the current minor, and the abbreviated gate is allowed *only* if Daniel explicitly approves the exception, documented in the release notes.
+
+## Acceptance (whole-feature verification gate)
+
+Distinct from per-task verification. This is the gate for the #69 PR itself, not for future releases cut via the runbook.
+
+1. `docs/release-process.md` exists, renders cleanly on GitHub, and a read-through against issue #69's six acceptance criteria confirms each is met.
+2. `docs/setup/install-docker.md` no longer has the "(stub)" header or the "full guide in #69" banner; every section listed above is present; the file passes a "would a stranger follow this?" review.
+3. `gh label list --repo brockamer/findajob` shows `migration-required` with the documented color + description.
+4. `CHANGELOG.md` is still valid: version cross-reference links at the bottom intact, `[Unreleased]` and `[0.1.0] — TBD` sections present, new entries under Unreleased for #69.
+5. `CLAUDE.md` "Key File Locations" references `docs/release-process.md`, and a body subsection explains release management at a high level.
+6. **Functional dry-run of the runbook** — Claude executes Sections 1–6 of the runbook on paper against the pending v0.1.0: shows Daniel the draft CHANGELOG diff, list of migration-required PRs (expected: zero for v0.1.0), and the proposed tag command. If Claude can produce a coherent proposal using only the written runbook, the runbook works. The actual tag push happens post-merge after Daniel's approval.
+
+## Ownership & workflow
+
+Per issue #69 and `feedback_release_management.md`:
+
+- **Claude:** proposes the release cut, drafts CHANGELOG entries, flags migration markers, writes release notes, runs the dogfood gate, executes the tag push, runs post-tag verification, owns rollback.
+- **Daniel:** reviews and approves the proposed cut; reviews this spec, the resulting plan, and the implementation PR.
+
+## Documentation Impact
+
+This is the Documentation-Impact checkpoint required by `docs/plan-conventions.md`. Every doc surface this spec touches:
+
+- **`docs/release-process.md`** — NEW. The core deliverable.
+- **`docs/setup/install-docker.md`** — full rewrite of current stub.
+- **`CLAUDE.md`** — "Key File Locations" entry + short "Release management" subsection.
+- **`CHANGELOG.md`** — new entries under `[Unreleased]`, tweak to "Notes" line in `[0.1.0] — TBD` block.
+- **`README.md`** — *not* touched in this spec. Prerequisites section L35–42 still reads native-only; flagged in PR #77, folded into #76 or a future fix-up PR.
+- **Role prompts / in-code docstrings** — none affected.
+- **CLAUDE.local.md** — not touched; no PII, no installation-specific state.
+
+If an additional surface is discovered during implementation, the plan's Documentation Impact section (authored in the next step) amends this list.
+
+## Risks & mitigations
+
+- **Runbook drift** — the runbook is useless if future changes to `build-image.yml` or `create-release.yml` aren't mirrored. Mitigation: CLAUDE.md's "Documentation Sync Rule" memory applies; any PR touching those workflows must also touch release-process.md in the same commit.
+- **Dogfood gate gets skipped "just this once"** — the runbook states the gate is binary, and the spec records that exceptions require explicit Daniel approval documented in the release notes. Mitigation: written discipline plus the "Release management is Claude's responsibility" memory.
+- **External user reads outdated install-docker.md** — mitigation: the file is baked into the image but also served from `main` on GitHub. Users land on the GitHub copy via the link in the release notes. Keep the two in sync by treating install-docker.md as part of every release's verification.
+- **`migration-required` label applied too aggressively** — dilutes the signal. Mitigation: Q2-B criteria codified in the runbook; if unsure, don't label. Re-labeling post-merge is allowed.
+- **`migration-required` label missed when it was needed** — users get hit by a breaking change silently. Mitigation: release-process.md §3 (pre-release checklist) includes a per-PR review of the changed files for schema/config/mount changes, catching label misses before the cut.
+
+## Self-review checklist
+
+Spec-to-implementation coverage map, to be validated against the plan's tasks:
+
+| Spec section | Implemented by |
+|---|---|
+| Component 1 (release-process.md) | Plan task: create `docs/release-process.md` |
+| Component 2 (install-docker.md rewrite) | Plan task: rewrite `docs/setup/install-docker.md` |
+| Component 3 (migration-required label) | Plan task: `gh label create` + mention in release-process.md |
+| Component 4 (CLAUDE.md update) | Plan task: edit CLAUDE.md |
+| Component 5 (CHANGELOG.md entries) | Plan task: edit CHANGELOG.md |
+| Whole-feature verification gate | Plan's Verification section |
+| Documentation Impact | Plan's Documentation Impact section (must re-derive from this spec, not just copy) |
+
+Placeholder scan: no TBDs, no TODOs in this spec. Type/contract consistency: N/A (docs-only). Scope check: contained in a single PR per Q4-A; v0.1.0 cut tracked as a distinct follow-up task after PR merges.


### PR DESCRIPTION
## Summary

- **`docs/release-process.md`** (new, 344 lines) — Claude's 48h-dogfood-gate release runbook: Ownership, Version scheme, Pre-release checklist, Dogfood gate (6 observable signals), `migration-required` label criteria, CHANGELOG workflow, Tag cut mechanics, Post-tag verification, Rollback (incl. first-release note for v0.1.0).
- **`docs/setup/install-docker.md`** — full rewrite of the stub for external users: Tag pinning strategy (table covering `v0.1` / `v0.1.0` / `latest` / `main-<sha>`), Updating workflow anchored to the "⚠️ Action required before upgrade" release-notes section, Rolling back locally via `.env` pin.
- **`migration-required`** GitHub label — created, documented. `create-release.yml` already surfaces labeled PRs (shipped in #13).
- **`CLAUDE.md`** — added "Operations" block in Key File Locations (pointing at both new docs) + "Release Management" H2 subsection before Working Style.
- **`CHANGELOG.md`** — added 4 `Added` bullets under `[Unreleased]` for the #69 changes, updated the Notes line in `[0.1.0] — TBD` from forward-looking to past-tense.

Closes #69 once the v0.1.0 cut follows — that's a post-merge step using the runbook just authored.

## Design + plan

- Spec: [`docs/superpowers/specs/2026-04-18-release-management-design.md`](docs/superpowers/specs/2026-04-18-release-management-design.md)
- Plan: [`docs/superpowers/plans/2026-04-18-release-management.md`](docs/superpowers/plans/2026-04-18-release-management.md)

## Key decisions

- **Dogfood gate: binary 48h**, six observable signals (2+ `pipeline_complete` events, poll_flags cycles clean, 07:00 UTC health-check fired, sheet syncs landed, form-ingest runs clean, zero tracebacks). No "mostly green."
- **`migration-required` label criteria**: schema changes, new required env keys, `state/config/` moves, crontab schedule changes (not bugfixes to broken cronlines), bind-mount layout changes, `docker compose down`-requiring changes. Claude applies at PR-open; user can challenge in review.
- **Runbook location: `docs/release-process.md`** (root of `docs/`, not under `setup/` — it's for release orchestration, not installation).
- **PR shape**: single PR; v0.1.0 cut is a separate post-merge step so the runbook can be used to execute it.

## Runbook dry-run for v0.1.0

Executed Sections 1-6 of the runbook against the pending v0.1.0 as an acceptance check:

- **Target tag:** `v0.1.0`
- **PR range:** no prior tag; 5 merged PRs total on the repo: #77 (v0.1.0 doc audit), #75 (notify.py crontab fix), #72 (#13 containerization), #68 (macOS deprecation), #64 (#10 prefilter generalization). (Pre-#64 work landed directly on main and will appear via GitHub's auto-generated commit-based notes from the first-release stub.)
- **`migration-required` PRs in range:** 0. First release; there's no prior version to migrate from.
- **Draft CHANGELOG diff:** at tag time Claude will move the 4 bullets from `[Unreleased]` into the `[0.1.0]` block's `### Added` (keeping them grouped as "Documentation"); renumber the `## [Unreleased]` header to `## [0.1.0] — 2026-04-17` (PT at that moment); insert a fresh `## [Unreleased]`; update the cross-reference link at the bottom.
- **Proposed tag command (not executed):**
  ```bash
  VERSION=0.1.0
  MAJOR_MINOR="${VERSION%.*}"
  git fetch origin && git checkout main && git pull
  grep -c "## \[${VERSION}\]" CHANGELOG.md   # Expected: 1
  git tag "v${VERSION}"
  git push origin "v${VERSION}"
  ```

## Acceptance criteria (from #69)

- [x] `CHANGELOG.md` exists at repo root with Keep-a-Changelog format — already satisfied via #13; reinforced here.
- [x] CI workflow auto-creates GitHub Release with notes + `migration-required` surfacing on `v*` tag push — satisfied via `create-release.yml` from #13.
- [x] `docs/release-process.md` covers dogfood gate, tag mechanics, verification, rollback.
- [x] `docs/setup/install-docker.md` covers pinning, updating, reading release notes.
- [x] `migration-required` GitHub label exists and is documented.
- [ ] **First real release (v0.1.0) cut using this process** — satisfied post-merge; confirm before tag push.

## Test plan

- [ ] Review `docs/release-process.md` — does it tell a future Claude session enough to cut a release without improvising?
- [ ] Review `docs/setup/install-docker.md` — would an external beta tester follow this to stand up, update, and roll back their stack safely?
- [ ] Spot-check `CLAUDE.md` — file-locations entry + Release Management subsection fit the document's existing structure.
- [ ] Confirm the `migration-required` label exists via [the labels page](https://github.com/brockamer/findajob/labels/migration-required).
- [ ] Approve the dry-run's proposed v0.1.0 CHANGELOG layout and tag command.
- [ ] After merge: session Task 5 — Claude runs the runbook's dogfood gate, proposes the cut, user approves, Claude tags v0.1.0.

## Residuals noted

- `findajob-brock` stack paths remain in `docs/release-process.md` dogfood-gate commands (they're the literal paths the runbook targets on the maintainer's LXC). Generalization to a parameterized `${STACK_DIR}` is out of scope for this PR; tracked implicitly via `docs/GENERALIZATION.md`'s ongoing hardcoded-content sweep.
- `docs/setup/install-docker.md` Troubleshooting section was expanded from 1 bullet to 4 (container startup, supercronic schedule-invalid, Gmail token refresh, fallback-to-issues). Spec said "unchanged" but the reviewer judged this a beneficial improvement for external-user usability; explicit acknowledgment so it's not lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)