### PR TITLE
Release v0.1.0: CHANGELOG [Unreleased] → [0.1.0] — 2026-04-20 (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
-### Added
-- `docs/release-process.md` — Claude-facing release orchestration runbook: 48h dogfood gate, CHANGELOG workflow, tag cut mechanics, post-tag verification, rollback (#69)
-- `docs/setup/install-docker.md` — full external-user Docker install + operations guide replacing the stub (#69)
-- `migration-required` GitHub label for PRs needing post-pull manual steps; auto-surfaced by `create-release.yml` in "Action required" section of release notes (#69)
-- `CLAUDE.md` "Release Management" subsection pointing future sessions at the runbook (#69)
-- `ops/aichat-ng/models-override.yaml` bundled into image at `/opt/findajob/bundled-aichat/`; entrypoint seeds it into `$HOME/.config/aichat_ng/` on first start when no catalog is present. Fresh installs get a known-good model catalog with `require_max_tokens: true` on Anthropic models so `claude:*` roles work out of the box (#106)
-
-### Fixed
-- `claude:*` roles (resume_tailor, cover_letter_writer, briefing_writer, outreach_drafter) failing silently when `models-override.yaml` was stale or missing required Anthropic flags — image now ships a bundled baseline catalog (#106)
-- Fresh Docker installs hitting silent scoring outage from day one: aichat-ng config was mounted at `/root/.config/aichat_ng` (unreadable under non-root PUID) and `HOME` was unset in the container environment. `ops/compose.yaml.example` now mounts `./state/aichat_ng` at `/app/.config/aichat_ng`, adds `HOME: /app` to both services' env, and adds a new `./state/rclone:/app/.config/rclone` mount so jobsync state persists across container recreation. `ops/entrypoint.sh` chown loop de-duped (hardcoded `/root/.config/aichat_ng` removed; now redundant with `$AICHAT_CFG_DIR`). `ops/stack.env.example` documents `FINDAJOB_JOBSYNC_REMOTE` with an example value. `docs/setup/install-docker.md` has a "Migrating from an older image" section for existing instances (#100)
-- Pre-tag smoke check command in `docs/release-process.md` was grepping `docker compose logs` for `pipeline_complete`, but `log_event()` writes only to `logs/pipeline.jsonl` — so the check could never succeed. Replaced with an `awk` read against the bind-mounted jsonl file (#111)
-
-### Changed
-- `ops/crontab` scoreboard line commented out: `notify.py scoreboard` depends on the `gh` CLI which is not in the image, producing a weekly Monday 08:30 PT traceback on every stack. Restoration tracked in #112 (REST API rewrite + env gate). No user-visible feature loss — the scoreboard updates a maintainer-only pinned issue on the operator's project repo (#111).
-- Release process: dogfood gate suspended until the first external tester is deployed on a pinned `:vX.Y` tag. Pre-tag requirement drops to a 24h smoke check (no tracebacks, at least one `pipeline_complete`). Full 48h six-signal gate preserved in file history for reactivation later.
-- Maintainer platform migrated from Proxmox LXC (`findajob.lan`) to Docker host (`docker.lan`). All release-process runbook SSH commands now target `docker.lan`. Old LXC entry moved to `CLAUDE.local.md` §Archived Platforms.
-
-## [0.1.0] — TBD
+## [0.1.0] — 2026-04-20
 
 First containerized release. Ships the pipeline as a Docker image pulled
 from GHCR and deployed via Docker Compose on a shared Docker host.
@@ -44,22 +27,33 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
   - `build-image.yml` — push to GHCR on `main` and on `v*.*.*` tags (#13)
   - `create-release.yml` — auto-generated release notes on tag push (#13)
   - `docker-build-smoke` job in `ci.yml` — image smoke tests on every push (#13)
-- `docs/setup/install-docker.md` — install guide stub (full guide in #69) (#13)
+- `docs/release-process.md` — Claude-facing release orchestration runbook: dogfood gate (now suspended, see Changed), CHANGELOG workflow, tag cut mechanics, post-tag verification, rollback (#69)
+- `docs/setup/install-docker.md` — full external-user Docker install + operations guide replacing the stub (#13, #69)
+- `migration-required` GitHub label for PRs needing post-pull manual steps; auto-surfaced by `create-release.yml` in "Action required" section of release notes (#69)
+- `CLAUDE.md` "Release Management" subsection pointing future sessions at the runbook (#69)
+- `ops/aichat-ng/models-override.yaml` bundled into image at `/opt/findajob/bundled-aichat/`; entrypoint seeds it into `$HOME/.config/aichat_ng/` on first start when no catalog is present. Fresh installs get a known-good model catalog with `require_max_tokens: true` on Anthropic models so `claude:*` roles work out of the box (#106)
+
+### Fixed
+- `claude:*` roles (resume_tailor, cover_letter_writer, briefing_writer, outreach_drafter) failing silently when `models-override.yaml` was stale or missing required Anthropic flags — image now ships a bundled baseline catalog (#106)
+- Fresh Docker installs hitting silent scoring outage from day one: aichat-ng config was mounted at `/root/.config/aichat_ng` (unreadable under non-root PUID) and `HOME` was unset in the container environment. `ops/compose.yaml.example` now mounts `./state/aichat_ng` at `/app/.config/aichat_ng`, adds `HOME: /app` to both services' env, and adds a new `./state/rclone:/app/.config/rclone` mount so jobsync state persists across container recreation. `ops/entrypoint.sh` chown loop de-duped (hardcoded `/root/.config/aichat_ng` removed; now redundant with `$AICHAT_CFG_DIR`). `ops/stack.env.example` documents `FINDAJOB_JOBSYNC_REMOTE` with an example value. `docs/setup/install-docker.md` has a "Migrating from an older image" section for existing instances (#100)
+- Pre-tag smoke check command in `docs/release-process.md` was grepping `docker compose logs` for `pipeline_complete`, but `log_event()` writes only to `logs/pipeline.jsonl` — so the check could never succeed. Replaced with an `awk` read against the bind-mounted jsonl file (#111)
 
 ### Changed
-- Deployment target: Linux host running Docker. Native systemd install remains
-  documented as a fallback but Docker Compose is the recommended path. (#13)
+- Deployment target: Linux host running Docker. Native systemd install remains documented as a fallback but Docker Compose is the recommended path (#13)
+- `ops/crontab` scoreboard line commented out: `notify.py scoreboard` depends on the `gh` CLI which is not in the image, producing a weekly Monday 08:30 PT traceback on every stack. Restoration tracked in #112 (REST API rewrite + env gate). No user-visible feature loss — the scoreboard updates a maintainer-only pinned issue on the operator's project repo (#111)
+- Release process: dogfood gate suspended until the first external tester is deployed on a pinned `:vX.Y` tag. Pre-tag requirement drops to a 24h smoke check (no tracebacks, at least one `pipeline_complete`). Full 48h six-signal gate preserved in file history for reactivation later
+- Maintainer platform migrated from Proxmox LXC (`findajob.lan`) to Docker host (`docker.lan`). All release-process runbook SSH commands now target `docker.lan`
 
 ### Deprecated
 - systemd user services for the pipeline scheduler — replaced by supercronic
   inside the container. Existing systemd units stay archived on the maintainer's
-  LXC during the observation window. (#13)
+  LXC during the observation window (#13)
 
 ### Notes
 - Release management process is documented in `docs/release-process.md` and
-  followed for this cut (#69).
+  followed for this cut (#69)
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
-  `blob42/aichat-ng` — is tracked in #70.
+  `blob42/aichat-ng` — is tracked in #70
 
 [Unreleased]: https://github.com/brockamer/findajob/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/brockamer/findajob/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Per `docs/release-process.md` §"CHANGELOG workflow", Step 5 of the v0.1.0 tag cut (#111): move the `[Unreleased]` entries into `[0.1.0]`, set the release date, reset `[Unreleased]` to empty.

## Change detail

- Merges all pending `[Unreleased]` entries (from #69, #100, #106, #111) into the existing `[0.1.0]` block, which was pre-populated with #13 content when the containerization work landed in the previous cycle.
- Sets date: `## [0.1.0] — 2026-04-20`.
- Resets `## [Unreleased]` to an empty block at the top (future changes land there).
- Cross-reference links at the bottom of the file are unchanged — `[0.1.0]` already pointed to the soon-to-exist tag URL.

## Why this is a PR, not a direct push

Release-process convention: this commit is what the tag points at. Landing via PR keeps CI coverage on the final pre-tag commit, matches the convention codified in `feedback_release_management.md`, and gives the next step (`git tag v0.1.0`) a clean, reviewed commit to anchor on.

## Test plan

- [ ] CI green (ruff, mypy, pytest, docker-build-smoke)
- [ ] After merge, confirm `:latest` rebuilds off the merge commit before tag push
- [ ] Tag `v0.1.0` applied to the merge commit; `:v0.1.0` / `:v0.1` / `:latest` all rebuild off same sha

Closes nothing — this PR is a dependency of #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)