### PR TITLE
Archive 6 stale plans/specs

### DIFF
--- a/docs/superpowers/plans/archived/2026-04/2026-04-14-lxc-migration.md
+++ b/docs/superpowers/plans/archived/2026-04/2026-04-14-lxc-migration.md
@@ -1,3 +1,7 @@
+---
+**Archived 2026-04-19. self-titled COMPLETE (2026-04-14); LXC migration shipped.**
+---
+
 # LXC Migration Implementation Plan — COMPLETE (2026-04-14)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/plans/archived/2026-04/2026-04-15-gdrive-sync-audit.md
+++ b/docs/superpowers/plans/archived/2026-04/2026-04-15-gdrive-sync-audit.md
@@ -1,3 +1,7 @@
+---
+**Archived 2026-04-19. self-titled ALL TASKS COMPLETE; Google Drive sync fixes shipped.**
+---
+
 # Google Drive Sync Audit & Fix Plan — COMPLETE
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/archived/2026-04/2026-04-10-jd-quality-design.md
+++ b/docs/superpowers/specs/archived/2026-04/2026-04-10-jd-quality-design.md
@@ -1,3 +1,7 @@
+---
+**Archived 2026-04-19. shipped — strip_jd_boilerplate() and JD_MAX_CHARS present in src/findajob/.**
+---
+
 # JD Quality Improvement — Design Spec
 
 **Date:** 2026-04-10

--- a/docs/superpowers/specs/archived/2026-04/2026-04-14-lxc-migration-design.md
+++ b/docs/superpowers/specs/archived/2026-04/2026-04-14-lxc-migration-design.md
@@ -1,3 +1,7 @@
+---
+**Archived 2026-04-19. design spec for the completed LXC migration plan.**
+---
+
 # Migration: Laptop → Proxmox LXC
 
 **Date:** 2026-04-14

--- a/docs/superpowers/specs/archived/2026-04/2026-04-15-doc-overhaul-design.md
+++ b/docs/superpowers/specs/archived/2026-04/2026-04-15-doc-overhaul-design.md
@@ -1,3 +1,7 @@
+---
+**Archived 2026-04-19. refs #18, #21 — both closed; doc overhaul work shipped.**
+---
+
 # Documentation Overhaul — Design Spec
 
 **Issue:** #18

--- a/docs/superpowers/specs/archived/2026-04/2026-04-15-search-expansion-design.md
+++ b/docs/superpowers/specs/archived/2026-04/2026-04-15-search-expansion-design.md
@@ -1,3 +1,7 @@
+---
+**Archived 2026-04-19. work done — see retroactive tracking issue filed 2026-04-19 summarizing what landed.**
+---
+
 # Search Expansion: Signal-to-Noise Improvement
 
 **Date:** 2026-04-15


### PR DESCRIPTION
## Summary

Routine grooming sweep (2026-04-19). Six plan/spec docs had completed or shipped work — archived under `docs/superpowers/{plans,specs}/archived/2026-04/` with a header on each explaining why. Git history preserved via `git mv`.

## Archived files

| File | Reason |
|---|---|
| `specs/2026-04-15-doc-overhaul-design.md` | refs #18, #21 — both closed |
| `plans/2026-04-14-lxc-migration.md` | self-titled COMPLETE (2026-04-14) |
| `specs/2026-04-14-lxc-migration-design.md` | design for completed migration |
| `plans/2026-04-15-gdrive-sync-audit.md` | self-titled ALL TASKS COMPLETE |
| `specs/2026-04-10-jd-quality-design.md` | `strip_jd_boilerplate()` / `JD_MAX_CHARS` landed in `src/findajob/` |
| `specs/2026-04-15-search-expansion-design.md` | work shipped; retroactive tracking issue #103 |

## Test plan

- [x] `git mv` preserves blame history
- [x] Each archived file begins with an archival header naming the ship reason
- [x] No references in active issues to the old paths (search-expansion work is recorded in #103)