### PR TITLE
v0.1.1 PR1: schema layer (init_db in entrypoint + fold migrations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+
+- Entrypoint now runs `init_db.py` on every container start so fresh deploys don't crash on first triage's `SELECT FROM jobs` (#116).
+- `init_db.py` now carries `cost_log.input_tokens`, `cost_log.output_tokens`, `cost_log.cost_usd`, and `jobs.user_notes` columns that previously lived only in one-shot migration scripts (#117). Fresh deploys no longer crash mid-scoring or on Applied-tab user-notes sync.
+
 ## [0.1.0] — 2026-04-20
 
 First containerized release. Ships the pipeline as a Docker image pulled

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -65,5 +65,12 @@ for dir in /app/data /app/logs /app/companies /app/config /app/candidate_context
     fi
 done
 
+# --- 3b. Initialize DB schema (idempotent) --------------------------------
+# CREATE TABLE IF NOT EXISTS so re-runs on populated DBs are no-ops.
+# Runs as $PUID:$PGID so the resulting pipeline.db is owned correctly.
+if [ -w /app/data ]; then
+    gosu "$PUID:$PGID" python3 /app/scripts/init_db.py >/dev/null
+fi
+
 # --- 4. Drop privileges and exec the command ------------------------------
 exec gosu "$PUID:$PGID" "$@"

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     gdrive_folder_url TEXT,
     fit_score REAL,
     probability_score REAL,
+    user_notes TEXT DEFAULT '',
 
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -77,6 +77,9 @@ CREATE TABLE IF NOT EXISTS cost_log (
     latency_ms INTEGER,
     success INTEGER DEFAULT 1,
     error_message TEXT,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cost_usd REAL,
     logged_at TEXT DEFAULT (datetime('now'))
 );
 

--- a/scripts/migrate_add_user_notes.py
+++ b/scripts/migrate_add_user_notes.py
@@ -5,6 +5,12 @@ Free-text field the user edits on the Applied tab; poll_flags.py syncs
 Applied sheet edits back to this column. Idempotent — ALTER TABLE ADD
 COLUMN IF NOT EXISTS via column-presence check.
 
+As of v0.1.1 this migration's column is folded into scripts/init_db.py.
+Fresh deploys get the column from init_db on first container start;
+this script is retained as a no-op for legacy stacks that were migrated
+at the time of user_notes landing. Safe to delete this file in v0.2.x
+once all known stacks have been verified on v0.1.1+.
+
 Usage:  python3 scripts/migrate_add_user_notes.py
 """
 

--- a/scripts/migrate_cost_log_columns.py
+++ b/scripts/migrate_cost_log_columns.py
@@ -7,6 +7,12 @@ new columns NULL until they're updated).
 
 Idempotent — safe to re-run.
 
+As of v0.1.1 this migration's columns are folded into scripts/init_db.py.
+Fresh deploys get the columns from init_db on first container start;
+this script is retained as a no-op for legacy stacks that were migrated
+at the time of #32 landing. Safe to delete this file in v0.2.x once all
+known stacks have been verified on v0.1.1+.
+
 Usage:  python3 scripts/migrate_cost_log_columns.py
 """
 

--- a/tests/test_init_db_schema.py
+++ b/tests/test_init_db_schema.py
@@ -8,6 +8,7 @@ When a one-shot migration is introduced (scripts/migrate_*.py), add a new
 test here asserting init_db.py covers its columns — otherwise fresh deploys
 will crash at the first production write to those columns.
 """
+
 from __future__ import annotations
 
 import os

--- a/tests/test_init_db_schema.py
+++ b/tests/test_init_db_schema.py
@@ -1,0 +1,61 @@
+"""Tests that init_db.py is the single source of truth for the SQLite schema.
+
+Each test creates a fresh DB via init_db.py, then asserts that every column
+written by production code (cost_tracking.log_call, poll_flags user_notes
+writes, etc.) exists on the freshly-initialized DB.
+
+When a one-shot migration is introduced (scripts/migrate_*.py), add a new
+test here asserting init_db.py covers its columns — otherwise fresh deploys
+will crash at the first production write to those columns.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fresh_db(tmp_path, monkeypatch):
+    """Run init_db.py against a scratch BASE and return the DB path."""
+    base = tmp_path / "repo"
+    (base / "data").mkdir(parents=True)
+    (base / "src" / "findajob").mkdir(parents=True)
+    # Provide a minimal findajob.paths module so init_db.py's import resolves.
+    (base / "src" / "findajob" / "__init__.py").write_text("")
+    (base / "src" / "findajob" / "paths.py").write_text(f'BASE = r"{base}"\n')
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(base / "src")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    init_db = repo_root / "scripts" / "init_db.py"
+
+    result = subprocess.run(
+        [sys.executable, str(init_db)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"init_db.py failed: {result.stderr}"
+    return base / "data" / "pipeline.db"
+
+
+def _columns(db_path: Path, table: str) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    finally:
+        conn.close()
+
+
+def test_cost_log_has_token_and_cost_columns(fresh_db):
+    """cost_tracking.log_call inserts into input_tokens, output_tokens, cost_usd."""
+    cols = _columns(fresh_db, "cost_log")
+    assert "input_tokens" in cols
+    assert "output_tokens" in cols
+    assert "cost_usd" in cols

--- a/tests/test_init_db_schema.py
+++ b/tests/test_init_db_schema.py
@@ -59,3 +59,9 @@ def test_cost_log_has_token_and_cost_columns(fresh_db):
     assert "input_tokens" in cols
     assert "output_tokens" in cols
     assert "cost_usd" in cols
+
+
+def test_jobs_has_user_notes_column(fresh_db):
+    """poll_flags.py writes to jobs.user_notes from Applied-tab sheet edits."""
+    cols = _columns(fresh_db, "jobs")
+    assert "user_notes" in cols


### PR DESCRIPTION
## Summary

- Entrypoint runs `init_db.py` on every container start (#116)
- Fold `migrate_cost_log_columns.py` and `migrate_add_user_notes.py` column adds into `init_db.py` (#117)
- Legacy migration docstrings note the fold; both remain idempotent no-ops
- New test module `tests/test_init_db_schema.py` asserts init_db.py is the schema single source of truth

Part of #120 (v0.1.1 umbrella). Unblocks the first external tester's deploy (#82).

## Test plan

- [x] `pytest tests/test_init_db_schema.py -v` — all green on branch
- [ ] CI green on the PR
- [ ] Manual smoke: `docker build -t findajob:local . && docker run --rm -v /tmp/empty-data:/app/data findajob:local sh -c 'sqlite3 /app/data/pipeline.db ".tables"'` prints `audit_log duplicate_groups cost_log feedback_log jobs`

## Notes

Entrypoint integration coverage deferred to PR3's fresh-install smoke (#119); CI's existing docker-build-smoke job validates the container still starts with the edited entrypoint.

## Migration-required

No. Idempotent schema changes; existing operator stacks pull the new image and the additive entrypoint step is a no-op against their populated DBs.

Generated with [Claude Code](https://claude.com/claude-code)