### PR TITLE
v0.1.1 PR3: fresh-install smoke + release-process rewrite (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Changed
+
+- Pre-tag smoke check is now a fresh-install end-to-end test (empty bind mounts → documented install procedure → assert `scored > 0` and schema fold + aichat seed landed), not a 24h operator-stack observation window (#119). `docs/release-process.md` rewritten accordingly; the 48h dogfood gate is permanently retired for `v0.1.x`. Smoke is run locally on a docker-equipped host before each tag cut; CI wiring is deferred to a follow-up.
+
 ### Fixed
 
 - Entrypoint now runs `init_db.py` on every container start so fresh deploys don't crash on first triage's `SELECT FROM jobs` (#116).
 - `init_db.py` now carries `cost_log.input_tokens`, `cost_log.output_tokens`, `cost_log.cost_usd`, and `jobs.user_notes` columns that previously lived only in one-shot migration scripts (#117). Fresh deploys no longer crash mid-scoring or on Applied-tab user-notes sync.
 - Entrypoint now seeds `aichat-ng config.yaml` from a sanitized template and creates the `roles` symlink on first container start (#118). Fresh deploys no longer fail every scoring subprocess with "Failed to load config.yaml."
+- `scripts/test_container_integration.sh` was stubbing config "enough to bring the scheduler up without erroring on import" and thus missed the four fresh-install bugs that shipped in `v0.1.0`. Rewritten to exercise the full install → triage → `pipeline_complete` cycle with fictional fixtures ("Casey Example") (#119).
 
 ## [0.1.0] — 2026-04-20
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,11 +2,11 @@
 
 This is the runbook Claude follows when cutting a release of the findajob pipeline's
 Docker image. Claude orchestrates the release end-to-end — proposing the cut, drafting
-the CHANGELOG, running the pre-tag smoke check (the full dogfood gate is suspended —
-see §"Pre-tag smoke check"), writing notes, pushing the tag, verifying the outcome,
-and owning any rollback. The user reviews and approves the proposed cut but does
-not author any of the release artifacts. This split is codified in the
-`feedback_release_management.md` memory.
+the CHANGELOG, running the fresh-install pre-tag smoke check (see §"Pre-tag smoke
+check"), writing notes, pushing the tag, verifying the outcome, and owning any
+rollback. The user reviews and approves the proposed cut but does not author any
+of the release artifacts. This split is codified in the `feedback_release_management.md`
+memory.
 
 Two GitHub Actions workflows do the mechanical work once a tag is pushed.
 [`.github/workflows/build-image.yml`](../.github/workflows/build-image.yml) builds the
@@ -20,14 +20,15 @@ remain in place; if they change, update this doc in the same commit.
 ## Ownership
 
 Claude drives every release. That means proposing when to cut, drafting the CHANGELOG
-entries from the merged PRs in the range, running the pre-tag smoke check (the full
-48h dogfood gate is suspended — see §"Pre-tag smoke check"), flagging migration
-markers on PRs as they come in (or retroactively if a trigger was missed), writing
-the release notes content, executing `git tag` and `git push origin vX.Y.Z`, running
-post-tag verification against GitHub Actions and GHCR, and owning rollback if
-anything goes wrong. The user's role is review-only: they look at the proposed
-cut, confirm the smoke-check output, and approve or request changes. They
-do not write CHANGELOG bullets, author the notes, or run the tag commands. If the release breaks something, Claude owns the recovery.
+entries from the merged PRs in the range, running the fresh-install pre-tag smoke
+check (see §"Pre-tag smoke check"), flagging migration markers on PRs as they come
+in (or retroactively if a trigger was missed), writing the release notes content,
+executing `git tag` and `git push origin vX.Y.Z`, running post-tag verification
+against GitHub Actions and GHCR, and owning rollback if anything goes wrong. The
+user's role is review-only: they look at the proposed cut, confirm the smoke-check
+output, and approve or request changes. They do not write CHANGELOG bullets, author
+the notes, or run the tag commands. If the release breaks something, Claude owns
+the recovery.
 
 ## Version scheme
 
@@ -91,52 +92,56 @@ tag against `HEAD`, and each released version links to its tag page. If the late
 release added a new link and the previous `[Unreleased]` line wasn't updated to
 reference the new tag, the file is inconsistent — fix before cutting.
 
-## Pre-tag smoke check (dogfood gate suspended)
+## Pre-tag smoke check
 
-**Current status: suspended as of 2026-04-20.** The full 48h multi-signal dogfood
-gate is on hold until the first external tester is deployed on a pinned `:vX.Y`
-tag. Today there are zero external users on any tag — the gate would be forcing
-every `main` merge through a 48h window to protect users who don't exist yet.
-Reactivation trigger is at the bottom of this section.
+Before cutting any `v0.1.x` tag, the fresh-install smoke test must pass. The smoke
+test spins up a throwaway stack with **empty bind mounts**, runs the documented
+install procedure end-to-end, triggers `triage.py`, and asserts:
 
-Until reactivation, the pre-tag requirement is a lightweight smoke check: the
-maintainer's own `docker.lan` stack ran cleanly in the last 24 hours. Two
-commands, run from the dev laptop. First, set `STACK_DIR` to the absolute
-path of the maintainer's compose stack on docker.lan (operator's value
-lives in `CLAUDE.local.md`):
+1. `pipeline.jsonl` contains a `pipeline_complete` event with `scored > 0`
+2. `jobs` table has rows in stage `scored` or `manual_review`
+3. `cost_log` has rows (proves the #117 schema fold is working on fresh DBs)
+4. `/app/.config/aichat_ng/config.yaml` is present in the container (proves
+   the #118 entrypoint seed is working)
 
-```bash
-STACK_DIR=/opt/stacks/findajob-<your-tag>
-```
-
-**1. No tracebacks in the scheduler container's stdout/stderr over the last 24 hours:**
+Run locally on a docker-equipped host before proposing the tag. From the
+maintainer's dev laptop, the workflow is: build the image on `docker.lan` (or
+any docker-equipped host), then run the smoke script against it. Set
+`FINDAJOB_SMOKE_SHEET_ID` to the sheet ID the service account can write to
+(either the operator's existing test sheet or a dedicated smoke sheet):
 
 ```bash
-ssh docker.lan "docker compose -f $STACK_DIR/compose.yaml logs scheduler --since 24h" \
-  | grep -c Traceback
+# On docker.lan (or any host with docker + this repo checked out)
+cd /path/to/findajob
+docker build -t findajob:local .
+FINDAJOB_SMOKE_SHEET_ID=<sheet-id> FINDAJOB_TEST_IMAGE=findajob:local \
+  scripts/test_container_integration.sh
 ```
 
-Expected: `0`.
+The script takes 2–5 minutes (dominated by ~20 LLM scoring calls over the real
+network) and costs ≤$0.10 of API budget per run.
 
-**2. At least one `pipeline_complete` event written by `triage.py` in the last 24 hours.** `log_event()` writes to `/app/logs/pipeline.jsonl` (bind-mounted on docker.lan to `$STACK_DIR/state/logs/pipeline.jsonl`), not to stdout — so this check reads the jsonl file directly, not `docker compose logs`:
+**If the smoke is green on the commit you intend to tag, the gate is cleared
+and Claude may propose the cut.** No time window, no 24h/48h observation. A
+binary signal tied to what a fresh tester actually exercises.
 
-```bash
-ssh docker.lan "awk -v cutoff=\"\$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%S)\" \
-  '/\"event\": \"pipeline_complete\"/ { split(\$0, a, \"\\\"ts\\\": \\\"\"); split(a[2], b, \"\\\"\"); if (b[1] >= cutoff) print }' \
-  $STACK_DIR/state/logs/pipeline.jsonl | wc -l"
-```
+CI wiring for this smoke is deferred to a follow-up issue: the script depends
+on 9 live API keys + a writable Google Sheet, and wiring that into GitHub
+Actions is a meaningful security and ops decision orthogonal to the smoke
+itself. Until CI runs the smoke, Claude runs it locally before proposing each
+tag cut and reports the result to the user as part of the cut proposal.
 
-Expected: `≥1` (triage fires daily at 00:00 PT, so one event every 24h is the baseline).
+### Why no dogfood window
 
-If both pass, the gate is cleared and Claude may propose the cut.
-
-### When the gate reactivates
-
-As soon as any external user is deployed on a pinned `:v0.1` or `:v0.1.0` tag —
-Alice Doe (first external tester, #20), or any subsequent tester — re-read this
-section and rebuild the gate to match the signals that actually protect that
-user's experience. The six-signal, 48h-window version is preserved in git
-history (file revisions prior to 2026-04-20) as a starting draft.
+The previous gate observed the operator's own stack for 24–48h. That validated
+whether the operator's legacy state kept working; it did not validate whether
+a fresh deploy worked. Shipping v0.1.0 under that gate produced #115, #116,
+#117, #118 — four fresh-install bugs, none of which the operator's own stack
+could have surfaced. The gate was guarding users who didn't exist yet while
+letting real install bugs through. The fresh-install smoke catches the bug
+class that matters. The 48h gate is not coming back for v0.1.x; if future
+scale or multi-tenancy (see #71) requires a multi-signal time-window gate, it
+will be redesigned to observe external-user signals, not operator-stack ones.
 
 ## migration-required label criteria
 

--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -44,6 +44,30 @@ Edit `.env` to taste — at minimum set `FINDAJOB_TZ` and (if dogfooding) `FINDA
 - `state/config/*.yaml|.txt|.json` — personal config files. See [configure.md](configure.md) for each file's purpose.
 - `state/candidate_context/profile.md` + `master_resume.md` — your candidate profile. See [`candidate_context/profile.md.example`](https://github.com/brockamer/findajob/blob/main/candidate_context/profile.md.example).
 
+### What the entrypoint does automatically
+
+As of `:v0.1.1`, the container image's entrypoint handles these on every
+start — you do not run any of these commands manually:
+
+- Creates `state/data/pipeline.db` with the full schema if it's missing.
+  Idempotent: no-op on populated DBs (#116, #117).
+- Seeds `state/aichat_ng/config.yaml` from a sanitized template **only if
+  absent**. Your customizations (added clients, custom models, REPL prefs)
+  persist across image pulls (#118).
+- Seeds `state/aichat_ng/models-override.yaml` only if absent (#106).
+- Creates the `state/aichat_ng/roles` symlink pointing at the image's
+  bundled `/app/config/roles/` **only if absent** — so you can override
+  with your own roles dir (#118).
+- Seeds tracked config files (`roles/`, `scoring_schema.json`,
+  `model_pricing.yaml`, `reference.docx`, `strip-bookmarks.lua`) into
+  `state/config/` on every start — these are always overwritten so image
+  updates propagate on `docker compose up`. Your personal config files
+  (`sheet_id.txt`, `jsearch_queries.txt`, etc.) are left alone because
+  they don't exist in the bundled set.
+
+Fill in your personal config files above and run `docker compose up -d` —
+no manual schema init, no handcrafted aichat-ng config, no symlink setup.
+
 ## 4. Initial auth: Gmail (optional)
 
 ```bash

--- a/scripts/test_container_integration.sh
+++ b/scripts/test_container_integration.sh
@@ -1,113 +1,270 @@
 #!/bin/bash
 # scripts/test_container_integration.sh
 #
-# Local pre-release smoke test for the findajob container image.
-# Spins up a throwaway stack, runs each scheduled script once, asserts
-# no exceptions and sane DB state, then tears down.
+# v0.1.1+: Fresh-install smoke test for the findajob container image.
 #
-# Prerequisites:
-# - docker + docker compose on PATH
-# - A findajob image already built locally (findajob:local) OR pass via
-#   FINDAJOB_TEST_IMAGE env var
-# - data/.env from a working instance (copied into the throwaway stack)
+# Spins up a throwaway stack with EMPTY bind mounts, provides the minimum
+# realistic input (live API keys, a Google Sheet ID the service account can
+# write to, one fixture candidate profile), runs the full triage-to-
+# pipeline_complete cycle, and asserts a scored job lands in the DB. Proves
+# an external tester can go from "clone + configure" to working Dashboard
+# with no operator intervention.
+#
+# This is the pre-tag release gate. Claude runs it from a docker-equipped
+# host before proposing any v0.1.x tag cut. See docs/release-process.md
+# §"Pre-tag smoke check".
+#
+# Prereqs:
+# - docker + docker compose v2
+# - findajob image available locally as ${FINDAJOB_TEST_IMAGE:-findajob:local}
+#   (build with `docker build -t findajob:local .` from the repo root first)
+# - A real data/.env with live API keys — either at
+#   $HOME/.findajob/state/data/.env or ./data/.env
+# - FINDAJOB_SMOKE_SHEET_ID env var — a Google Sheet the service account
+#   can write to (reuse the operator's test sheet or a dedicated smoke sheet)
 #
 # Usage:
-#   FINDAJOB_TEST_IMAGE=findajob:local scripts/test_container_integration.sh
+#   FINDAJOB_SMOKE_SHEET_ID=<sheet-id> FINDAJOB_TEST_IMAGE=findajob:local \
+#     scripts/test_container_integration.sh
 #
-# Run this as part of the #69 release gate before tagging v0.1.N.
+# Expected runtime: 2–5 minutes (dominated by ~20 LLM scoring calls over
+# the real network). API budget: ≤$0.10 per run.
 
 set -euo pipefail
 
+# ────────────────────────────────────────────────────────────────────────────
+# 1. Resolve repo root + fixture paths
+# ────────────────────────────────────────────────────────────────────────────
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURES="$REPO_ROOT/tests/fixtures"
+
+for f in smoke_profile.md smoke_jsearch_queries.txt smoke_prefilter_rules.yaml \
+         smoke_in_domain_patterns.yaml smoke_companies_of_interest.txt; do
+    if [ ! -f "$FIXTURES/$f" ]; then
+        echo "ERROR: missing fixture $FIXTURES/$f" >&2
+        exit 2
+    fi
+done
+
+# ────────────────────────────────────────────────────────────────────────────
+# 2. Resolve env + config inputs
+# ────────────────────────────────────────────────────────────────────────────
+
 IMAGE="${FINDAJOB_TEST_IMAGE:-findajob:local}"
-STACK_DIR="$(mktemp -d -t findajob-test-XXXXXX)"
+
+if [ -z "${FINDAJOB_SMOKE_SHEET_ID:-}" ]; then
+    cat >&2 <<EOF
+ERROR: FINDAJOB_SMOKE_SHEET_ID env var is required.
+
+Set it to the Google Sheet ID the service account can write to — either
+the operator's existing test sheet or a dedicated smoke-test sheet.
+Example:
+
+  export FINDAJOB_SMOKE_SHEET_ID=1AbCdEfGhIjKlMnOpQrStUvWxYz
+  scripts/test_container_integration.sh
+EOF
+    exit 2
+fi
+
+# Source .env either from the operator's standard location or from the
+# working copy — same fallback the old script used.
+SRC_ENV=""
+if [ -f "$HOME/.findajob/state/data/.env" ]; then
+    SRC_ENV="$HOME/.findajob/state/data/.env"
+elif [ -f "$REPO_ROOT/data/.env" ]; then
+    SRC_ENV="$REPO_ROOT/data/.env"
+else
+    echo "ERROR: need data/.env with live API keys — either $HOME/.findajob/state/data/.env or $REPO_ROOT/data/.env" >&2
+    exit 2
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# 3. Lay down scratch stack dir with empty bind mounts
+# ────────────────────────────────────────────────────────────────────────────
+
+SCRATCH="$(mktemp -d -t findajob-smoke-XXXXXX)"
 cleanup() {
-    echo "[cleanup] tearing down stack at $STACK_DIR"
-    (cd "$STACK_DIR" && docker compose down -v 2>/dev/null || true)
-    rm -rf "$STACK_DIR"
+    echo "[cleanup] tearing down stack at $SCRATCH"
+    if [ -d "$SCRATCH" ] && [ -f "$SCRATCH/compose.yaml" ]; then
+        (cd "$SCRATCH" && docker compose down -v 2>/dev/null || true)
+    fi
+    rm -rf "$SCRATCH"
 }
 trap cleanup EXIT
 
-echo "[setup] stack dir: $STACK_DIR  image: $IMAGE"
+echo "[setup] scratch dir: $SCRATCH  image: $IMAGE"
 
-mkdir -p "$STACK_DIR/state"/{data,config,candidate_context,companies,logs,aichat_ng}
+mkdir -p "$SCRATCH/state"/{data,config,candidate_context,companies,logs,aichat_ng,rclone}
 
-# Copy user's real data/.env (API keys) — tests hit real LLM and API endpoints
-if [ ! -f "$HOME/.findajob/state/data/.env" ] && [ ! -f "${PWD}/data/.env" ]; then
-    echo "ERROR: need data/.env with API keys — either $HOME/.findajob/state/data/.env or ./data/.env" >&2
-    exit 2
-fi
-cp "${PWD}/data/.env" "$STACK_DIR/state/data/.env" 2>/dev/null \
-    || cp "$HOME/.findajob/state/data/.env" "$STACK_DIR/state/data/.env"
-chmod 600 "$STACK_DIR/state/data/.env"
+# ────────────────────────────────────────────────────────────────────────────
+# 4. Seed inputs into the bind mounts
+# ────────────────────────────────────────────────────────────────────────────
 
-# Minimal stub config — enough to bring the scheduler up without erroring on import
-cat > "$STACK_DIR/state/config/sheet_id.txt" <<'EOF'
-TEST_SHEET_ID_PLACEHOLDER
-EOF
+# API keys → state/data/.env (copied from live operator install)
+cp "$SRC_ENV" "$SCRATCH/state/data/.env"
+chmod 600 "$SCRATCH/state/data/.env"
 
-cat > "$STACK_DIR/state/candidate_context/profile.md" <<'EOF'
-# Test Profile
-Minimal stub for container integration testing.
-EOF
+# Google Sheet ID → state/config/sheet_id.txt
+echo "$FINDAJOB_SMOKE_SHEET_ID" > "$SCRATCH/state/config/sheet_id.txt"
 
-# Compose file pointing at the local image
-cat > "$STACK_DIR/compose.yaml" <<EOF
+# Candidate profile → state/candidate_context/profile.md
+cp "$FIXTURES/smoke_profile.md" "$SCRATCH/state/candidate_context/profile.md"
+
+# Scorer config files → state/config/
+cp "$FIXTURES/smoke_jsearch_queries.txt"       "$SCRATCH/state/config/jsearch_queries.txt"
+cp "$FIXTURES/smoke_prefilter_rules.yaml"      "$SCRATCH/state/config/prefilter_rules.yaml"
+cp "$FIXTURES/smoke_in_domain_patterns.yaml"   "$SCRATCH/state/config/in_domain_patterns.yaml"
+cp "$FIXTURES/smoke_companies_of_interest.txt" "$SCRATCH/state/config/companies_of_interest.txt"
+
+# Empty feed_urls.txt — smoke test drives jobs via RapidAPI queries only
+: > "$SCRATCH/state/config/feed_urls.txt"
+
+# ────────────────────────────────────────────────────────────────────────────
+# 5. Write compose.yaml — mirrors ops/compose.yaml.example, overrides image
+# ────────────────────────────────────────────────────────────────────────────
+
+cat > "$SCRATCH/compose.yaml" <<EOF
 services:
   scheduler:
     image: ${IMAGE}
     env_file: ./state/data/.env
     environment:
-      TZ: America/New_York
+      TZ: America/Los_Angeles
       PUID: $(id -u)
       PGID: $(id -g)
+      HOME: /app
       JSP_BASE: /app
       FINDAJOB_JOBSYNC_ENABLED: "false"
+      FINDAJOB_TRIAGE_TIMEOUT: "7200"
     volumes:
       - ./state/data:/app/data
       - ./state/config:/app/config
       - ./state/candidate_context:/app/candidate_context
       - ./state/companies:/app/companies
       - ./state/logs:/app/logs
-      - ./state/aichat_ng:/root/.config/aichat_ng
-    command: sleep infinity   # don't actually run cron; we exec scripts ourselves
+      - ./state/aichat_ng:/app/.config/aichat_ng
+      - ./state/rclone:/app/.config/rclone
 EOF
 
-echo "[start] bringing up stack"
-(cd "$STACK_DIR" && docker compose up -d)
+# ────────────────────────────────────────────────────────────────────────────
+# 6. Bring up the stack and wait for supercronic to load cleanly
+# ────────────────────────────────────────────────────────────────────────────
 
-EXEC="docker compose -f $STACK_DIR/compose.yaml exec -T scheduler"
+echo "[start] docker compose up -d"
+(cd "$SCRATCH" && docker compose up -d)
 
-echo "[init] creating scratch pipeline.db"
-$EXEC python3 /app/scripts/init_db.py
+EXEC="docker compose -f $SCRATCH/compose.yaml exec -T scheduler"
 
-echo "[test] python package imports"
-$EXEC python3 -c "import findajob; import findajob.paths; assert findajob.paths.BASE == '/app'"
-
-echo "[test] supercronic validates crontab"
-$EXEC supercronic -test /app/crontab
-
-echo "[test] aichat-ng executes"
-$EXEC aichat-ng --version
-
-echo "[test] notify.py health-check on empty state"
-$EXEC python3 /app/scripts/notify.py health-check || echo "[note] health-check may warn on empty DB — non-fatal"
-
-echo "[test] poll_flags.py dry run (Sheet is stub — expect a soft failure, not a Python crash)"
-set +e
-$EXEC python3 /app/scripts/poll_flags.py
-POLL_EXIT=$?
-set -e
-# Acceptable: 0 (if Sheet exists and is empty) or non-zero-with-clean-stderr.
-# Unacceptable: a Python traceback, which would indicate a packaging or path bug.
-echo "[test] poll_flags.py exit: $POLL_EXIT (traceback-free is the pass criterion)"
-
-echo "[test] DB has expected tables"
-TABLES=$($EXEC sqlite3 /app/data/pipeline.db ".tables")
-echo "Tables: $TABLES"
-for t in jobs audit_log feedback_log; do
-    echo "$TABLES" | grep -q "$t" || { echo "ERROR: missing table $t" >&2; exit 1; }
+echo "[wait] supercronic read crontab"
+DEADLINE=$(( $(date +%s) + 60 ))
+READ_CRONTAB=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+    if (cd "$SCRATCH" && docker compose logs scheduler 2>&1) | grep -q "read crontab"; then
+        READ_CRONTAB=1
+        break
+    fi
+    sleep 2
 done
 
+if [ "$READ_CRONTAB" -ne 1 ]; then
+    echo "ERROR: supercronic did not log 'read crontab' within 60s" >&2
+    (cd "$SCRATCH" && docker compose logs scheduler | tail -80) >&2
+    exit 1
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# 7. Run triage.py in the foreground (tees stdout)
+# ────────────────────────────────────────────────────────────────────────────
+
+echo "[run] triage.py"
+set +e
+$EXEC python3 /app/scripts/triage.py
+TRIAGE_EXIT=$?
+set -e
+
+if [ "$TRIAGE_EXIT" -ne 0 ]; then
+    echo "ERROR: triage.py exited non-zero ($TRIAGE_EXIT)" >&2
+    exit 1
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# 8. Assert pipeline_complete event with scored > 0 in pipeline.jsonl
+# ────────────────────────────────────────────────────────────────────────────
+
+echo "[assert] pipeline_complete event with scored > 0"
+JSONL_SCORED=$($EXEC python3 -c "
+import json, sys
+scored = 0
+found = False
+try:
+    with open('/app/logs/pipeline.jsonl') as fh:
+        for line in fh:
+            try:
+                ev = json.loads(line)
+            except Exception:
+                continue
+            if ev.get('event') == 'pipeline_complete':
+                found = True
+                scored = int(ev.get('scored', 0))
+except FileNotFoundError:
+    print('ERROR: /app/logs/pipeline.jsonl not found', file=sys.stderr)
+    sys.exit(1)
+if not found:
+    print('ERROR: no pipeline_complete event in pipeline.jsonl', file=sys.stderr)
+    sys.exit(1)
+print(scored)
+") || { echo "ERROR: pipeline.jsonl check failed" >&2; exit 1; }
+
+if [ "$JSONL_SCORED" -lt 1 ]; then
+    echo "ERROR: pipeline_complete event had scored=$JSONL_SCORED (expected >= 1)" >&2
+    exit 1
+fi
+echo "  pipeline_complete.scored = $JSONL_SCORED"
+
+# ────────────────────────────────────────────────────────────────────────────
+# 9. Assert jobs table has rows in stage scored or manual_review
+# ────────────────────────────────────────────────────────────────────────────
+
+echo "[assert] jobs table has scored/manual_review rows"
+JOB_COUNT=$($EXEC sqlite3 /app/data/pipeline.db \
+    "SELECT COUNT(*) FROM jobs WHERE stage IN ('scored','manual_review');" | tr -d '[:space:]')
+
+if [ -z "$JOB_COUNT" ] || [ "$JOB_COUNT" -lt 1 ]; then
+    echo "ERROR: jobs table has 0 scored/manual_review rows (expected >= 1)" >&2
+    exit 1
+fi
+echo "  jobs(scored|manual_review) = $JOB_COUNT"
+
+# ────────────────────────────────────────────────────────────────────────────
+# 10. Assert cost_log has rows (confirms #117 schema fold)
+# ────────────────────────────────────────────────────────────────────────────
+
+echo "[assert] cost_log has rows (schema fold)"
+COST_COUNT=$($EXEC sqlite3 /app/data/pipeline.db \
+    "SELECT COUNT(*) FROM cost_log;" | tr -d '[:space:]')
+
+if [ -z "$COST_COUNT" ] || [ "$COST_COUNT" -lt 1 ]; then
+    echo "ERROR: cost_log has 0 rows (expected >= 1 — #117 fold not working)" >&2
+    exit 1
+fi
+echo "  cost_log rows = $COST_COUNT"
+
+# ────────────────────────────────────────────────────────────────────────────
+# 11. Assert aichat-ng config.yaml present (confirms #118 seed)
+# ────────────────────────────────────────────────────────────────────────────
+
+echo "[assert] /app/.config/aichat_ng/config.yaml present (aichat seed)"
+if ! $EXEC test -f /app/.config/aichat_ng/config.yaml; then
+    echo "ERROR: /app/.config/aichat_ng/config.yaml missing — entrypoint seed did not run (#118)" >&2
+    exit 1
+fi
+echo "  aichat-ng config.yaml: OK"
+
+# ────────────────────────────────────────────────────────────────────────────
+# 12. Done — cleanup runs on EXIT
+# ────────────────────────────────────────────────────────────────────────────
+
 echo
-echo "✅  Container integration test passed."
-echo "   Stack dir (auto-cleaned): $STACK_DIR"
+echo "✅  Fresh-install smoke passed."
+echo "    Stack dir (auto-cleaned): $SCRATCH"

--- a/tests/fixtures/smoke_companies_of_interest.txt
+++ b/tests/fixtures/smoke_companies_of_interest.txt
@@ -1,0 +1,13 @@
+# Recognizable employers so the smoke test's company-of-interest branch
+# gets exercised (sync_sheet archival exception + notify mis-score check
+# rely on this set being non-empty).
+amazon
+google
+microsoft
+apple
+nvidia
+equinix
+digitalrealty
+cloudflare
+stripe
+netflix

--- a/tests/fixtures/smoke_in_domain_patterns.yaml
+++ b/tests/fixtures/smoke_in_domain_patterns.yaml
@@ -1,0 +1,17 @@
+# In-domain patterns matched against Casey Example's target titles.
+# Lets a handful of raw jobs match the positive patterns so Stage 2 of the
+# prefilter (in-domain + no JD → score 5/6 deterministically) gets exercised
+# alongside the LLM scoring path.
+positive:
+  - '\binfrastructure\s+(engineer|operations|lead|manager)\b'
+  - '\bsite\s+reliability\s+(engineer|manager|lead)\b'
+  - '\bdata\s*center\s+(operations|manager|lead|technician|site|engineer)\b'
+  - '\bdatacenter\s+(operations|manager|lead|site)\b'
+  - '\bhardware\s+(operations|program\s+manager|npi)\b'
+  - '\bnpi\s+(program\s+manager|manager|lead|engineer)\b'
+  - '\boperational\s+readiness\b'
+  - '\bsite\s+operations\s+manager\b'
+  - '\bengineering\s+operations\s+(manager|lead)\b'
+
+poison:
+  - '\b(custodial|janitorial|workplace\s+services|office\s+services)\b'

--- a/tests/fixtures/smoke_jsearch_queries.txt
+++ b/tests/fixtures/smoke_jsearch_queries.txt
@@ -1,0 +1,5 @@
+# Minimal jsearch queries for fresh-install smoke test.
+# 2 queries keeps API budget ≤$0.10 per run (2 × (LinkedIn + Indeed) ≈ 80
+# raw jobs, ≤20 scored after prefilter + dedup).
+infrastructure engineer
+site reliability engineer

--- a/tests/fixtures/smoke_prefilter_rules.yaml
+++ b/tests/fixtures/smoke_prefilter_rules.yaml
@@ -1,0 +1,26 @@
+# Minimal prefilter rules for the fresh-install smoke test.
+#
+# Intentionally permissive — we want the LLM scorer to be exercised, so we
+# hard-reject only the most obviously out-of-domain categories (sales,
+# clinical healthcare, legal/HR/finance, retail). Everything else falls
+# through to the scorer so `cost_log` gets rows and the DB ends up with
+# `scored`/`manual_review` jobs.
+hard_rejects:
+  sales_bd:
+    - '\baccount\s+executive\b'
+    - '\bsales\s+(specialist|representative|manager)\b'
+    - '\benterprise\s+sales\b'
+  clinical_healthcare:
+    - '\bnurs(e|ing)\b'
+    - '\bpatient\s+care\b'
+    - '\bpharmaceut'
+  finance_legal_hr:
+    - '\blegal\s+counsel\b'
+    - '\bhuman\s+resources\s+(manager|director)\b'
+    - '\brecruiter\b'
+  retail:
+    - '\bretail\s+(manager|associate|sales)\b'
+    - '\bcashier\b'
+
+# No context suppressors — smoke test doesn't need in-domain nuance.
+context_suppressors: []

--- a/tests/fixtures/smoke_profile.md
+++ b/tests/fixtures/smoke_profile.md
@@ -1,0 +1,31 @@
+# Smoke-test persona: "Casey Example" (fictional)
+
+**THIS IS A FICTIONAL PERSONA used exclusively by
+`scripts/test_container_integration.sh` as a minimal but coherent candidate
+profile for the fresh-install smoke test.** No real person named Casey
+Example is associated with findajob. Do not use this file as a template —
+see `candidate_context/profile.md.example` for the real template.
+
+---
+
+Casey Example is an infrastructure operations generalist with ~12 years of
+experience across data center site operations, large-scale systems
+reliability, and hardware-to-production validation programs. They are
+equally comfortable on a swing shift at 3am debugging a power incident and
+leading a Monday-morning reliability review with directors. They have
+managed cross-functional NPI (new product introduction) cohorts of 20+
+engineers, run on-call rotations for fleets of 100k+ servers, and built out
+operational readiness checklists that are still in use at their prior
+employers. They write clearly, keep runbooks current, and prefer roles with
+a strong operations rhythm over pure-IC coding work.
+
+Target titles Casey would accept today: Data Center Operations Manager,
+Infrastructure Operations Lead, Site Reliability Engineering Manager,
+Hardware Operations Program Manager, NPI Program Manager, Operational
+Readiness Lead, Site Operations Manager, Engineering Operations Manager.
+Hard avoid: pure software engineer / SDE titles (Casey does not code
+professionally), sales / BD roles, security analyst tracks, IT service desk
+/ help desk management, clinical healthcare roles, and pure facilities-only
+roles that do not touch infrastructure (custodial, workplace services,
+office management). Open to hybrid or remote anywhere in the US; prefers
+West Coast hours.


### PR DESCRIPTION
## Summary

- `scripts/test_container_integration.sh` rewritten: empty bind mounts → real fresh install → triage → assert `scored > 0` + `cost_log` rows + aichat-ng seed (#119)
- New test fixtures (`tests/fixtures/smoke_*`) — fictional candidate "Casey Example", 2 queries, ≈$0.05/run API budget
- `docs/release-process.md` §"Pre-tag smoke check" rewritten; §"When the gate reactivates" removed (48h window retired for v0.1.x per operator decision)
- `docs/setup/install-docker.md` — new "What the entrypoint does automatically" callout; no new manual-step language (pre-existing "Migrating from an older image" section preserved — it documents existing-stack migration, not fresh install)
- `CHANGELOG.md` — PR3 bullet under [Unreleased]

Part of #120. **Requires PR1 (#121) and PR2 (#122) merged** — both confirmed merged; the new smoke asserts their fixes are present on fresh installs.

## Scope note: CI wiring intentionally deferred (Option B)

The plan's original Task 23 wired the new smoke into `.github/workflows/ci.yml` using 9 Actions secrets (LLM API keys + a dedicated smoke sheet ID). A pre-flight check revealed the repo has **zero Actions secrets** currently. Wiring CI with live API keys now is:

- A meaningful security decision (9 keys exposed to CI, cost drift per PR)
- A meaningful ops decision (≈$0.05–0.10 per CI run × every triggering PR)
- Orthogonal to the bug fix this PR represents

**This PR ships the smoke as a local-only gate.** `docs/release-process.md` instructs the operator to run it on a docker-equipped host (e.g. docker.lan) before proposing a tag. A follow-up issue will be filed to track CI wiring once the security/ops trade-off is decided.

## Shipping untested

No local dry-run. The dev Chromebook has no docker. The 270-line script is dead-reckoned against the plan spec and `ops/compose.yaml.example`. Operator will debug on docker.lan before proposing the v0.1.1 tag; any first-run fixes land as a follow-up commit on `main`.

## Test plan

- [ ] Run on docker.lan: `docker build -t findajob:local . && FINDAJOB_SMOKE_SHEET_ID=<sheet> FINDAJOB_TEST_IMAGE=findajob:local scripts/test_container_integration.sh` → green
- [x] `grep -in reactivat docs/release-process.md` → no matches
- [x] `grep -n -E 'init_db|config\.yaml|roles.*symlink|aichat.*config' docs/setup/install-docker.md` shows only auto-seed callout text + historical migration section (no new manual-step language)
- [x] `bash -n scripts/test_container_integration.sh` → syntax OK

## Migration-required

No. Process/docs change plus a test script. No runtime behavior change in the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)