### PR TITLE
v0.1.1 PR2: seed aichat-ng config.yaml + roles symlink (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 - Entrypoint now runs `init_db.py` on every container start so fresh deploys don't crash on first triage's `SELECT FROM jobs` (#116).
 - `init_db.py` now carries `cost_log.input_tokens`, `cost_log.output_tokens`, `cost_log.cost_usd`, and `jobs.user_notes` columns that previously lived only in one-shot migration scripts (#117). Fresh deploys no longer crash mid-scoring or on Applied-tab user-notes sync.
+- Entrypoint now seeds `aichat-ng config.yaml` from a sanitized template and creates the `roles` symlink on first container start (#118). Fresh deploys no longer fail every scoring subprocess with "Failed to load config.yaml."
 
 ## [0.1.0] — 2026-04-20
 

--- a/ops/aichat-ng/config.yaml.example
+++ b/ops/aichat-ng/config.yaml.example
@@ -1,0 +1,95 @@
+# aichat-ng config — seeded by ops/entrypoint.sh when state/aichat_ng/config.yaml
+# is absent. Re-pulling :v0.1.x will NOT overwrite your local edits; delete
+# the file first if you want to re-seed from this template.
+#
+# API keys come from state/data/.env via ${VAR} substitution that
+# aichat-ng performs at load time. Customize this file for operator-
+# specific settings (default model, keybindings, REPL prefs, custom
+# clients); never paste keys directly into the YAML.
+#
+# See https://github.com/sigoden/aichat/blob/main/config.example.yaml
+# for the full set of supported options.
+#
+# Note: the model catalog (pricing, token limits, thinking-mode flags)
+# lives in models-override.yaml, which entrypoint seeds separately.
+# Do NOT add a top-level `models:` block here or inline `models:` blocks
+# under existing clients — they will shadow models-override.yaml.
+
+model: gemini:gemini-3-flash-preview
+temperature: 0
+rag_embedding_model: gemini-embed:gemini-embedding-001
+rag_reranker_model: null
+rag_top_k: 6
+rag_chunk_size: 1200
+rag_chunk_overlap: 200
+
+document_loaders:
+  docx: 'pandoc -f docx -t plain $1'
+  pdf:  'pdftotext $1 -'
+
+function_calling: false
+
+# Roles are loaded from /app/config/roles (seeded by the image entrypoint);
+# ops/entrypoint.sh also creates the expected symlink at
+# $AICHAT_CFG_DIR/roles -> /app/config/roles on first container start.
+
+clients:
+  - type: openai
+    api_key: ${OPENAI_API_KEY}
+
+  - type: claude
+    api_base: https://api.anthropic.com/v1
+    api_key: ${ANTHROPIC_API_KEY}
+
+  - type: gemini
+    api_base: https://generativelanguage.googleapis.com/v1beta
+    api_key: ${GOOGLE_API_KEY}
+    # Disable content filters so the pipeline can score job postings that
+    # mention sensitive topics (harassment lawsuits, safety incidents, etc.)
+    # without silent blocks.
+    patch:
+      chat_completions:
+        '.*':
+          body:
+            safetySettings:
+              - category: HARM_CATEGORY_HARASSMENT
+                threshold: BLOCK_NONE
+              - category: HARM_CATEGORY_HATE_SPEECH
+                threshold: BLOCK_NONE
+              - category: HARM_CATEGORY_SEXUALLY_EXPLICIT
+                threshold: BLOCK_NONE
+              - category: HARM_CATEGORY_DANGEROUS_CONTENT
+                threshold: BLOCK_NONE
+
+  # gemini-embed: embedding endpoint. models-override.yaml ships
+  # text-embedding-004 under the gemini provider, but the pipeline uses
+  # gemini-embedding-001 — declare it inline so the catalog knows about it.
+  - type: gemini
+    name: gemini-embed
+    api_base: https://generativelanguage.googleapis.com/v1beta
+    api_key: ${GOOGLE_API_KEY}
+    models:
+      - name: gemini-embedding-001
+        type: embedding
+        default_chunk_size: 1500
+        max_batch_size: 100
+
+  - type: openai-compatible
+    name: openrouter
+    api_base: https://openrouter.ai/api/v1
+    api_key: ${OPENROUTER_API_KEY}
+
+  - type: openai-compatible
+    name: perplexity
+    api_base: https://api.perplexity.ai
+    api_key: ${PERPLEXITY_API_KEY}
+
+  - type: openai-compatible
+    name: groq
+    api_base: https://api.groq.com/openai/v1
+    api_key: ${GROQ_API_KEY}
+
+  - type: openai-compatible
+    name: xai
+    api_base: https://api.x.ai/v1
+    api_key: ${XAI_API_KEY}

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -43,16 +43,30 @@ if [ -d /opt/findajob/bundled-config ]; then
     cp -R /opt/findajob/bundled-config/. /app/config/
 fi
 
-# --- 2b. Seed bundled aichat-ng model catalog if missing ------------------
-# models-override.yaml gates which model flags (require_max_tokens, etc.)
-# apply to each provider. A stale/missing catalog breaks claude:* roles
-# silently. Ship a known-good baseline so fresh installs work out of the box.
-# Seed only if the target file is absent — preserves any user customizations
-# (custom models, pricing overrides) in an existing catalog.
+# --- 2b. Seed bundled aichat-ng config if missing -------------------------
+# models-override.yaml — always seeded if missing (owned by the project, not
+# the operator; catalog drift from the bundled version breaks claude:*
+# thinking modes silently).
+# config.yaml — seeded from config.yaml.example only if the destination is
+# absent. Operator customizations (custom model, added clients, REPL prefs)
+# survive container restarts; re-seeding would clobber them.
+# roles symlink — points at /app/config/roles (seeded by the image via
+# bundled-config, see section 2 above). Created only if not already present
+# as a symlink or real dir, so operators can override with their own dir.
 AICHAT_CFG_DIR="${HOME:-/root}/.config/aichat_ng"
-if [ -d /opt/findajob/bundled-aichat ] && [ ! -f "$AICHAT_CFG_DIR/models-override.yaml" ]; then
-    mkdir -p "$AICHAT_CFG_DIR"
-    cp -R /opt/findajob/bundled-aichat/. "$AICHAT_CFG_DIR/"
+mkdir -p "$AICHAT_CFG_DIR"
+
+if [ -d /opt/findajob/bundled-aichat ]; then
+    if [ ! -f "$AICHAT_CFG_DIR/models-override.yaml" ] && [ -f /opt/findajob/bundled-aichat/models-override.yaml ]; then
+        cp /opt/findajob/bundled-aichat/models-override.yaml "$AICHAT_CFG_DIR/models-override.yaml"
+    fi
+    if [ ! -f "$AICHAT_CFG_DIR/config.yaml" ] && [ -f /opt/findajob/bundled-aichat/config.yaml.example ]; then
+        cp /opt/findajob/bundled-aichat/config.yaml.example "$AICHAT_CFG_DIR/config.yaml"
+    fi
+fi
+
+if [ ! -e "$AICHAT_CFG_DIR/roles" ]; then
+    ln -s /app/config/roles "$AICHAT_CFG_DIR/roles"
 fi
 
 # --- 3. Chown writable dirs if ownership doesn't already match -----------

--- a/tests/test_aichat_config_template.py
+++ b/tests/test_aichat_config_template.py
@@ -1,0 +1,50 @@
+"""Tests for the aichat-ng config template shipped in ops/aichat-ng/.
+
+The template is YAML-valid and contains the client entries the pipeline
+expects (claude, openai, gemini, openrouter, perplexity). We can't run
+aichat-ng against the template itself (no API keys loaded at test time),
+but we can assert structure so a future edit doesn't accidentally break
+parseability.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPO = Path(__file__).resolve().parents[1]
+TEMPLATE = REPO / "ops" / "aichat-ng" / "config.yaml.example"
+
+
+def test_template_parses_as_yaml():
+    assert TEMPLATE.exists(), f"template not at {TEMPLATE}"
+    data = yaml.safe_load(TEMPLATE.read_text())
+    assert isinstance(data, dict)
+
+
+def test_template_has_required_clients():
+    data = yaml.safe_load(TEMPLATE.read_text())
+    assert "clients" in data
+    # Clients are identified by explicit `name:` when present, otherwise
+    # aichat-ng falls back to the `type:` for the client name.
+    names = set()
+    for c in data["clients"]:
+        names.add(c.get("name") or c.get("type"))
+    # These are the clients the roles config actually invokes.
+    required = {"claude", "openai", "gemini", "openrouter", "perplexity"}
+    missing = required - names
+    assert not missing, f"template missing required clients: {missing}"
+
+
+def test_template_has_no_literal_keys():
+    text = TEMPLATE.read_text()
+    # API-key-shaped strings on an api_key line: `sk-...`, `pplx-...`,
+    # `xai-...`, `gsk_...`, `AIza...`, or 40+ alphanumeric chars.
+    suspicious = re.findall(
+        r"api_key:\s*(sk-[A-Za-z0-9_-]+|pplx-[A-Za-z0-9]+|xai-[A-Za-z0-9]+|"
+        r"gsk_[A-Za-z0-9]+|AIza[A-Za-z0-9_-]+|[A-Za-z0-9]{40,})",
+        text,
+    )
+    assert not suspicious, f"template contains literal keys: {suspicious}"

--- a/tests/test_aichat_config_template.py
+++ b/tests/test_aichat_config_template.py
@@ -6,13 +6,13 @@ aichat-ng against the template itself (no API keys loaded at test time),
 but we can assert structure so a future edit doesn't accidentally break
 parseability.
 """
+
 from __future__ import annotations
 
 import re
 from pathlib import Path
 
 import yaml
-
 
 REPO = Path(__file__).resolve().parents[1]
 TEMPLATE = REPO / "ops" / "aichat-ng" / "config.yaml.example"


### PR DESCRIPTION
## Summary

- New sanitized `ops/aichat-ng/config.yaml.example` template; API keys via `${VAR}` substitution from `state/data/.env`
- Existing `COPY ops/aichat-ng/` in Dockerfile already bundles the new template into `/opt/findajob/bundled-aichat/` alongside `models-override.yaml` (no Dockerfile change needed)
- `ops/entrypoint.sh` section 2b rewritten with per-file guards: seeds `config.yaml` on first start only if absent; creates `$AICHAT_CFG_DIR/roles -> /app/config/roles` symlink only if not already present. Previous wholesale `cp -R` was gated by `models-override.yaml` presence — on any stack with the catalog already present, config.yaml was never seeded
- Three unit tests assert template YAML validity, required client names, and absence of literal API keys

Part of #120. Unblocks Alice Doe's deploy (#82).

## Deviations from plan

Task 16's docker-run integration test (`tests/test_entrypoint_aichat_seed.py`) was intentionally skipped per the Option-C pattern used in PR1: this dev env has no docker, and CI's `lint-and-test` job doesn't build the image. End-to-end coverage for the seed/symlink/no-overwrite behaviors lands in PR3's fresh-install smoke (plan Task 22) where it has a real image to run against.

Task 14 sourced the operator's live config from `docker.lan` as a structural reference only and drew these calls against both the plan's template and the live file:
- **Kept** operator's inline `gemini-embed` `models:` block (declares `gemini-embedding-001`, not in `models-override.yaml`) — dropping it would break embeddings on fresh install.
- **Dropped** operator's inline `openai` `models:` block (`gpt-4o`, `gpt-5` — both in `models-override.yaml`; this was the violation `feedback_aichat_models_block` warns about).
- **Preserved** `document_loaders`, `function_calling: false`, `rag_*` settings, and the gemini `patch:` safetySettings block (content-filter disable is pipeline-required, not operator-pref).
- **Defaulted** `model: gemini:gemini-3-flash-preview` per CLAUDE.md pipeline table (not operator's personal `claude:claude-sonnet-4-6:thinking`).

## Test plan

- [x] `pytest tests/test_aichat_config_template.py -v` — 3/3 green (FAIL before template created, PASS after)
- [x] `pytest tests/` — full suite 453/453 green
- [x] `bash -n ops/entrypoint.sh` and `sh -n ops/entrypoint.sh` — syntax clean
- [x] `grep` of template for secret-shaped strings — no matches
- [ ] CI green on PR (lint-and-test + docker-build-smoke)
- [ ] End-to-end: PR3 fresh-install smoke exercises seed + symlink on a real image

## Migration-required

No. Additive: existing operator stacks already have `config.yaml` in `state/aichat_ng/`, so the `[ ! -f "$AICHAT_CFG_DIR/config.yaml" ]` guard makes the seed a no-op for them. Same goes for the `roles` symlink — the `[ ! -e ]` guard leaves existing dirs/links alone.