### PR TITLE
Docker: fix aichat-ng mount path + add HOME/rclone (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ### Fixed
 - `claude:*` roles (resume_tailor, cover_letter_writer, briefing_writer, outreach_drafter) failing silently when `models-override.yaml` was stale or missing required Anthropic flags — image now ships a bundled baseline catalog (#106)
+- Fresh Docker installs hitting silent scoring outage from day one: aichat-ng config was mounted at `/root/.config/aichat_ng` (unreadable under non-root PUID) and `HOME` was unset in the container environment. `ops/compose.yaml.example` now mounts `./state/aichat_ng` at `/app/.config/aichat_ng`, adds `HOME: /app` to both services' env, and adds a new `./state/rclone:/app/.config/rclone` mount so jobsync state persists across container recreation. `ops/entrypoint.sh` chown loop de-duped (hardcoded `/root/.config/aichat_ng` removed; now redundant with `$AICHAT_CFG_DIR`). `ops/stack.env.example` documents `FINDAJOB_JOBSYNC_REMOTE` with an example value. `docs/setup/install-docker.md` has a "Migrating from an older image" section for existing instances (#100)
 
 ### Changed
 - Release process: dogfood gate suspended until the first external tester is deployed on a pinned `:vX.Y` tag. Pre-tag requirement drops to a 24h smoke check (no tracebacks, at least one `pipeline_complete`). Full 48h six-signal gate preserved in file history for reactivation later.

--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -22,7 +22,7 @@ See [configure.md](configure.md). API keys and personal config end up in `state/
 
 ```bash
 # On the Docker host
-sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng}
+sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng,rclone}
 sudo chown -R $(id -u):$(id -g) /opt/stacks/findajob-<you>/
 ```
 
@@ -96,6 +96,52 @@ Before running `docker compose pull && docker compose up -d`:
    Or click **Pull** + **Deploy** in Dockge.
 
 The "Action required" section is driven by PRs labeled `migration-required` (see [`docs/release-process.md`](../release-process.md) for the criteria). If a release has no such PRs in its range, the section won't appear.
+
+## Migrating from an older image: aichat-ng / rclone mount paths
+
+If your stack was deployed before the aichat-ng mount-path fix, your `compose.yaml` still mounts `./state/aichat_ng` to `/root/.config/aichat_ng`. The container now runs as a non-root user (PUID), so `/root` is unreadable and all scoring calls fail silently. You also need a new `rclone` mount and a `HOME=/app` env var.
+
+Apply these changes once, per instance:
+
+1. **Stop the stack.**
+   ```bash
+   cd /opt/stacks/findajob-<you>/
+   docker compose down
+   ```
+
+2. **Create the new `state/rclone/` bind-mount directory.**
+   ```bash
+   mkdir -p state/rclone
+   sudo chown $(id -u):$(id -g) state/rclone
+   ```
+
+3. **Edit `compose.yaml`** (or re-pull `ops/compose.yaml.example` if you haven't customized it). Three changes to the `scheduler` service:
+
+   - Under `environment:`, add `HOME: /app`.
+   - Change the aichat-ng volume from `./state/aichat_ng:/root/.config/aichat_ng` to `./state/aichat_ng:/app/.config/aichat_ng`.
+   - Add a new volume: `./state/rclone:/app/.config/rclone`.
+
+   Apply the same `HOME: /app` change to the `gmail-auth` service.
+
+4. **Fix ownership of `state/aichat_ng/`** in case it was populated under the old path:
+   ```bash
+   sudo chown -R $(id -u):$(id -g) state/aichat_ng
+   ```
+
+5. **Pull and bring the stack back up.**
+   ```bash
+   docker compose pull
+   docker compose up -d
+   docker compose logs -f scheduler  # Ctrl-C once you see supercronic's schedule dump
+   ```
+
+6. **(If using jobsync)** Re-run `docker compose exec scheduler rclone config` so the rclone remote lands in `/app/.config/rclone/rclone.conf` (the new persistent location).
+
+Verify with a scoring smoke test:
+```bash
+docker compose exec scheduler aichat-ng -m claude:claude-sonnet-4-6 -- 'reply "ok"'
+```
+Expected output: `ok`. If aichat-ng errors with "no such file or directory" or returns nothing, the config is still in the old location — re-check the mount path.
 
 ## Rolling back locally
 

--- a/ops/compose.yaml.example
+++ b/ops/compose.yaml.example
@@ -13,6 +13,7 @@ services:
       TZ: ${FINDAJOB_TZ:-America/New_York}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
+      HOME: /app
       JSP_BASE: /app
       FINDAJOB_JOBSYNC_ENABLED: ${FINDAJOB_JOBSYNC_ENABLED:-false}
       FINDAJOB_TRIAGE_TIMEOUT: ${FINDAJOB_TRIAGE_TIMEOUT:-7200}
@@ -22,7 +23,8 @@ services:
       - ./state/candidate_context:/app/candidate_context
       - ./state/companies:/app/companies
       - ./state/logs:/app/logs
-      - ./state/aichat_ng:/root/.config/aichat_ng
+      - ./state/aichat_ng:/app/.config/aichat_ng
+      - ./state/rclone:/app/.config/rclone
     networks:
       - findajob-network
 
@@ -34,6 +36,7 @@ services:
       TZ: ${FINDAJOB_TZ:-America/New_York}
       PUID: ${PUID:-1000}
       PGID: ${PGID:-1000}
+      HOME: /app
       JSP_BASE: /app
     volumes:
       - ./state/config:/app/config

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -56,7 +56,7 @@ if [ -d /opt/findajob/bundled-aichat ] && [ ! -f "$AICHAT_CFG_DIR/models-overrid
 fi
 
 # --- 3. Chown writable dirs if ownership doesn't already match -----------
-for dir in /app/data /app/logs /app/companies /app/config /app/candidate_context /root/.config/aichat_ng "$AICHAT_CFG_DIR"; do
+for dir in /app/data /app/logs /app/companies /app/config /app/candidate_context /app/.config/rclone "$AICHAT_CFG_DIR"; do
     if [ -d "$dir" ]; then
         current_owner="$(stat -c %u "$dir" 2>/dev/null || echo 0)"
         if [ "$current_owner" != "$PUID" ]; then

--- a/ops/stack.env.example
+++ b/ops/stack.env.example
@@ -23,9 +23,15 @@ PGID=1000
 # Google Drive sync via rclone. Disabled by default — #59 makes this
 # obsolete once the web materials viewer ships.
 #
-# If true: set FINDAJOB_JOBSYNC_REMOTE in state/data/.env (e.g.,
-# gdrive:01 PROJECTS/Jobs To Apply For) and ensure state/aichat_ng/
-# (shared with rclone config dir) has your rclone remote configured.
+# If true:
+#   1. Configure an rclone remote inside the container so its config
+#      lands in the bind-mount:
+#        docker compose exec scheduler rclone config
+#      Files are written to /app/.config/rclone/rclone.conf, which
+#      persists across container restarts via the state/rclone/ mount.
+#   2. Set FINDAJOB_JOBSYNC_REMOTE in state/data/.env to the remote
+#      + path where job folders should land. Example:
+#        FINDAJOB_JOBSYNC_REMOTE=gdrive:01 PROJECTS/Jobs To Apply For
 FINDAJOB_JOBSYNC_ENABLED=false
 
 # Triage timeout in seconds. Default 7200 (2h) is generous for steady


### PR DESCRIPTION
## Summary

- Fixes the silent day-one scoring outage on fresh Docker installs: `aichat-ng` was mounted at `/root/.config/aichat_ng` (unreadable under non-root PUID) with no `HOME` env set.
- Adds a persistent `state/rclone/` bind mount so jobsync config survives container recreation.
- Brings `ops/` tracked files into alignment with what the operator's live `docker.lan` instance has already been running.

Applies the fix diagnosed in #100 on 2026-04-19 and applied live; tracked files were lagging until now.

## What changed

- `ops/compose.yaml.example`: `HOME=/app` added to both services; aichat mount rebound to `/app/.config/aichat_ng`; new `./state/rclone:/app/.config/rclone` mount.
- `ops/entrypoint.sh`: chown loop de-duped (hardcoded `/root/.config/aichat_ng` removed — redundant with `$AICHAT_CFG_DIR`), adds `/app/.config/rclone`.
- `ops/stack.env.example`: documents `docker compose exec scheduler rclone config` as the setup path and shows an example `FINDAJOB_JOBSYNC_REMOTE` value.
- `docs/setup/install-docker.md`: step 1 mkdir list includes `rclone`; new "Migrating from an older image" section walks existing operators through the edit.
- `CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Impact on recent #106/#107 aichat-ng bundling fix

