### PR TITLE
Add docs/roadmap.md; split phase narrative out of issue #58

### DIFF
--- a/docs/project-board.md
+++ b/docs/project-board.md
@@ -1,8 +1,25 @@
 # Project Board — How It Works
 
-The GitHub Projects v2 board at [findajob Pipeline](https://github.com/users/brockamer/projects/1) is the **single source of truth for what is being worked on and why**. No markdown tracking files, no separate backlog lists, no TODO.md. If it isn't on the board, it isn't on the roadmap.
+The GitHub Projects v2 board at [findajob Pipeline](https://github.com/users/brockamer/projects/1) is the **single source of truth for execution state** — what is being worked on, by whom, what state. Phase-level narrative and cross-issue decisions live in [`roadmap.md`](roadmap.md). If it isn't on the board or in the roadmap, it isn't on the plan.
 
 This document describes the conventions so anyone (human or Claude session) can triage, prioritize, and move work consistently.
+
+## Division of labor — board vs. roadmap vs. canonical docs
+
+Drift is the main failure mode. Every fact has exactly one home. On conflict, the canonical home wins.
+
+| Fact type | Lives in | Wins on conflict |
+|---|---|---|
+| Phase arc + phase ordering rationale | [`roadmap.md`](roadmap.md) | roadmap |
+| Cross-issue decisions (numbered, append-only) | [`roadmap.md`](roadmap.md) | roadmap |
+| Milestone-level acceptance criteria | [`roadmap.md`](roadmap.md) | roadmap |
+| Issue Status, Priority, Milestone, labels | board | board |
+| Issue body (summary, per-issue acceptance, prose depends-on) | issue | issue |
+| Issue dependencies (`blockedBy` edges) | native GitHub dependency API | native edges |
+| Deployment / architecture facts | [`deployment-model.md`](deployment-model.md) | canonical doc |
+| Release process | [`release-process.md`](release-process.md) | canonical doc |
+
+Issue bodies may *reference* the roadmap ("see Phase 4 in roadmap.md") but should not restate phase ordering or decisions. That's how drift starts. The jared sweep includes a drift-scan check for this (see `jared/references/board-sweep.md`).
 
 ## Columns (Status field)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,82 @@
+# Project roadmap
+
+Canonical phase-narrative for findajob. Captures *why* the work is ordered the way it is — the board captures *what* is being worked on right now.
+
+See [`project-board.md`](project-board.md) for the full division of labor between this doc and the board. Short version: phase ordering, cross-issue decisions, and milestone-level acceptance live here. Issue state, per-issue acceptance, and dependencies live on the board.
+
+If a roadmap fact drifts between this doc and an issue, *this doc wins*.
+
+---
+
+## Active milestone: General Availability
+
+[Milestone 4 · due 2026-05-31](https://github.com/brockamer/findajob/milestone/4) — open issues assigned to the milestone are the execution units; find them via the milestone page.
+
+**Goal.** A second person (Alice Doe, the first external tester) runs the pipeline independently in a different field. Config layer fully externalized, user docs written, onboarding flow exists.
+
+**Milestone-level acceptance** (all must hold to close):
+
+1. External tester is deriving daily utility — not merely testing.
+2. Her data survives code updates with zero admin action on her part.
+3. Web frontend has retired Sheets reads (Dashboard/Applied/Review/Waitlist), writes (STATUS/REJECT_REASON), manual JD ingest, and Google Drive materials viewing.
+4. Apply-gate stayed met on average during the arc (daily applies ≥ 1/day averaged across any 7-day window).
+
+### Phase arc
+
+```
+Phase 1 (shipped)          Config externalization + frontend evaluation
+Phase 2 (shipped)          Docker migration + release management
+Phase 2.5                  v0.1.0 tag cut (48h dogfood gate)
+Phase 3                    Web materials viewer (retires rclone + Drive)
+Phase 4                    First-tester deployment (needs onboarding interview)
+Phase 5                    Remaining web-frontend sub-phases:
+                             read-only views → STATUS/REJECT workflows →
+                             manual JD ingest → stats/trends
+Phase 6 (parallel w/ 5)    User-facing documentation (split per area)
+```
+
+Phase ordering is deliberate — see Decisions 8 (Phase 3 before Phase 4) and 11 (onboarding interview critical path to Phase 4).
+
+### Decisions
+
+Append-only. Numbers are stable references. Amend an entry in place only for factual corrections (renamed file, etc.); supersede with a new entry otherwise.
+
+1. **rclone replacement — tabled.** Accepted pending the Phase 3 materials viewer, which retires the rclone layer entirely. No tactical hardening pass in the interim.
+2. **Beta-tester deployment workflow — image-pull cycle.** Bind-mounted `state/` subtree for data, image pulls for code. Operator's Claude Code session (on his laptop, SSHed into `docker.lan`) runs `docker compose pull && docker compose up -d` for each stack. Tester data never at risk from updates.
+3. **Auth — Wireguard perimeter only.** No session auth in the app, no TLS code, no public exposure. See [`deployment-model.md`](deployment-model.md) for topology.
+4. **Timeline — 3–5 weeks full arc.** Contingent on: scope holds, apply-gate stays met daily, no surprise complexity in the `poll_flags.py` pivot (the cross-cutting sub-phase of Phase 5).
+5. **Phase 1 parallelizes** via `superpowers:dispatching-parallel-agents` + ralph-loop (mechanical config-externalization work) + `frontend-design` (Phase 5 viewer).
+6. **Registry + image-tagging:** GHCR. `:main-<sha>` on merge, `:latest` floating, `:v<x.y.z>` on git tag, plus moving alias `:v0.1` repointed on each patch. Testers pin to the minor alias, auto-accept patches; operator dogfoods `:latest`.
+7. **Release ownership:** Claude orchestrates releases (tagging, CHANGELOG, notes, migration markers, dogfood verification); user reviews and approves. See [`release-process.md`](release-process.md).
+8. **Phase reorder — Phase 3 before Phase 4.** Shipping a beta tester without materials access was a fake win. The web materials viewer was promoted to Phase 3 so the tester's first pull has working materials access with zero rclone on her side. Operator keeps rclone through the Docker migration (env-var gated) — deleted when Phase 3 lands.
+9. **aichat-ng build strategy:** pull prebuilt musl binary from `blob42/aichat-ng` GitHub Releases pinned to a tag; no Rust toolchain in image. Fallback to source build is a one-line change if the fork goes stale.
+10. **Scheduler inside container:** `supercronic` running a crontab that mirrors the old systemd timers 1:1. Timezone set per instance via `TZ=America/Los_Angeles`. On-demand scripts via `docker compose exec`.
+11. **Onboarding interview — Phase 4 prerequisite.** Hand-curating a second tester's candidate config is untenable; the interview is critical path to Phase 4.
+12. **v0.1.0 dogfood gate discipline:** during the 48h observation on `:latest`, any merge to `main` restarts the clock. Phase 3 + Phase 4 work happens on unmerged branches.
+13. **User-facing documentation — split planned.** The umbrella scope is too broad for one issue. Plan: three focused issues, each paired with the shipping work that makes the doc concrete — (a) day-1 Dashboard usage guide paired with Phase 4 tester deploy, (b) tuning guide paired with first feedback-calibration cycle, (c) troubleshooting guide paired with first real tester failure.
+
+### Scope out (explicit)
+
+- Public web access / app-level auth (follow-up if demand materializes).
+- Separate rclone-replacement project.
+- Manual RAG source document editing.
+- Alternative LLM provider exploration.
+
+---
+
+## Future milestones
+
+- [Reliable Materials](https://github.com/brockamer/findajob/milestone/1) — no due date set; narrative stays on the milestone page until it becomes active.
+- [Expanded Coverage](https://github.com/brockamer/findajob/milestone/2) — no due date set.
+
+When one of these activates, add a `## Active milestone: <name>` section with the same shape (goal, acceptance, phase arc, decisions, scope-out). Move the outgoing milestone's section to `## Shipped milestones` below — or archive to a dated file if this page grows long.
+
+---
+
+## Conventions
+
+- **One active milestone at a time** gets a full `## Active milestone` section.
+- **Phases are a narrative layer on top of issues.** An issue can belong to exactly one phase; a phase is a group of issues that ship together or in close sequence.
+- **Issue numbers are not embedded in the phase arc** — they drift. Look up execution units via the milestone page.
+- **Decision log is append-only.** Numbers are stable references.
+- **Close the meta-issue** that originally held this narrative with a pointer here. The meta-issue was scaffolding for the doc, not a work item.


### PR DESCRIPTION
## Summary

Extract the Milestone 4 / General Availability phase narrative out of issue #58 (a roadmap-shaped meta-issue) into a dedicated `docs/roadmap.md`. Codify the board-vs-roadmap division of labor in `docs/project-board.md` so drift is bounded.

## Why a doc (not everything on the board)

Industry-standard SWE practice for OSS: board = execution state, roadmap doc = phase narrative + cross-issue decisions. GitHub Projects v2 has no narrative surface; milestones hold one description field. Decisions like "Phase 3 before Phase 4" span many issues and need persistence past an individual issue's close.

Drift is the failure mode, not the split itself. Guardrails:

1. **Single source of truth per fact type** — table in `docs/project-board.md` names the canonical home for each.
2. **Jared roadmap-drift sweep check** (added in separate claude-skills change) scans issue bodies for language that restates or contradicts the roadmap.
3. **Phase arc drops inline issue numbers** — those drift as issues get renumbered / split / obsolete. Look up execution units via the milestone page.

## Changes

- **`docs/roadmap.md` (new)** — Goal, milestone-level acceptance, phase arc, 13-entry append-only decision log, scope-out, conventions for future milestones.
- **`docs/project-board.md`** — Opening paragraph revised to name the split; new "Division of labor" section with a table naming canonical homes and win-on-conflict rules.

## Follow-ups (out of this PR)

- Close #58 with a pointer to `docs/roadmap.md`.
- Convert #20 to an epic via native sub-issues of #82 and #100.
- Set Status on #100 (Up Next top), #101 (Backlog), #102 (Backlog).
- Update jared skill in claude-skills repo with the roadmap-drift sweep check (already drafted locally).

## Test plan

- [x] `docs/roadmap.md` renders correctly
- [x] `docs/project-board.md` opens with the revised single-source-of-truth framing
- [x] No inline issue numbers in the phase arc (stability check)
- [ ] After merge: #58 closed with pointer; jared drift-scan check lands in claude-skills repo