Safe. The seed mechanism in `entrypoint.sh` (lines 52–56) is untouched. `$AICHAT_CFG_DIR` still resolves via `${HOME:-/root}/.config/aichat_ng`. With `HOME=/app` now set explicitly, both the seed and the chown target land at `/app/.config/aichat_ng`, matching the bind mount. On `docker.lan`, the models-override.yaml already exists in that bind mount, so the seed is a no-op — verified last session.

## Migration required

Existing installs must stop the stack, create `state/rclone/`, edit `compose.yaml` (three changes to the `scheduler` service, one to `gmail-auth`), then pull + up. Walkthrough in the new "Migrating from an older image" section of the install guide.

The `migration-required` label on this PR surfaces it in the next release's "⚠️ Action required before upgrade" section per `docs/release-process.md`.

## Closes

- #100 — Docker: aichat-ng config unreachable under non-root PUID; missing HOME and rclone mount

## Test plan

- [ ] CI smoke (docker-build-smoke job in `ci.yml`) — build succeeds with the edited entrypoint.
- [ ] Dry-run the migration steps against a scratch stack dir on `docker.lan` (not necessary on the live instance — it's already been manually patched to match).
- [ ] Post-merge: next `:latest` pull on `docker.lan` should be a no-op behaviorally (mount already aligned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)