### PR TITLE
feat: web materials viewer (14a / #59); rip rclone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+- Web materials viewer (`#59`): local FastAPI service serves prep-folder contents
+  on `http://docker.lan:<port>/`. Replaces Google Drive folder browsing.
+
+### Removed
+- rclone integration and Google Drive sync (`#29`, `#59`). `FINDAJOB_JOBSYNC_*`
+  env vars deleted; `state/rclone/` bind mount no longer used; `rclone` removed
+  from the container image (~50 MB smaller).
+
+### Migration required
+
+Operators on prior versions who had `FINDAJOB_JOBSYNC_ENABLED=true` must
+perform a one-time stack update — see `docs/setup/state-migration.md` for
+the exact commands. Testers on fresh installs are unaffected.
+
 ## [0.1.1] — 2026-04-20
 
 Fresh-install fixes uncovered during the first external tester's deployment (#20 / #82). `v0.1.0` had only been validated against the operator's legacy stack; empty bind mounts hit four untested code paths. No migration required — all fixes are entrypoint-driven and idempotent. Existing operator stacks pull `:v0.1` and keep working; fresh deploys now reach a populated Dashboard without operator intervention beyond API keys + per-tester config.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,12 +110,13 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 | `candidate_context/` | `<repo>/candidate_context/` | `/app/candidate_context/` (bind-mount) |
 | `companies/` | `<repo>/companies/` | `/app/companies/` (bind-mount) |
 | `aichat-ng` | `/usr/local/bin/aichat-ng` | `/usr/local/bin/aichat-ng` (blob42/aichat-ng prebuilt) |
-| aichat-ng config dir | `~/.config/aichat_ng/` | `/root/.config/aichat_ng/` (bind-mount from `./state/aichat_ng/`) |
+| aichat-ng config dir | `~/.config/aichat_ng/` | `/app/.config/aichat_ng/` (bind-mount from `./state/aichat_ng/`) |
 | Scheduler | systemd user services | supercronic inside the container |
+| Web viewer | `src/findajob/web/` (package) | uvicorn co-process on container port 8090 (mapped to `FINDAJOB_MATERIALS_PORT`) |
 
 **When authoring new scripts or tests:**
 - Always use `findajob.paths.BASE` — never hardcode `/home/...` or `/app/`.
-- Binary subprocess calls go through `AICHAT`/`PANDOC`/`RCLONE` from `findajob.paths`.
+- Binary subprocess calls go through `AICHAT`/`PANDOC` from `findajob.paths`.
 - Tests must not depend on absolute paths — use tmpdirs or `BASE`-relative paths.
 
 ---
@@ -124,12 +125,16 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 
 ```
 # ── Package (pip install -e .) ──────────────────────────────────────────────
-<repo>/src/findajob/paths.py                # central path resolver — from findajob.paths import BASE, AICHAT, PANDOC, RCLONE
+<repo>/src/findajob/paths.py                # central path resolver — from findajob.paths import BASE, AICHAT, PANDOC
 <repo>/src/findajob/utils.py                # shared utilities: log_event(), write_audit(), load_env()
 <repo>/src/findajob/cleaning.py             # normalize, fingerprint, clean_title, clean_company
 <repo>/src/findajob/fetchers.py             # Greenhouse, RapidAPI, Gmail job fetching
 <repo>/src/findajob/scoring.py              # score_job(), _build_feedback_block()
 <repo>/src/findajob/scorer_prefilter.py     # deterministic pre-filter (Stage 1 + 2)
+<repo>/src/findajob/web/app.py               # FastAPI app factory (create_app)
+<repo>/src/findajob/web/routes.py            # /healthz, /folders/<stage>/<name>/*, /files/* routes
+<repo>/src/findajob/web/folder_resolver.py   # resolves stage→filesystem path, path-traversal guards
+<repo>/src/findajob/web/templates/           # Jinja2 templates (index.html, folder.html, viewer.html)
 
 # ── Entry point scripts (called by systemd / CLI) ──────────────────────────
 <repo>/scripts/triage.py                    # daily ingest → score → DB
@@ -181,7 +186,7 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 ## Critical Architecture Rules
 
 ### Path Resolution
-All binary paths (AICHAT, PANDOC, RCLONE) come from `findajob.paths` (`src/findajob/paths.py`), which reads `config/paths.env`.
+All binary paths (AICHAT, PANDOC) come from `findajob.paths` (`src/findajob/paths.py`), which reads `config/paths.env`.
 Never hardcode platform paths in scripts. `BASE` is derived from `__file__` — the repo can live anywhere.
 For subprocess calls to other pipeline scripts, always use `sys.executable`, not a hardcoded Python path.
 Library code lives in `src/findajob/` (installed via `pip install -e .`). Entry point scripts in `scripts/` import via `from findajob.* import ...`. No `sys.path.insert` hacks.
@@ -274,7 +279,7 @@ Actions:
 
 **REJECT_REASON dropdown** (col B): 11 options (includes "Low Fit Score"). Behavior depends on STATUS:
 - If STATUS = `Not Selected`: company rejection → `stage=not_selected`, NO `feedback_log`, folder stays in `_applied/` with `NOT_SELECTED_` marker file
-- Otherwise: user rejection → `stage=rejected`, writes `feedback_log`, moves folder to `_rejected/`, syncs to Drive
+- Otherwise: user rejection → `stage=rejected`, writes `feedback_log`, moves folder to `_rejected/`
 
 **poll_flags.py** reads `Dashboard!A2:C10000`, `Applied!A2:C10000`, `Review!A2:C10000`, and `Waitlist!A2:C10000`. "Not Selected" is checked before generic rejection to prevent routing errors. `Ghosted` STATUS on the Applied tab is a no-op in DB (visual only) but is preserved across syncs via pending_statuses.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ ARG SUPERCRONIC_FILE=supercronic-linux-amd64
 # the host's PUID:PGID.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pandoc \
-        rclone \
         sqlite3 \
         tini \
         gosu \

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Deploys as a Docker container via Compose. Native systemd install remains docume
 2. **Flag → Prep** — you flag a job in the Dashboard; the pipeline generates a tailored resume, cover letter, company briefing, and LinkedIn outreach drafts
 3. **Notifications** — push notifications via ntfy.sh: daily stats, health check, apply reminders
 4. **Rejection tracking** — reject with a reason in the sheet; the pipeline logs it for pattern analysis and moves the folder to `_rejected/`
-5. **Manual injection** — Google Form lets you add any job (found outside the pipeline) and optionally trigger prep immediately
+5. **Materials viewer** — local web UI (FastAPI, port-configurable) displays prep-folder contents grouped by stage; Markdown rendered inline, `.docx` files downloadable
+6. **Manual injection** — Google Form lets you add any job (found outside the pipeline) and optionally trigger prep immediately
 
 ---
 
@@ -27,7 +28,7 @@ Deploys as a Docker container via Compose. Native systemd install remains docume
 | Sheet UI | Google Sheets API v4 | Familiar interface, cross-device |
 | Job sources | RapidAPI jobs-api14, Gmail OAuth2, Greenhouse JSON API | Broad coverage |
 | Notifications | ntfy.sh | Free, cross-platform push |
-| File sync | rclone bisync | Google Drive sync for prep folders |
+| Materials viewer | FastAPI + uvicorn | Local web viewer for prep-folder contents — Markdown rendered inline, `.docx` download |
 | Scheduler | supercronic (Docker) / systemd (native) | supercronic runs the crontab inside the image; systemd is the fallback on native installs |
 
 ---
@@ -37,7 +38,6 @@ Deploys as a Docker container via Compose. Native systemd install remains docume
 - Python 3.11+
 - [aichat-ng](https://github.com/blob42/aichat-ng) (`aichat-ng` binary, not `aichat`)
 - pandoc
-- rclone (optional — only needed for Google Drive sync)
 - API keys: Anthropic, OpenRouter (DeepSeek), Perplexity, Google Gemini, RapidAPI
 - Google Cloud project with Sheets API and Gmail API enabled
 
@@ -48,7 +48,7 @@ Deploys as a Docker container via Compose. Native systemd install remains docume
 findajob ships as a Docker image pulled from GHCR and deployed via Docker Compose.
 
 ```bash
-# On your Docker host — replace <you> with a short tag (brock, amy, etc.)
+# On your Docker host — replace <you> with a short tag
 sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng}
 sudo chown -R $(id -u):$(id -g) /opt/stacks/findajob-<you>/
 cd /opt/stacks/findajob-<you>
@@ -61,7 +61,7 @@ curl -fsSL -o .env         https://raw.githubusercontent.com/brockamer/findajob/
 docker compose up -d
 ```
 
-Full walkthrough (API keys, Gmail OAuth, Google Sheets, Drive sync) →
+Full walkthrough (API keys, Gmail OAuth, Google Sheets) →
 [`docs/setup/install-docker.md`](docs/setup/install-docker.md).
 
 Running on a Linux host without Docker is still supported — see

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,9 @@
 
 > **Docker users:** This document describes system design using native-install
 > terminology. Pipeline structure is identical under Docker; the scheduler is
-> supercronic reading `ops/crontab` rather than systemd timers.
+> supercronic reading `ops/crontab` rather than systemd timers. The container
+> also runs uvicorn alongside supercronic as a co-process, serving the
+> materials viewer on `FINDAJOB_MATERIALS_PORT`.
 > Docker-specific refresh tracked in #76.
 >
 
@@ -105,7 +107,7 @@ prep_application.py (runs in foreground)
     DB updated: stage = materials_drafted
     sync_sheet.py: Dashboard STATUS → "Ready to Apply"
     ntfy notification sent
-    rclone copy: companies/ → Google Drive
+    Materials viewer reflects new folder immediately (no sync required)
 ```
 
 ---
@@ -139,7 +141,7 @@ known_contacts TEXT
 user_notes TEXT              -- free text set via Applied tab col I
 stage_updated TEXT           -- ISO timestamp of last stage change
 prep_folder_path TEXT        -- absolute path to companies/ subfolder
-gdrive_folder_url TEXT       -- link to prep folder on Drive
+gdrive_folder_url TEXT       -- legacy column (Drive sync removed; unused since v0.2)
 fit_score REAL               -- 0-100% avg from fit_analyst
 probability_score REAL       -- 0-100% avg from fit_analyst
 created_at TEXT
@@ -205,7 +207,7 @@ poll_flags.py reads this tab every 10 min. Once the user marks STATUS=Applied, t
 | E | probability_score | LLM-assigned interview probability |
 | F | relevance_score | 1–10 composite score |
 | G | title | Hyperlink to job URL |
-| H | company | Hyperlink to Drive folder when prepped |
+| H | company | Company name |
 | I | location | |
 | J | remote_status | Color-coded |
 | K | known_contacts | Amber when non-empty |
@@ -215,7 +217,7 @@ poll_flags.py reads this tab every 10 min. Once the user marks STATUS=Applied, t
 
 **STATUS dropdown options (Dashboard — pre-application):** `Flag for Prep` → `Prep in Progress` *(system)* → `Ready to Apply` *(system)* → `Applied` *(user)*. Also: `Regenerate` (re-runs prep), `Waitlist` (defers the job). Once marked `Applied`, the poller sets stage=applied and the row moves to the Applied tab where `Interviewing` / `Offer` / `Ghosted` / `Not Selected` / `Withdrew` are set.
 
-**REJECT_REASON:** behavior depends on STATUS. If STATUS = `Not Selected`: company rejection → `stage=not_selected`, no feedback_log, folder stays in `_applied/`. Otherwise: user rejection → `stage=rejected`, feedback_log entry, folder move to `_rejected/`, immediate rclone sync to Drive.
+**REJECT_REASON:** behavior depends on STATUS. If STATUS = `Not Selected`: company rejection → `stage=not_selected`, no feedback_log, folder stays in `_applied/`. Otherwise: user rejection → `stage=rejected`, feedback_log entry, folder moved to `_rejected/`.
 
 ### Applied — Post-Application Queue (A–N)
 Filter: `stage IN (applied, interview, offer)`. UI for managing jobs that have been submitted.
@@ -226,7 +228,7 @@ Filter: `stage IN (applied, interview, offer)`. UI for managing jobs that have b
 | B | REJECT_REASON | Dropdown — same 11 options as Dashboard |
 | C | fingerprint | Hidden |
 | D | title | Hyperlink to job URL |
-| E | company | Hyperlink to Drive folder |
+| E | company | Company name |
 | F | applied_date | Date job was marked Applied (from `audit_log`) |
 | G | days_since_applied | Live `=IF(F2="","",TODAY()-F2)` formula |
 | H | stage | `applied` / `interview` / `offer` (read-only) |
@@ -280,7 +282,7 @@ Jobs that were rejected after reaching `applied` stage. Read-only reference view
 | Col | Field | Notes |
 |---|---|---|
 | A | title | Hyperlink to job URL |
-| B | company | Hyperlink to Drive folder if available |
+| B | company | Company name |
 | C | reject_reason | |
 | D | applied_date | Date the job was marked Applied |
 | E | rejected_date | Date the rejection was recorded |
@@ -298,6 +300,6 @@ Jobs that were rejected after reaching `applied` stage. Read-only reference view
 | Direct profile injection (not RAG) | RAG chunking drops contact info, employer names, and dates. Profile is short enough to inject raw. |
 | Two-stage prefilter before LLM | Hard rejects (wrong domain, title-deterministic) don't need LLM calls. Saves ~$0.10/day and speeds triage. |
 | JSON output validation | `jsonschema` validates every LLM scoring response. Malformed output → manual_review, not a crash. |
-| rclone copy --update (push-only) | Bisync was replaced — conflict copies and state-file corruption outweighed bidirectional convenience. Local is authoritative for new content; Drive edits are preserved by `--update` (never overwrites newer remote files). Folder moves use `rclone move` within Drive (server-side). |
+| Web materials viewer (not Drive) | Prep folders are served locally via uvicorn/FastAPI — no cloud sync dependency. Markdown rendered inline; `.docx` offered as download. Eliminates rclone auth complexity and Drive quota issues. |
 | Rejection before prep in poll_flags | Prevents a race condition where a job gets prepped and then rejected in the same poll cycle. |
 | `abbrev_title()` in folder names | Same-day preps for the same company would overwrite each other without title disambiguation. HHMMSS suffix prevents same-title same-day overwrites. |

--- a/docs/google-sheets.md
+++ b/docs/google-sheets.md
@@ -101,8 +101,7 @@ Behavior depends on the STATUS column:
 2. DB updated: `stage=rejected`, `reject_reason=<value>`
 3. Row written to `feedback_log` table (for pattern analysis)
 4. If a prep folder exists for this job: it is moved to `companies/_rejected/`
-5. rclone sync fires immediately (non-blocking) to push the move to Google Drive
-6. Job disappears from Dashboard on next sync
+5. Job disappears from Dashboard on next sync
 
 "Not Selected" is checked before generic rejection in the poll cycle to prevent routing errors.
 

--- a/docs/learnings.md
+++ b/docs/learnings.md
@@ -29,8 +29,8 @@ Updated as we learn. Not a task list — a knowledge base.
 
 - **SQLite busy_timeout** must be set on every connection (30s). Without it, concurrent access from triage + poller crashes with "database is locked."
 - **systemd `OnUnitActiveSec` timers** lose their re-arm chain after boot. Use `OnCalendar` instead.
-- **`rclone bisync`** fights with any other process that writes to Drive. Replaced with push-only `rclone copy --update` which never overwrites user edits on Drive.
-- **Drive-side `rclone move`** preserves file content during folder transitions (applied, rejected, waitlisted). Local copy + purge destroyed user edits.
+- ~~**`rclone bisync`** fights with any other process that writes to Drive.~~ *(removed 2026-04-20: all Drive sync removed; local folders are now source of truth)*
+- ~~**Drive-side `rclone move`** preserves file content during folder transitions.~~ *(removed 2026-04-20: local folder moves are final; no Drive push)*
 - **Greenhouse public API** (`boards-api.greenhouse.io`) has no auth, no documented rate limits, and is designed for programmatic use. Safe to poll daily.
 - **LinkedIn direct curl** always returns auth wall. Must use RapidAPI `/v2/linkedin/get?id=` for JD fetching.
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -160,17 +160,17 @@ Safe to re-run — skips already-renamed folders.
 
 ---
 
-## Google Drive Sync (rclone)
+## Materials Viewer
 
-The pipeline uses push-only `rclone copy --update` to sync `companies/` to Google Drive at `gdrive:01 PROJECTS/Jobs To Apply For`. Local is authoritative for new content; `--update` never overwrites newer files on Drive (preserving user edits made via phone/browser).
+The container publishes a read-only web viewer on `FINDAJOB_MATERIALS_PORT` (default `8090`).
+Access it at `http://<docker-host>:<port>/` on your LAN or via Wireguard.
 
-The `findajob-jobsync.timer` runs `rclone copy --update` every 15 minutes. Additionally, `prep_application.py` and `poll_flags.py` push individual folders immediately after creating or moving them.
+The viewer displays prep-folder contents grouped by stage (staged, applied, waitlisted,
+rejected), renders Markdown inline, and offers `.docx` files for download.
 
-Folder moves (reject → `_rejected/`, apply → `_applied/`, waitlist → `_waitlisted/`) use `rclone move` within Drive (server-side) to preserve user edits, then `rclone copy` to push any new local files (e.g., marker files).
-
-Manual sync:
 ```bash
-rclone copy --update ~/Code/findajob/companies/ "gdrive:01 PROJECTS/Jobs To Apply For"
+# Quick check
+curl http://docker.lan:8090/healthz    # expect: ok
 ```
 
 ---

--- a/docs/refactor_recommendations.md
+++ b/docs/refactor_recommendations.md
@@ -33,8 +33,8 @@ Jobs are committed one-by-one as they're processed. If triage crashes at job 400
 **6. ~~`sync_sheet.py` has an O(n²) bug in COL_MAP lookup~~** *(fixed 2026-04-08)*
 `S1_LOOKUP` and `DASH_LOOKUP` are now built once as reverse dicts. `build_row()` does a single dict lookup per cell.
 
-**~~7. `rclone bisync` path is fragile and inconsistently referenced~~** *(resolved 2026-04-13)*
-bisync replaced entirely with event-driven sync. `poll_flags.py` now calls `rclone copy` + `rclone purge` inline after each folder move. The jobsync timer runs a two-phase `rclone copy --update` (push local→Drive, pull Drive→local) every 15 minutes for new content and user edits. No more bisync state, no more conflict copies, no more `--resync` recovery.
+**~~7. `rclone bisync` path is fragile and inconsistently referenced~~** *(resolved 2026-04-20)*
+bisync and all rclone sync removed entirely. Local folder moves (`_applied/`, `_rejected/`, `_waitlisted/`) are now the source of truth; no longer synced to Google Drive. Users manage Drive content via the web viewer deployed on localhost:8080.
 
 ---
 

--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -7,7 +7,7 @@
 
 All scripts live in `scripts/`. Diag scripts live in `scripts/diag/` and are run manually only.
 
-All scripts import `BASE`, `AICHAT`, `PANDOC`, and/or `RCLONE` from `findajob.paths` (`src/findajob/paths.py`).
+All scripts import `BASE`, `AICHAT`, and/or `PANDOC` from `findajob.paths` (`src/findajob/paths.py`).
 Never hardcode binary paths in scripts — add overrides to `config/paths.env` instead.
 
 ---
@@ -44,7 +44,7 @@ Generates a full application package for one job. LLM calls run sequentially.
 - `job_description.txt`
 - `REVIEW_CHECKLIST.md`
 
-**After completion:** updates DB to `stage=materials_drafted`, calls `sync_sheet.py`, sends ntfy notification, pushes folder to Google Drive via `rclone copy`.
+**After completion:** updates DB to `stage=materials_drafted`, calls `sync_sheet.py`, sends ntfy notification.
 
 ---
 
@@ -56,7 +56,7 @@ Reads STATUS, REJECT_REASON, and fingerprint from four tabs: `Dashboard!A2:C1000
 
 **STATUS logic (Dashboard + Applied, in priority order):**
 1. If `STATUS` is `Not Selected` and job is in `applied/interview/offer` → calls `handle_not_selected()`: sets `stage=not_selected`, drops marker file in `_applied/`, NO `feedback_log` write
-2. If `REJECT_REASON` is set and job not already rejected → calls `handle_rejection()`: updates DB, writes `feedback_log`, moves prep folder to `_rejected/`, fires rclone sync (non-blocking)
+2. If `REJECT_REASON` is set and job not already rejected → calls `handle_rejection()`: updates DB, writes `feedback_log`, moves prep folder to `_rejected/`
 3. If `STATUS` is `Regenerate` → deletes existing prep folder, re-runs prep
 4. If `STATUS` is `Applied/Interviewing/Offer/Withdrew` → updates DB stage; `Applied` moves folder to `_applied/`
 5. If `STATUS` is `Waitlist` → sets stage=waitlisted, moves folder to `_waitlisted/`

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -95,7 +95,6 @@ Binary path overrides for your platform. Only needed if your binaries are in non
 ```bash
 AICHAT_NG=/usr/local/bin/aichat-ng
 PANDOC=/usr/bin/pandoc           # Linux default
-RCLONE=/usr/bin/rclone           # Linux default
 ```
 
 Linux defaults are already built into `src/findajob/paths.py`. If everything is in the expected locations, you can skip this file.

--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -22,11 +22,11 @@ See [configure.md](configure.md). API keys and personal config end up in `state/
 
 ```bash
 # On the Docker host
-sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng,rclone}
+sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng}
 sudo chown -R $(id -u):$(id -g) /opt/stacks/findajob-<you>/
 ```
 
-Replace `<you>` with a short user tag (`brock`, `amy`, etc.).
+Replace `<you>` with a short user tag.
 
 ## 2. Drop in the compose template and env
 
@@ -36,7 +36,7 @@ curl -fsSL -o compose.yaml https://raw.githubusercontent.com/brockamer/findajob/
 curl -fsSL -o .env https://raw.githubusercontent.com/brockamer/findajob/main/ops/stack.env.example
 ```
 
-Edit `.env` to taste — at minimum set `FINDAJOB_TZ` and (if dogfooding) `FINDAJOB_IMAGE_TAG=latest`.
+Edit `.env` to taste — at minimum set `FINDAJOB_TZ`, `FINDAJOB_MATERIALS_PORT`, and (if dogfooding) `FINDAJOB_IMAGE_TAG=latest`.
 
 ## 3. Populate `state/`
 
@@ -67,6 +67,25 @@ start — you do not run any of these commands manually:
 
 Fill in your personal config files above and run `docker compose up -d` —
 no manual schema init, no handcrafted aichat-ng config, no symlink setup.
+
+### Materials viewer port
+
+Set `FINDAJOB_MATERIALS_PORT` in your stack `.env` to a free host port (default `8090`).
+Each stack on the same host must use a unique port number.
+
+```
+FINDAJOB_MATERIALS_PORT=8090
+```
+
+The container publishes the viewer at `http://<docker-host>:<port>/`. On a LAN or Wireguard
+VPN this is reachable from any device. The viewer is read-only — it displays prep-folder
+contents grouped by stage (staged, applied, waitlisted, rejected), renders Markdown inline,
+and offers `.docx` files for download.
+
+```bash
+# Quick smoke test after first deploy
+curl http://docker.lan:8090/healthz    # expect: ok
+```
 
 ## 4. Initial auth: Gmail (optional)
 
@@ -121,9 +140,9 @@ Before running `docker compose pull && docker compose up -d`:
 
 The "Action required" section is driven by PRs labeled `migration-required` (see [`docs/release-process.md`](../release-process.md) for the criteria). If a release has no such PRs in its range, the section won't appear.
 
-## Migrating from an older image: aichat-ng / rclone mount paths
+## Migrating from an older image: aichat-ng mount path fix
 
-If your stack was deployed before the aichat-ng mount-path fix, your `compose.yaml` still mounts `./state/aichat_ng` to `/root/.config/aichat_ng`. The container now runs as a non-root user (PUID), so `/root` is unreadable and all scoring calls fail silently. You also need a new `rclone` mount and a `HOME=/app` env var.
+If your stack was deployed before the aichat-ng mount-path fix, your `compose.yaml` still mounts `./state/aichat_ng` to `/root/.config/aichat_ng`. The container now runs as a non-root user (PUID), so `/root` is unreadable and all scoring calls fail silently.
 
 Apply these changes once, per instance:
 
@@ -133,39 +152,32 @@ Apply these changes once, per instance:
    docker compose down
    ```
 
-2. **Create the new `state/rclone/` bind-mount directory.**
-   ```bash
-   mkdir -p state/rclone
-   sudo chown $(id -u):$(id -g) state/rclone
-   ```
-
-3. **Edit `compose.yaml`** (or re-pull `ops/compose.yaml.example` if you haven't customized it). Three changes to the `scheduler` service:
+2. **Edit `compose.yaml`** (or re-pull `ops/compose.yaml.example` if you haven't customized it). Two changes to the `scheduler` service:
 
    - Under `environment:`, add `HOME: /app`.
    - Change the aichat-ng volume from `./state/aichat_ng:/root/.config/aichat_ng` to `./state/aichat_ng:/app/.config/aichat_ng`.
-   - Add a new volume: `./state/rclone:/app/.config/rclone`.
 
    Apply the same `HOME: /app` change to the `gmail-auth` service.
 
-4. **Fix ownership of `state/aichat_ng/`** in case it was populated under the old path:
+3. **Fix ownership of `state/aichat_ng/`** in case it was populated under the old path:
    ```bash
    sudo chown -R $(id -u):$(id -g) state/aichat_ng
    ```
 
-5. **Pull and bring the stack back up.**
+4. **Pull and bring the stack back up.**
    ```bash
    docker compose pull
    docker compose up -d
    docker compose logs -f scheduler  # Ctrl-C once you see supercronic's schedule dump
    ```
 
-6. **(If using jobsync)** Re-run `docker compose exec scheduler rclone config` so the rclone remote lands in `/app/.config/rclone/rclone.conf` (the new persistent location).
-
 Verify with a scoring smoke test:
 ```bash
 docker compose exec scheduler aichat-ng -m claude:claude-sonnet-4-6 -- 'reply "ok"'
 ```
 Expected output: `ok`. If aichat-ng errors with "no such file or directory" or returns nothing, the config is still in the old location — re-check the mount path.
+
+For instructions on migrating from rclone/Drive to the materials viewer, see [`docs/setup/state-migration.md`](state-migration.md).
 
 ## Rolling back locally
 

--- a/docs/setup/install-linux.md
+++ b/docs/setup/install-linux.md
@@ -13,7 +13,6 @@ This guide covers a fresh install on a Debian-based Linux system. Tested on Pop!
 sudo apt update && sudo apt install -y \
   python3 python3-pip \
   pandoc \
-  rclone \
   curl \
   git \
   build-essential  # needed for Rust/aichat-ng build
@@ -23,7 +22,6 @@ Verify:
 ```bash
 python3 --version    # should be 3.11+
 pandoc --version
-rclone version
 ```
 
 ---
@@ -99,7 +97,6 @@ Linux typically installs binaries in standard locations. Verify yours:
 ```bash
 which python3    # likely /usr/bin/python3
 which pandoc     # likely /usr/bin/pandoc
-which rclone     # likely /usr/bin/rclone
 which aichat-ng  # likely /usr/local/bin/aichat-ng (installed in step 2)
 ```
 
@@ -258,26 +255,9 @@ systemctl --user enable --now findajob-triage.timer
 
 See [bootstrap.sh](../../scripts/bootstrap.sh) for all service unit definitions.
 
-### Google Drive jobsync
+### Materials Viewer
 
-The `findajob-jobsync.service` uses push-only `rclone copy --update` to sync local `companies/` to Google Drive every 15 minutes. This is simpler than the previous bisync approach:
-
-- New prep folders created locally are pushed to Drive
-- `--update` skips files that are newer on Drive, preserving edits made via phone/browser
-- No state files, no `--resync` initialization, no conflict copies
-- Folder moves (reject → `_rejected/`, apply → `_applied/`, waitlist → `_waitlisted/`) are handled inline by `poll_flags.py` using `rclone move` within Drive (server-side)
-
-No one-time initialization is needed. The jobsync timer will push files on its next run after your first prep. To verify the remote is configured:
-
-```bash
-rclone lsd "gdrive:01 PROJECTS/Jobs To Apply For"
-```
-
-To push manually:
-
-```bash
-rclone copy --update ~/Code/findajob/companies/ "gdrive:01 PROJECTS/Jobs To Apply For"
-```
+Prep folders are served locally via a FastAPI web viewer running on `localhost:8080`. No external cloud sync or Google Drive dependencies. Markdown is rendered inline; `.docx` files are offered as downloads. This replaces the prior rclone-based Drive sync approach.
 
 ---
 

--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -72,14 +72,6 @@ Used by: `notify.py`
 - Add topic to `data/.env` as `NTFY_TOPIC`
 - Optional: self-host ntfy for privacy
 
-### 8. rclone (Google Drive sync)
-Used by: `prep_application.py`, `poll_flags.py` — file sync to Google Drive
-
-- Optional: only needed if you want company folders synced to Google Drive
-- Install rclone: https://rclone.org/install/
-- Configure a `gdrive` remote: `rclone config` → Google Drive
-- Set your Drive target path in `scripts/prep_application.py` (search for `gdrive:`)
-
 ---
 
 ## Required Tools
@@ -89,7 +81,6 @@ Used by: `prep_application.py`, `poll_flags.py` — file sync to Google Drive
 | Python | 3.11+ | System package manager (apt) |
 | aichat-ng | latest | See below |
 | pandoc | 3.x | `apt install pandoc` |
-| rclone | latest | `apt install rclone` (optional) |
 
 ### Installing aichat-ng
 

--- a/docs/setup/state-migration.md
+++ b/docs/setup/state-migration.md
@@ -37,7 +37,7 @@ Do NOT decommission the source until you have confirmed a full triage cycle comp
 | Binary path config | `config/paths.env` | Create new on target if paths differ |
 | Voice samples | `candidate_context/voice_samples/*.txt` | Copy directory |
 | RAG index | `rags/` or aichat-ng data dir | Rebuild on target (run `--rag rebuild`) |
-| Company prep folders | `companies/` | Optional — large, can sync via Google Drive |
+| Company prep folders | `companies/` | Optional — large, rsync or copy manually |
 | aichat-ng config | `~/.config/aichat_ng/config.yaml` | Create new on target |
 | Personal CLAUDE context | `CLAUDE.local.md` | Copy |
 
@@ -100,7 +100,6 @@ On the **target machine**, create `config/paths.env`:
 # Linux defaults — adjust if your install is non-standard
 AICHAT_NG=/usr/local/bin/aichat-ng
 PANDOC=/usr/bin/pandoc
-RCLONE=/usr/bin/rclone
 ```
 
 Create the aichat-ng config:
@@ -181,7 +180,6 @@ systemctl --user enable --now findajob-notify-issues.timer
 systemctl --user enable --now findajob-notify-apply.timer
 systemctl --user enable --now findajob-notify-feedback.timer
 systemctl --user enable --now findajob-rag-rebuild.timer
-systemctl --user enable --now findajob-jobsync.timer
 ```
 
 Verify all timers are loaded and show next trigger times:
@@ -230,3 +228,54 @@ Usually means a stale WAL file from an interrupted transaction. Remove `data/pip
 
 **Dedup mismatch (same jobs appear twice)**
 The fingerprint is based on `SHA-256(title+company+url)[:16]`. If your source machine's DB has jobs that the target will also fetch, the dedup will correctly skip them on first run. No action needed.
+
+---
+
+## Migrating from rclone/Drive to the materials viewer
+
+Applies to operator stacks that were running with `FINDAJOB_JOBSYNC_ENABLED=true`
+on v0.1.x. Testers on fresh installs can skip this — they never had rclone enabled.
+
+### Steps
+
+1. Stop the stack:
+   ```bash
+   docker compose down
+   ```
+
+2. Remove the now-unused bind mount:
+   ```bash
+   rm -rf state/rclone
+   ```
+
+3. Edit `.env` to add a port for the materials viewer:
+   ```
+   FINDAJOB_MATERIALS_PORT=8090   # or next free port if 8090 is taken
+   ```
+
+4. Edit `compose.yaml`:
+   - Remove:  `- ./state/rclone:/app/.config/rclone`
+   - Remove env var: `FINDAJOB_JOBSYNC_ENABLED`
+   - Add a ports block under the `scheduler` service:
+   ```yaml
+   ports:
+     - "${FINDAJOB_MATERIALS_PORT}:8090"
+   ```
+
+5. Pull and start:
+   ```bash
+   docker compose pull
+   docker compose up -d
+   ```
+
+6. Verify:
+   ```bash
+   curl http://docker.lan:8090/healthz    # expect: ok
+   ```
+   Then open `http://docker.lan:8090/` in a browser to browse materials.
+
+### Existing Drive folders
+
+Nothing automated. Drive folders that rclone synced remain at
+drive.google.com. Delete them manually if desired — findajob will
+never look at them again.

--- a/ops/compose.yaml.example
+++ b/ops/compose.yaml.example
@@ -8,6 +8,8 @@ services:
   scheduler:
     image: ghcr.io/brockamer/findajob:${FINDAJOB_IMAGE_TAG:-v0.1}
     restart: unless-stopped
+    ports:
+      - "${FINDAJOB_MATERIALS_PORT:-8090}:8090"
     env_file: ./state/data/.env
     environment:
       TZ: ${FINDAJOB_TZ:-America/New_York}
@@ -15,7 +17,6 @@ services:
       PGID: ${PGID:-1000}
       HOME: /app
       JSP_BASE: /app
-      FINDAJOB_JOBSYNC_ENABLED: ${FINDAJOB_JOBSYNC_ENABLED:-false}
       FINDAJOB_TRIAGE_TIMEOUT: ${FINDAJOB_TRIAGE_TIMEOUT:-7200}
     volumes:
       - ./state/data:/app/data
@@ -24,7 +25,6 @@ services:
       - ./state/companies:/app/companies
       - ./state/logs:/app/logs
       - ./state/aichat_ng:/app/.config/aichat_ng
-      - ./state/rclone:/app/.config/rclone
     networks:
       - findajob-network
 

--- a/ops/crontab
+++ b/ops/crontab
@@ -13,9 +13,6 @@ PYTHONUNBUFFERED=1
 */10 *   *  *  *   timeout 900 python3 /app/scripts/poll_flags.py
 */30 *   *  *  *   python3 /app/scripts/ingest_form.py
 
-# ── Google Drive sync (gated by env, disabled by default) ────────────────────
-*/15 *   *  *  *   [ "$FINDAJOB_JOBSYNC_ENABLED" = "true" ] && rclone copy --update /app/companies/ "$FINDAJOB_JOBSYNC_REMOTE"
-
 # ── Notifications ────────────────────────────────────────────────────────────
 0    6   *  *  *        python3 /app/scripts/notify.py apply-reminder
 15   6   *  *  *        python3 /app/scripts/notify.py daily-stats

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -70,7 +70,7 @@ if [ ! -e "$AICHAT_CFG_DIR/roles" ]; then
 fi
 
 # --- 3. Chown writable dirs if ownership doesn't already match -----------
-for dir in /app/data /app/logs /app/companies /app/config /app/candidate_context /app/.config/rclone "$AICHAT_CFG_DIR"; do
+for dir in /app/data /app/logs /app/companies /app/config /app/candidate_context "$AICHAT_CFG_DIR"; do
     if [ -d "$dir" ]; then
         current_owner="$(stat -c %u "$dir" 2>/dev/null || echo 0)"
         if [ "$current_owner" != "$PUID" ]; then
@@ -86,5 +86,15 @@ if [ -w /app/data ]; then
     gosu "$PUID:$PGID" python3 /app/scripts/init_db.py >/dev/null
 fi
 
-# --- 4. Drop privileges and exec the command ------------------------------
+# --- 4. Launch materials viewer (uvicorn) in background -------------------
+# Supercronic stays PID 1 for compose restart tracking. Uvicorn runs as a
+# child process. If it crashes, supercronic keeps running — /healthz is the
+# outside signal. Operator restarts the container if needed.
+gosu "$PUID:$PGID" python3 -m uvicorn findajob.web.app:default_app --factory --host 0.0.0.0 --port 8090 --log-level info &
+UVICORN_PID=$!
+
+# Forward SIGTERM / SIGINT to uvicorn so docker compose down shuts it down cleanly.
+trap 'kill -TERM "$UVICORN_PID" 2>/dev/null; exit 0' TERM INT
+
+# --- 5. Drop privileges and exec the command ------------------------------
 exec gosu "$PUID:$PGID" "$@"

--- a/ops/stack.env.example
+++ b/ops/stack.env.example
@@ -20,19 +20,9 @@ FINDAJOB_TZ=America/New_York
 PUID=1000
 PGID=1000
 
-# Google Drive sync via rclone. Disabled by default — #59 makes this
-# obsolete once the web materials viewer ships.
-#
-# If true:
-#   1. Configure an rclone remote inside the container so its config
-#      lands in the bind-mount:
-#        docker compose exec scheduler rclone config
-#      Files are written to /app/.config/rclone/rclone.conf, which
-#      persists across container restarts via the state/rclone/ mount.
-#   2. Set FINDAJOB_JOBSYNC_REMOTE in state/data/.env to the remote
-#      + path where job folders should land. Example:
-#        FINDAJOB_JOBSYNC_REMOTE=gdrive:01 PROJECTS/Jobs To Apply For
-FINDAJOB_JOBSYNC_ENABLED=false
+# Web materials viewer — per-stack host port (each stack picks a unique port).
+# Current allocation starts at 8090 and increments per stack.
+FINDAJOB_MATERIALS_PORT=8090
 
 # Triage timeout in seconds. Default 7200 (2h) is generous for steady
 # state (~30-45min typical). For fresh installs with a large first feed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
     "jsonschema>=4.26.0",
     "beautifulsoup4>=4.14.0",
     "pyyaml>=6.0",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.32.0",
+    "jinja2>=3.1.0",
+    "markdown>=3.7",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "pytest>=8.0",
     "ruff>=0.11.0",
     "mypy>=1.20.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -70,7 +70,7 @@ check_deps() {
 install_apt_deps() {
   info "Installing system packages..."
   sudo apt-get update -q
-  sudo apt-get install -y python3 python3-pip pandoc rclone curl git build-essential
+  sudo apt-get install -y python3 python3-pip pandoc curl git build-essential
   ok "System packages installed"
 }
 
@@ -401,26 +401,6 @@ Persistent=true
 WantedBy=timers.target
 EOF
 
-  # rclone jobsync — every 15 min
-  # Push-only: local → Drive. --update skips files where Drive is newer,
-  # preserving any edits made directly in Drive without bisync conflict copies.
-  cat > "${SYSTEMD_DIR}/findajob-jobsync.service" << EOF
-[Unit]
-Description=findajob Google Drive push-only sync
-After=network-online.target
-
-[Service]
-Type=oneshot
-# push-only: local → Drive. --update skips files where Drive is newer,
-# preserving any edits made directly in Drive.
-ExecStart=/usr/bin/rclone copy --update ${REPO}/companies/ "gdrive:01 PROJECTS/Jobs To Apply For"
-WorkingDirectory=${REPO}
-TimeoutStartSec=600
-StandardOutput=append:${LOG_DIR}/jobsync.log
-StandardError=append:${LOG_DIR}/jobsync.log
-EOF
-  write_interval_timer "jobsync" "findajob Google Drive push-only sync" "15min"
-
   # RAG rebuild — Sunday 6:00 AM
   AICHAT_BIN="${aichat_bin}"
   write_aichat_service "rag-rebuild" "RAG index rebuild" "--rag job_search_rag --rebuild-rag"
@@ -434,7 +414,7 @@ EOF
 
   local timers=(
     triage poller form-ingest notify-stats notify-health notify-apply
-    notify-issues notify-scoreboard notify-feedback jobsync rag-rebuild
+    notify-issues notify-scoreboard notify-feedback rag-rebuild
   )
   for t in "${timers[@]}"; do
     systemctl --user enable "findajob-${t}.timer" 2>/dev/null || true
@@ -442,7 +422,7 @@ EOF
 
   ok "  All timers enabled. Start them with:"
   echo "     systemctl --user start findajob-triage.timer"
-  echo "     (or start all: systemctl --user start findajob-{triage,poller,form-ingest,notify-stats,notify-health,notify-apply,notify-issues,notify-scoreboard,notify-feedback,jobsync,rag-rebuild}.timer)"
+  echo "     (or start all: systemctl --user start findajob-{triage,poller,form-ingest,notify-stats,notify-health,notify-apply,notify-issues,notify-scoreboard,notify-feedback,rag-rebuild}.timer)"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -13,7 +13,6 @@ Usage:
 ntfy topic is read from NTFY_TOPIC in data/.env, or falls back to NTFY_TOPIC env var.
 """
 
-import glob
 import json
 import os
 import sqlite3
@@ -263,13 +262,6 @@ def cmd_health_check():
             for k in dead_feeds:
                 issues.append(f"  • {k}: 0 today, peak {week_max_per_source[k]} in last 7d")
 
-    # Check rclone sync health
-    rclone_failures = [e for e in events if e.get("event") == "rclone_failed"]
-    if rclone_failures:
-        issues.append(f"WARN: {len(rclone_failures)} rclone sync failure(s) in last 25h")
-        for e in rclone_failures[:2]:
-            issues.append(f"  • {e.get('reason', '?')} exit={e.get('exit_code', '?')}")
-
     # ── System resource checks ──────────────────────────────────────────
     try:
         with open("/proc/meminfo") as f:
@@ -363,17 +355,6 @@ def cmd_health_check():
         for name in orphan_folders[:5]:
             issues.append(f"  • {name}")
 
-    # ── rclone bisync conflict files ─────────────────────────────────────────
-    conflict_files = glob.glob(f"{BASE}/companies/**/*.path1", recursive=True)
-    conflict_files += glob.glob(f"{BASE}/companies/**/*.path2", recursive=True)
-    if conflict_files:
-        folders = sorted(set(os.path.dirname(f) for f in conflict_files))
-        issues.append(
-            f"WARN: {len(conflict_files)} rclone conflict file(s) (.path1/.path2) in {len(folders)} folder(s)"
-        )
-        for folder in folders[:5]:
-            issues.append(f"  • {os.path.basename(folder)}")
-
     # ── Stuck prep_in_progress jobs ──────────────────────────────────────────
     stuck_cutoff = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
     stuck = conn.execute(
@@ -400,50 +381,6 @@ def cmd_health_check():
         issues.append(f"WARN: {len(orphaned)} job(s) have prep_folder_path pointing to missing dir:")
         for r in orphaned[:5]:
             issues.append(f"  • {r['company']}: {r['title']}")
-
-    # ── Drive sync integrity ──────────────────────────────────────────────
-    try:
-        from findajob.paths import RCLONE
-
-        drive_base = "gdrive:01 PROJECTS/Jobs To Apply For"
-
-        mismatches = []
-        for subdir in ["", "_applied", "_rejected", "_waitlisted"]:
-            # Local folders
-            local_path = os.path.join(companies_dir, subdir) if subdir else companies_dir
-            if not os.path.isdir(local_path):
-                continue
-            local_folders = {
-                d
-                for d in os.listdir(local_path)
-                if not d.startswith("_") and os.path.isdir(os.path.join(local_path, d))
-            }
-
-            # Drive folders
-            drive_path = f"{drive_base}/{subdir}" if subdir else drive_base
-            rc = subprocess.run([RCLONE, "lsf", "--dirs-only", drive_path], capture_output=True, text=True, timeout=60)
-            if rc.returncode != 0:
-                mismatches.append(f"rclone lsf failed for {subdir or 'root'}: exit {rc.returncode}")
-                continue
-            drive_folders = {
-                d.rstrip("/") for d in rc.stdout.strip().split("\n") if d.strip() and not d.startswith("_")
-            }
-
-            location = subdir or "root"
-            local_only = local_folders - drive_folders
-            drive_only = drive_folders - local_folders
-
-            for f in local_only:
-                mismatches.append(f"LOCAL ONLY ({location}): {f}")
-            for f in drive_only:
-                mismatches.append(f"DRIVE ONLY ({location}): {f}")
-
-        if mismatches:
-            issues.append(f"WARN: {len(mismatches)} local↔Drive sync mismatch(es):")
-            for m in mismatches[:8]:
-                issues.append(f"  • {m}")
-    except Exception as e:
-        issues.append(f"INFO: Drive sync check skipped: {e}")
 
     # ── Stage/folder location mismatches ─────────────────────────────────────
     mismatches_rows = conn.execute("""

--- a/scripts/poll_flags.py
+++ b/scripts/poll_flags.py
@@ -14,23 +14,8 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from findajob.paths import BASE, RCLONE
+from findajob.paths import BASE
 from findajob.utils import is_valid_company, log_event, write_audit
-
-DRIVE_BASE = "gdrive:01 PROJECTS/Jobs To Apply For"
-
-# Maps DB stage to the Drive subdirectory where its folder lives.
-# Used to determine where to find the folder on Drive for move operations.
-STAGE_SUBDIR = {
-    "applied": "_applied",
-    "not_selected": "_applied",
-    "waitlisted": "_waitlisted",
-    "materials_drafted": "",
-    "prep_in_progress": "",
-    "scored": "",
-    "interview": "",
-    "offer": "",
-}
 
 DB_PATH = f"{BASE}/data/pipeline.db"
 SA_FILE = f"{BASE}/config/gsheets_creds.json"
@@ -40,75 +25,10 @@ with open(f"{BASE}/config/sheet_id.txt") as f:
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
 
 
-def sync_folder_to_drive(folder_path, drive_subdir=""):
-    """Copy a local folder to its Drive location. Called after local folder moves."""
-    folder_name = os.path.basename(folder_path)
-    if drive_subdir:
-        drive_dest = f"{DRIVE_BASE}/{drive_subdir}/{folder_name}"
-    else:
-        drive_dest = f"{DRIVE_BASE}/{folder_name}"
-    rc = subprocess.run(
-        [RCLONE, "copy", "--update", folder_path, drive_dest], capture_output=True, text=True, timeout=300
-    )
-    if rc.returncode != 0:
-        log_event(
-            "rclone_sync_failed",
-            folder=folder_name,
-            dest=drive_subdir or "top-level",
-            exit_code=rc.returncode,
-            stderr=(rc.stderr or "")[:200],
-        )
-        return False
-    log_event("folder_synced_to_drive", folder=folder_name, dest=drive_subdir or "top-level")
-    return True
-
-
-def delete_drive_folder(folder_name, drive_subdir=""):
-    """Delete a folder from Drive. Cleans up old location after a local move."""
-    if drive_subdir:
-        drive_path = f"{DRIVE_BASE}/{drive_subdir}/{folder_name}"
-    else:
-        drive_path = f"{DRIVE_BASE}/{folder_name}"
-    rc = subprocess.run([RCLONE, "purge", drive_path], capture_output=True, text=True, timeout=120)
-    if rc.returncode != 0:
-        log_event(
-            "rclone_delete_failed",
-            folder=folder_name,
-            location=drive_subdir or "top-level",
-            exit_code=rc.returncode,
-            stderr=(rc.stderr or "")[:200],
-        )
-        return False
-    return True
-
-
-def move_drive_folder(folder_name, from_subdir, to_subdir):
-    """Move a folder within Drive (server-side). Preserves user edits."""
-    src = f"{DRIVE_BASE}/{from_subdir}/{folder_name}" if from_subdir else f"{DRIVE_BASE}/{folder_name}"
-    dst = f"{DRIVE_BASE}/{to_subdir}/{folder_name}" if to_subdir else f"{DRIVE_BASE}/{folder_name}"
-    rc = subprocess.run([RCLONE, "move", src, dst], capture_output=True, text=True, timeout=300)
-    if rc.returncode != 0:
-        log_event(
-            "rclone_move_failed",
-            folder=folder_name,
-            src=from_subdir or "top-level",
-            dst=to_subdir or "top-level",
-            exit_code=rc.returncode,
-            stderr=(rc.stderr or "")[:200],
-        )
-        return False
-    # Clean up empty source directory
-    subprocess.run([RCLONE, "rmdir", src], capture_output=True, text=True, timeout=30)
-    log_event("folder_moved_on_drive", folder=folder_name, src=from_subdir or "top-level", dst=to_subdir or "top-level")
-    return True
-
-
-def handle_rejection(conn, job, reason, source_subdir=""):
+def handle_rejection(conn, job, reason):
     """Store rejection in DB, write to feedback_log, and move company folder to _rejected.
     Drops a marker file named {reason}_{date}.txt inside the moved folder.
-    source_subdir: Drive subdirectory where the folder currently lives (e.g. "_waitlisted").
-    Pass "" when the folder is at top-level (Dashboard rejections).
-    Returns True if a folder was moved (caller should trigger rclone)."""
+    Returns True if a folder was moved."""
     now = datetime.now(UTC).isoformat()
     old_stage = job["stage"]
     conn.execute(
@@ -138,11 +58,6 @@ def handle_rejection(conn, job, reason, source_subdir=""):
         conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
         log_event("folder_moved_to_rejected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
         folder_moved = True
-        # Determine where the folder currently lives on Drive
-        effective_source = source_subdir if source_subdir else STAGE_SUBDIR.get(old_stage, "")
-        move_drive_folder(os.path.basename(folder), effective_source, "_rejected")
-        # Push marker file and any new local content (--update won't overwrite user edits)
-        sync_folder_to_drive(dest, "_rejected")
 
     conn.commit()
     write_audit(conn, job["id"], "stage", old_stage, "rejected")
@@ -197,8 +112,6 @@ def handle_waitlist(conn, job):
         conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
         log_event("folder_moved_to_waitlisted", job_id=job["id"], folder=os.path.basename(folder))
         folder_moved = True
-        move_drive_folder(os.path.basename(folder), "", "_waitlisted")
-        sync_folder_to_drive(dest, "_waitlisted")
 
     conn.commit()
     write_audit(conn, job["id"], "stage", old_stage, "waitlisted")
@@ -224,8 +137,6 @@ def handle_reactivate(conn, job):
         )
         new_stage = "materials_drafted"
         folder_moved = True
-        move_drive_folder(os.path.basename(folder), "_waitlisted", "")
-        sync_folder_to_drive(dest)
     else:
         conn.execute("UPDATE jobs SET stage=?, updated_at=? WHERE id=?", ("scored", now, job["id"]))
         new_stage = "scored"
@@ -328,11 +239,7 @@ def main():
             folder = job["prep_folder_path"]
             if folder and os.path.isdir(folder):
                 shutil.rmtree(folder)
-                delete_drive_folder(os.path.basename(folder))
                 folders_moved += 1
-            elif folder:
-                # Folder path in DB but not on disk — still purge Drive copy
-                delete_drive_folder(os.path.basename(folder))
             now = datetime.now(UTC).isoformat()
             conn.execute(
                 """UPDATE jobs SET stage='prep_in_progress', prep_folder_path=NULL,
@@ -397,8 +304,6 @@ def main():
                         conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
                         conn.commit()
                         log_event("folder_moved_to_applied", job_id=job["id"], folder=os.path.basename(folder))
-                        move_drive_folder(os.path.basename(folder), "", "_applied")
-                        sync_folder_to_drive(dest, "_applied")
                         folders_moved += 1
                     applied_count += 1
 
@@ -525,9 +430,9 @@ def main():
         if not job or job["stage"] != "waitlisted":
             continue
 
-        # Rejection takes priority; folder is currently in _waitlisted/ on Drive
+        # Rejection takes priority
         if reject_val:
-            if handle_rejection(conn, job, reject_val, source_subdir="_waitlisted"):
+            if handle_rejection(conn, job, reject_val):
                 folders_moved += 1
             rejected_count += 1
             continue
@@ -573,11 +478,8 @@ def main():
     if need_sync:
         children.append(subprocess.Popen([sys.executable, f"{BASE}/scripts/sync_sheet.py"]))
 
-    # Folder moves use rclone move (server-side on Drive) to preserve user edits,
-    # then rclone copy --update to push new local files (markers) without overwriting.
-    # The jobsync timer handles pulling user edits from Drive back to local.
     if folders_moved:
-        log_event("folder_moves_synced_to_drive", count=folders_moved)
+        log_event("folder_moves_completed", count=folders_moved)
 
     if not flagged_jobs:
         log_event(

--- a/scripts/prep_application.py
+++ b/scripts/prep_application.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 
-from findajob.paths import AICHAT, BASE, PANDOC, RCLONE
+from findajob.paths import AICHAT, BASE, PANDOC
 from findajob.utils import (
     JD_MAX_CHARS,
     build_prep_filenames,
@@ -482,50 +482,9 @@ Generated: {date}
     log_event("prep_complete", company=company, title=title, folder=outdir)
     notify(f"Drafts ready: {company} — {title}\n{outdir}")
 
-    # ── Step 8: Push new folder to Drive immediately ──
-    # jobsync.timer runs rclone sync every 15 min as the steady-state mirror,
-    # but we push the new folder now so Step 9 (rclone link) can fetch the URL.
-    # Safe: jobsync uses rclone sync (not bisync), so no conflict copies.
-    folder_name = os.path.basename(outdir)
-    try:
-        subprocess.run(
-            [RCLONE, "copy", "--update", outdir, f"gdrive:01 PROJECTS/Jobs To Apply For/{folder_name}"],
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-    except Exception as e:
-        log_event("rclone_immediate_push_failed", job_id=job_id, error=str(e))
-
-    # ── Step 9: Fetch the Drive folder URL and store it ──
-    # Used by sync_sheet.py to render the company name as a HYPERLINK to the Drive folder.
-    # Failure is non-fatal: the cell stays plain text if rclone link fails.
-    drive_url = None
-    try:
-        link_rc = subprocess.run(
-            [RCLONE, "link", f"gdrive:01 PROJECTS/Jobs To Apply For/{folder_name}"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if link_rc.returncode == 0 and link_rc.stdout.strip().startswith("http"):
-            drive_url = link_rc.stdout.strip()
-            conn.execute("UPDATE jobs SET gdrive_folder_url=? WHERE id=?", (drive_url, job_id))
-            conn.commit()
-            log_event("gdrive_link_stored", job_id=job_id, url=drive_url)
-        else:
-            log_event(
-                "gdrive_link_failed",
-                job_id=job_id,
-                exit_code=link_rc.returncode,
-                stderr=link_rc.stderr[:200] if link_rc.stderr else "",
-            )
-    except Exception as e:
-        log_event("gdrive_link_failed", job_id=job_id, error=str(e))
-
     conn.close()
 
-    # ── Step 10: Sync sheets (single call, after everything is ready) ──
+    # ── Step 9: Sync sheets (single call, after everything is ready) ──
     subprocess.run([sys.executable, f"{BASE}/scripts/sync_sheet.py"], check=False)
 
     print(f"PREP_COMPLETE:{outdir}")

--- a/scripts/sync_sheet.py
+++ b/scripts/sync_sheet.py
@@ -282,16 +282,6 @@ def sync_dashboard(svc, conn):
         # Replace plain title with a HYPERLINK formula pointing to the JD URL
         title_idx = DASH_HEADERS.index("title")
         sheet_row[title_idx] = hyperlink(row["url"], row["title"])
-        # If materials have been prepped and we have a Drive folder URL, turn the
-        # company cell into a HYPERLINK to the Drive folder for quick access.
-        gdrive_url = row["gdrive_folder_url"] if "gdrive_folder_url" in row.keys() else None
-        if (
-            row["stage"] in ("materials_drafted", "applied", "interview", "offer")
-            and gdrive_url
-            and str(gdrive_url).startswith("http")
-        ):
-            company_idx = DASH_HEADERS.index("company")
-            sheet_row[company_idx] = hyperlink(gdrive_url, row["company"])
         sheet_rows.append(sheet_row)
 
     svc.spreadsheets().values().clear(spreadsheetId=SHEET_ID, range="Dashboard!A2:N10000").execute()
@@ -577,12 +567,7 @@ def sync_applied(svc, conn):
         # Live formula so "days_since_applied" updates without re-sync.
         days_formula = f'=IF(F{i}="","",TODAY()-F{i})' if applied_date else ""
         title_cell = hyperlink(row["url"], row["title"]) if row["url"] else safe_str(row["title"])
-        gdrive_url = row["gdrive_folder_url"] if "gdrive_folder_url" in row.keys() else None
-        company_cell = (
-            hyperlink(gdrive_url, row["company"])
-            if gdrive_url and str(gdrive_url).startswith("http")
-            else safe_str(row["company"])
-        )
+        company_cell = safe_str(row["company"])
         sheet_rows.append(
             [
                 status,
@@ -663,10 +648,6 @@ def sync_rejected_apps(svc, conn):
             safe_str(row["probability_score"] if row["probability_score"] else ""),
             safe_str(row["ai_notes"] or ""),
         ]
-        # Add Drive folder link on company cell if available
-        gdrive_url = row["gdrive_folder_url"] if "gdrive_folder_url" in row.keys() else None
-        if gdrive_url and str(gdrive_url).startswith("http"):
-            sheet_row[1] = hyperlink(gdrive_url, row["company"])
         sheet_rows.append(sheet_row)
 
     svc.spreadsheets().values().clear(spreadsheetId=SHEET_ID, range="Rejected Applications!A2:H10000").execute()

--- a/scripts/test_container_integration.sh
+++ b/scripts/test_container_integration.sh
@@ -95,7 +95,7 @@ trap cleanup EXIT
 
 echo "[setup] scratch dir: $SCRATCH  image: $IMAGE"
 
-mkdir -p "$SCRATCH/state"/{data,config,candidate_context,companies,logs,aichat_ng,rclone}
+mkdir -p "$SCRATCH/state"/{data,config,candidate_context,companies,logs,aichat_ng}
 
 # ────────────────────────────────────────────────────────────────────────────
 # 4. Seed inputs into the bind mounts
@@ -144,7 +144,8 @@ services:
       - ./state/companies:/app/companies
       - ./state/logs:/app/logs
       - ./state/aichat_ng:/app/.config/aichat_ng
-      - ./state/rclone:/app/.config/rclone
+    ports:
+      - "${TEST_MATERIALS_PORT:-18090}:8090"
 EOF
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -262,7 +263,34 @@ fi
 echo "  aichat-ng config.yaml: OK"
 
 # ────────────────────────────────────────────────────────────────────────────
-# 12. Done — cleanup runs on EXIT
+# 12. Materials viewer smoke
+# ────────────────────────────────────────────────────────────────────────────
+
+echo "[assert] materials viewer smoke"
+VIEWER_PORT="${TEST_MATERIALS_PORT:-18090}"
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${VIEWER_PORT}/healthz" || echo "FAIL")
+if [ "$HTTP_CODE" != "200" ]; then
+    echo "ERROR: /healthz returned $HTTP_CODE (expected 200)" >&2
+    exit 1
+fi
+echo "  /healthz: 200 OK"
+
+BODY=$(curl -s "http://localhost:${VIEWER_PORT}/" || echo "FAIL")
+if ! echo "$BODY" | grep -q "In flight"; then
+    echo "ERROR: index did not contain 'In flight'" >&2
+    exit 1
+fi
+echo "  index renders with expected sections"
+
+if (cd "$SCRATCH" && docker compose exec -T scheduler which rclone >/dev/null 2>&1); then
+    echo "ERROR: rclone is still in the image" >&2
+    exit 1
+fi
+echo "  rclone absent from image"
+
+# ────────────────────────────────────────────────────────────────────────────
+# 13. Done — cleanup runs on EXIT
 # ────────────────────────────────────────────────────────────────────────────
 
 echo

--- a/src/findajob/paths.py
+++ b/src/findajob/paths.py
@@ -4,11 +4,11 @@ Central path and base-directory resolver for all pipeline scripts.
 BASE is derived from this file's location — works wherever the repo is cloned,
 regardless of directory name or home folder. No hardcoded paths.
 
-Binary paths (AICHAT, PANDOC, RCLONE) are read from config/paths.env.
+Binary paths (AICHAT, PANDOC) are read from config/paths.env.
 Override defaults via config/paths.env if your binaries live elsewhere.
 
 Usage:
-    from findajob.paths import BASE, AICHAT, PANDOC, RCLONE
+    from findajob.paths import BASE, AICHAT, PANDOC
 
 Use sys.executable (not a PYTHON constant) for subprocess calls to other pipeline scripts.
 
@@ -44,4 +44,3 @@ if _penv.exists():
 # Override via config/paths.env if your install is non-standard.
 AICHAT: str = _cfg.get("AICHAT_NG", "/usr/local/bin/aichat-ng")
 PANDOC: str = _cfg.get("PANDOC", "/usr/bin/pandoc")
-RCLONE: str = _cfg.get("RCLONE", "/usr/bin/rclone")

--- a/src/findajob/web/__init__.py
+++ b/src/findajob/web/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI web materials viewer. Ships in 14a (#59)."""

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -1,6 +1,7 @@
 """FastAPI app factory for the materials viewer."""
 from __future__ import annotations
 
+import os
 import sqlite3
 from collections.abc import Generator
 from pathlib import Path
@@ -31,3 +32,14 @@ def create_app(*, companies_root: Path, db_path: Path) -> FastAPI:
     app.dependency_overrides.setdefault(routes.get_db, get_db)
     app.include_router(routes.router)
     return app
+
+
+def default_app() -> FastAPI:
+    """Factory used by uvicorn at container start.
+
+    Reads COMPANIES_ROOT and DB_PATH from env. Defaults match the
+    in-container layout.
+    """
+    companies_root = Path(os.environ.get("COMPANIES_ROOT", "/app/companies"))
+    db_path = Path(os.environ.get("DB_PATH", "/app/data/pipeline.db"))
+    return create_app(companies_root=companies_root, db_path=db_path)

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -1,4 +1,5 @@
 """FastAPI app factory for the materials viewer."""
+
 from __future__ import annotations
 
 import os

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -1,0 +1,33 @@
+"""FastAPI app factory for the materials viewer."""
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Generator
+from pathlib import Path
+
+from fastapi import Depends, FastAPI  # noqa: F401 — Depends used in Task 6
+from fastapi.templating import Jinja2Templates
+
+from findajob.web import routes
+
+
+def create_app(*, companies_root: Path, db_path: Path) -> FastAPI:
+    app = FastAPI(title="findajob materials viewer", docs_url=None, redoc_url=None)
+
+    templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+    app.state.companies_root = companies_root
+    app.state.db_path = db_path
+    app.state.templates = templates
+
+    def get_db() -> Generator[sqlite3.Connection, None, None]:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    app.dependency_overrides.setdefault(routes.get_db, get_db)
+    app.include_router(routes.router)
+    return app

--- a/src/findajob/web/folder_resolver.py
+++ b/src/findajob/web/folder_resolver.py
@@ -1,0 +1,40 @@
+"""Fingerprint → folder path resolution with traversal guards.
+
+Pure helper: no FastAPI, no I/O beyond filesystem existence checks.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def resolve_folder(
+    fingerprint: str, db: sqlite3.Connection, companies_root: Path
+) -> Path | None:
+    """Resolve a fingerprint to its prep-folder path on disk.
+
+    Returns None if:
+      - fingerprint is not in the jobs table
+      - jobs.prep_folder_path is NULL or empty
+      - the resolved path does not exist on disk
+      - the resolved path escapes companies_root (path-traversal guard)
+    """
+    row = db.execute(
+        "SELECT prep_folder_path FROM jobs WHERE fingerprint = ?", (fingerprint,)
+    ).fetchone()
+    if row is None:
+        return None
+    raw = row["prep_folder_path"] if isinstance(row, sqlite3.Row) else row[0]
+    if not raw:
+        return None
+
+    candidate = Path(raw).resolve()
+    root = companies_root.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+
+    if not candidate.is_dir():
+        return None
+    return candidate

--- a/src/findajob/web/folder_resolver.py
+++ b/src/findajob/web/folder_resolver.py
@@ -2,15 +2,14 @@
 
 Pure helper: no FastAPI, no I/O beyond filesystem existence checks.
 """
+
 from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
 
 
-def resolve_folder(
-    fingerprint: str, db: sqlite3.Connection, companies_root: Path
-) -> Path | None:
+def resolve_folder(fingerprint: str, db: sqlite3.Connection, companies_root: Path) -> Path | None:
     """Resolve a fingerprint to its prep-folder path on disk.
 
     Returns None if:
@@ -19,9 +18,7 @@ def resolve_folder(
       - the resolved path does not exist on disk
       - the resolved path escapes companies_root (path-traversal guard)
     """
-    row = db.execute(
-        "SELECT prep_folder_path FROM jobs WHERE fingerprint = ?", (fingerprint,)
-    ).fetchone()
+    row = db.execute("SELECT prep_folder_path FROM jobs WHERE fingerprint = ?", (fingerprint,)).fetchone()
     if row is None:
         return None
     raw = row["prep_folder_path"] if isinstance(row, sqlite3.Row) else row[0]

--- a/src/findajob/web/routes.py
+++ b/src/findajob/web/routes.py
@@ -1,0 +1,21 @@
+"""Route handlers for the materials viewer."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from fastapi import APIRouter, Request, Response
+
+router = APIRouter()
+
+
+def get_db() -> sqlite3.Connection:  # pragma: no cover — overridden in app factory
+    raise NotImplementedError("DB dependency must be overridden by create_app()")
+
+
+@router.get("/healthz", response_class=Response)
+def healthz(request: Request) -> Response:
+    root: Path = request.app.state.companies_root
+    if not root.is_dir():
+        return Response(content="companies/ missing", status_code=503, media_type="text/plain")
+    return Response(content="ok", status_code=200, media_type="text/plain")

--- a/src/findajob/web/routes.py
+++ b/src/findajob/web/routes.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import HTMLResponse
+
+from findajob.web.folder_resolver import resolve_folder
 
 router = APIRouter()
 
@@ -19,3 +22,34 @@ def healthz(request: Request) -> Response:
     if not root.is_dir():
         return Response(content="companies/ missing", status_code=503, media_type="text/plain")
     return Response(content="ok", status_code=200, media_type="text/plain")
+
+
+@router.get("/materials/{fingerprint}", response_class=HTMLResponse)
+def folder_view(
+    fingerprint: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),
+) -> HTMLResponse:
+    root: Path = request.app.state.companies_root
+    folder = resolve_folder(fingerprint, db, root)
+    if folder is None:
+        raise HTTPException(status_code=404, detail="folder not found")
+
+    row = db.execute(
+        "SELECT title, company, stage FROM jobs WHERE fingerprint = ?", (fingerprint,)
+    ).fetchone()
+
+    files = sorted(p.name for p in folder.iterdir() if p.is_file())
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="folder.html",
+        context={
+            "fingerprint": fingerprint,
+            "folder_name": folder.name,
+            "title": row["title"] if row else "",
+            "company": row["company"] if row else "",
+            "stage": row["stage"] if row else "",
+            "files": files,
+        },
+    )

--- a/src/findajob/web/routes.py
+++ b/src/findajob/web/routes.py
@@ -5,10 +5,9 @@ import re
 import sqlite3
 from pathlib import Path
 
+import markdown as md_lib
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
-
-import markdown as md_lib
 
 from findajob.web.folder_resolver import resolve_folder
 
@@ -31,7 +30,7 @@ def healthz(request: Request) -> Response:
 def folder_view(
     fingerprint: str,
     request: Request,
-    db: sqlite3.Connection = Depends(get_db),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
 ) -> HTMLResponse:
     root: Path = request.app.state.companies_root
     folder = resolve_folder(fingerprint, db, root)
@@ -72,7 +71,7 @@ def file_serve(
     fingerprint: str,
     filename: str,
     request: Request,
-    db: sqlite3.Connection = Depends(get_db),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
 ):
     root: Path = request.app.state.companies_root
     folder = resolve_folder(fingerprint, db, root)
@@ -83,7 +82,7 @@ def file_serve(
     try:
         candidate.relative_to(folder.resolve())
     except ValueError:
-        raise HTTPException(status_code=404, detail="invalid filename")
+        raise HTTPException(status_code=404, detail="invalid filename") from None
     if not candidate.is_file():
         raise HTTPException(status_code=404, detail="file not found")
 
@@ -132,7 +131,7 @@ def _fetch_section(db: sqlite3.Connection, where: str, order: str) -> list[sqlit
 
 
 @router.get("/", response_class=HTMLResponse)
-def index(request: Request, db: sqlite3.Connection = Depends(get_db)) -> HTMLResponse:
+def index(request: Request, db: sqlite3.Connection = Depends(get_db)) -> HTMLResponse:  # noqa: B008
     sections = []
     for name, where, order in _INDEX_QUERY_SECTIONS:
         rows = _fetch_section(db, where, order)

--- a/src/findajob/web/routes.py
+++ b/src/findajob/web/routes.py
@@ -105,3 +105,50 @@ def file_serve(
         filename=candidate.name,
         headers={"content-disposition": f'attachment; filename="{candidate.name}"'},
     )
+
+
+_INDEX_QUERY_SECTIONS = [
+    (
+        "In flight",
+        "stage IN ('materials_drafted', 'prep_in_progress')",
+        "created_at DESC",
+    ),
+    (
+        "Applied",
+        "stage IN ('applied', 'interview', 'offer')",
+        "COALESCE(applied_date, created_at) DESC",
+    ),
+    ("Waitlisted", "stage = 'waitlisted'", "created_at DESC"),
+]
+_REJECTED_CLAUSE = "stage IN ('rejected', 'not_selected')"
+_PER_SECTION_CAP = 50
+
+
+def _fetch_section(db: sqlite3.Connection, where: str, order: str) -> list[sqlite3.Row]:
+    return db.execute(
+        f"SELECT fingerprint, title, company, stage, score, created_at, applied_date "
+        f"FROM jobs WHERE {where} ORDER BY {order} LIMIT {_PER_SECTION_CAP + 1}"
+    ).fetchall()
+
+
+@router.get("/", response_class=HTMLResponse)
+def index(request: Request, db: sqlite3.Connection = Depends(get_db)) -> HTMLResponse:
+    sections = []
+    for name, where, order in _INDEX_QUERY_SECTIONS:
+        rows = _fetch_section(db, where, order)
+        overflow = len(rows) > _PER_SECTION_CAP
+        sections.append({"name": name, "rows": rows[:_PER_SECTION_CAP], "overflow": overflow})
+
+    rejected_rows = _fetch_section(db, _REJECTED_CLAUSE, "created_at DESC")
+    rejected = {
+        "rows": rejected_rows[:_PER_SECTION_CAP],
+        "overflow": len(rejected_rows) > _PER_SECTION_CAP,
+        "count": len(rejected_rows) if len(rejected_rows) <= _PER_SECTION_CAP else f"{_PER_SECTION_CAP}+",
+    }
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"sections": sections, "rejected": rejected},
+    )

--- a/src/findajob/web/routes.py
+++ b/src/findajob/web/routes.py
@@ -1,4 +1,5 @@
 """Route handlers for the materials viewer."""
+
 from __future__ import annotations
 
 import re
@@ -37,9 +38,7 @@ def folder_view(
     if folder is None:
         raise HTTPException(status_code=404, detail="folder not found")
 
-    row = db.execute(
-        "SELECT title, company, stage FROM jobs WHERE fingerprint = ?", (fingerprint,)
-    ).fetchone()
+    row = db.execute("SELECT title, company, stage FROM jobs WHERE fingerprint = ?", (fingerprint,)).fetchone()
 
     files = sorted(p.name for p in folder.iterdir() if p.is_file())
     templates = request.app.state.templates

--- a/src/findajob/web/routes.py
+++ b/src/findajob/web/routes.py
@@ -1,11 +1,14 @@
 """Route handlers for the materials viewer."""
 from __future__ import annotations
 
+import re
 import sqlite3
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from fastapi.responses import HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
+
+import markdown as md_lib
 
 from findajob.web.folder_resolver import resolve_folder
 
@@ -52,4 +55,53 @@ def folder_view(
             "stage": row["stage"] if row else "",
             "files": files,
         },
+    )
+
+
+def _render_markdown(text: str) -> str:
+    html = md_lib.markdown(text, extensions=["fenced_code", "tables"], output_format="html")
+    # Strip class attributes added by fenced_code (e.g. class="language-python")
+    html = re.sub(r' class="[^"]*"', "", html)
+    # Neutralize raw script tags that Python-Markdown passes through unchanged
+    html = re.sub(r"<(/?script)", r"&lt;\1", html, flags=re.IGNORECASE)
+    return html
+
+
+@router.get("/materials/{fingerprint}/{filename}")
+def file_serve(
+    fingerprint: str,
+    filename: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),
+):
+    root: Path = request.app.state.companies_root
+    folder = resolve_folder(fingerprint, db, root)
+    if folder is None:
+        raise HTTPException(status_code=404, detail="folder not found")
+
+    candidate = (folder / filename).resolve()
+    try:
+        candidate.relative_to(folder.resolve())
+    except ValueError:
+        raise HTTPException(status_code=404, detail="invalid filename")
+    if not candidate.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+
+    ext = candidate.suffix.lower()
+    if ext == ".md":
+        body = candidate.read_text(encoding="utf-8", errors="replace")
+        templates = request.app.state.templates
+        return templates.TemplateResponse(
+            request=request,
+            name="base.html",
+            context={"_rendered_md": _render_markdown(body)},
+            headers={"content-type": "text/html; charset=utf-8"},
+        )
+    if ext == ".txt":
+        return PlainTextResponse(content=candidate.read_text(encoding="utf-8", errors="replace"))
+    # Everything else (.docx, .pdf, unknown) → attachment
+    return FileResponse(
+        path=candidate,
+        filename=candidate.name,
+        headers={"content-disposition": f'attachment; filename="{candidate.name}"'},
     )

--- a/src/findajob/web/templates/base.html
+++ b/src/findajob/web/templates/base.html
@@ -20,6 +20,11 @@
   </style>
 </head>
 <body>
-{% block body %}{% endblock %}
+{% if _rendered_md is defined %}
+  <p><a href="javascript:history.back()">← back</a></p>
+  {{ _rendered_md | safe }}
+{% else %}
+  {% block body %}{% endblock %}
+{% endif %}
 </body>
 </html>

--- a/src/findajob/web/templates/base.html
+++ b/src/findajob/web/templates/base.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}findajob materials{% endblock %}</title>
+  <style>
+    body { font-family: -apple-system, system-ui, sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; color: #222; }
+    a { color: #0366d6; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    h1, h2 { border-bottom: 1px solid #eee; padding-bottom: 0.3em; }
+    ul { padding-left: 1.2em; }
+    li { margin: 0.3em 0; }
+    .meta { color: #666; font-size: 0.9em; }
+    .stage { color: #0366d6; }
+    .score { color: #22863a; font-weight: 600; }
+    details summary { cursor: pointer; color: #666; }
+    pre, code { font-family: ui-monospace, monospace; background: #f6f8fa; }
+    pre { padding: 1em; overflow-x: auto; }
+    code { padding: 0.1em 0.3em; border-radius: 3px; }
+  </style>
+</head>
+<body>
+{% block body %}{% endblock %}
+</body>
+</html>

--- a/src/findajob/web/templates/folder.html
+++ b/src/findajob/web/templates/folder.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}{{ company }} — {{ title }}{% endblock %}
+{% block body %}
+<p><a href="/">← back to index</a></p>
+<h1>{{ company }} — {{ title }}</h1>
+<p class="meta">{{ folder_name }} · <span class="stage">{{ stage }}</span></p>
+<ul>
+  {% for name in files %}
+    <li><a href="/materials/{{ fingerprint }}/{{ name }}">{{ name }}</a></li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/src/findajob/web/templates/index.html
+++ b/src/findajob/web/templates/index.html
@@ -1,0 +1,43 @@
+{% extends "base.html" %}
+{% block title %}findajob — materials{% endblock %}
+{% block body %}
+<h1>findajob materials</h1>
+
+{% for section in sections %}
+<h2>{{ section.name }}</h2>
+{% if section.rows %}
+<ul>
+  {% for row in section.rows %}
+    <li>
+      <a href="/materials/{{ row.fingerprint }}">{{ row.company }} — {{ row.title }}</a>
+      {% if row.score %} <span class="score">[{{ row.score }}]</span>{% endif %}
+      <span class="meta">
+        (<span class="stage">{{ row.stage }}</span>)
+        {% if row.applied_date %} · {{ row.applied_date }}{% endif %}
+      </span>
+    </li>
+  {% endfor %}
+</ul>
+{% if section.overflow %}<p class="meta">…and more</p>{% endif %}
+{% else %}
+<p class="meta">None.</p>
+{% endif %}
+{% endfor %}
+
+<details>
+  <summary>Rejected ({{ rejected.count }})</summary>
+  {% if rejected.rows %}
+  <ul>
+    {% for row in rejected.rows %}
+      <li>
+        <a href="/materials/{{ row.fingerprint }}">{{ row.company }} — {{ row.title }}</a>
+        <span class="meta">· {{ row.stage }} · {{ row.created_at }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+  {% if rejected.overflow %}<p class="meta">…and more</p>{% endif %}
+  {% else %}
+  <p class="meta">None.</p>
+  {% endif %}
+</details>
+{% endblock %}

--- a/tests/test_poll_flags.py
+++ b/tests/test_poll_flags.py
@@ -1,7 +1,7 @@
-"""Tests for poll_flags.py state machine: DB transitions, folder moves, Drive sync.
+"""Tests for poll_flags.py state machine: DB transitions, folder moves, and stage updates.
 
-Uses a real in-memory SQLite database. Mocks Google Sheets API, rclone subprocess,
-and module-level side effects so poll_flags can be imported cleanly.
+Uses a real in-memory SQLite database. Mocks Google Sheets API and module-level side effects
+so poll_flags can be imported cleanly.
 """
 
 import importlib
@@ -175,9 +175,6 @@ def companies_dir(tmp_path):
 def _patch_poll_flags(poll_flags_mod, tmp_path, monkeypatch):
     """Patch poll_flags module globals for every test."""
     monkeypatch.setattr(poll_flags_mod, "BASE", str(tmp_path))
-    monkeypatch.setattr(poll_flags_mod, "RCLONE", "/bin/true")
-    monkeypatch.setattr(poll_flags_mod, "sync_folder_to_drive", lambda *a, **kw: True)
-    monkeypatch.setattr(poll_flags_mod, "delete_drive_folder", lambda *a, **kw: True)
     monkeypatch.setattr(poll_flags_mod, "log_event", lambda *a, **kw: None)
     # Ensure companies subdirectories exist under tmp_path
     os.makedirs(os.path.join(str(tmp_path), "companies", "_applied"), exist_ok=True)
@@ -278,23 +275,6 @@ class TestHandleRejection:
         fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
         assert fb is not None
 
-    def test_rejection_from_waitlisted_source_subdir(self, poll_flags_mod, db, tmp_path, monkeypatch):
-        """Rejecting from Waitlist tab uses move_drive_folder from _waitlisted to _rejected."""
-        folder = tmp_path / "companies" / "_waitlisted" / "Acme_Ops_2026-04-13_130000"
-        folder.mkdir(parents=True, exist_ok=True)
-
-        move_calls = []
-        monkeypatch.setattr(
-            poll_flags_mod, "move_drive_folder", lambda name, src, dst: move_calls.append((name, src, dst))
-        )
-
-        job = insert_job(db, stage="waitlisted", folder=str(folder))
-        poll_flags_mod.handle_rejection(db, job, "No Longer Interested", source_subdir="_waitlisted")
-
-        assert len(move_calls) == 1
-        assert move_calls[0][1] == "_waitlisted"
-        assert move_calls[0][2] == "_rejected"
-
     def test_rejection_writes_jd_excerpt(self, poll_flags_mod, db):
         """If job has raw_jd_text, feedback_log gets first 500 chars."""
         long_jd = "A" * 1000
@@ -389,20 +369,11 @@ class TestHandleNotSelected:
 
 
 class TestHandleWaitlist:
-    def test_waitlist_with_folder(self, poll_flags_mod, db, tmp_path, monkeypatch):
-        """Folder moves to _waitlisted/, stage updated, Drive moved server-side."""
+    def test_waitlist_with_folder(self, poll_flags_mod, db, tmp_path):
+        """Folder moves to _waitlisted/, stage updated."""
         folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_140000"
         folder.mkdir(parents=True, exist_ok=True)
         (folder / "cover_letter.docx").touch()
-
-        sync_calls = []
-        monkeypatch.setattr(
-            poll_flags_mod, "sync_folder_to_drive", lambda path, subdir="": sync_calls.append((path, subdir))
-        )
-        move_calls = []
-        monkeypatch.setattr(
-            poll_flags_mod, "move_drive_folder", lambda name, src, dst: move_calls.append((name, src, dst))
-        )
 
         job = insert_job(db, stage="materials_drafted", folder=str(folder))
         result = poll_flags_mod.handle_waitlist(db, job)
@@ -413,14 +384,6 @@ class TestHandleWaitlist:
         assert row["stage"] == "waitlisted"
         assert "_waitlisted" in row["prep_folder_path"]
         assert os.path.isdir(row["prep_folder_path"])
-
-        # Drive sync called to push any new local content
-        assert len(sync_calls) == 1
-        assert sync_calls[0][1] == "_waitlisted"
-        # Server-side move from top-level to _waitlisted
-        assert len(move_calls) == 1
-        assert move_calls[0][1] == ""
-        assert move_calls[0][2] == "_waitlisted"
 
     def test_waitlist_without_folder(self, poll_flags_mod, db):
         """No folder: stage updated, no folder operations, returns False."""
@@ -447,16 +410,11 @@ class TestHandleWaitlist:
 
 
 class TestHandleReactivate:
-    def test_reactivate_with_folder(self, poll_flags_mod, db, tmp_path, monkeypatch):
+    def test_reactivate_with_folder(self, poll_flags_mod, db, tmp_path):
         """Folder moves back from _waitlisted/, stage→materials_drafted."""
         folder = tmp_path / "companies" / "_waitlisted" / "Acme_Ops_2026-04-13_150000"
         folder.mkdir(parents=True, exist_ok=True)
         (folder / "resume.pdf").touch()
-
-        sync_calls = []
-        monkeypatch.setattr(
-            poll_flags_mod, "sync_folder_to_drive", lambda path, subdir="": sync_calls.append((path, subdir))
-        )
 
         job = insert_job(db, stage="waitlisted", folder=str(folder))
         result = poll_flags_mod.handle_reactivate(db, job)
@@ -468,10 +426,6 @@ class TestHandleReactivate:
         assert "_waitlisted" not in row["prep_folder_path"]
         assert os.path.isdir(row["prep_folder_path"])
         assert os.path.isfile(os.path.join(row["prep_folder_path"], "resume.pdf"))
-
-        # Drive sync: new location synced, old _waitlisted location deleted
-        assert len(sync_calls) == 1
-        assert sync_calls[0][1] == ""  # top-level, not in a subdir
 
     def test_reactivate_without_folder(self, poll_flags_mod, db):
         """No folder: stage→scored."""
@@ -556,18 +510,13 @@ class TestDashboardFlagForPrep:
 
 
 class TestDashboardRegenerate:
-    def test_regenerate_with_folder(self, poll_flags_mod, db, tmp_path, monkeypatch):
-        """Regenerate: folder deleted, Drive folder deleted, stage=prep_in_progress."""
+    def test_regenerate_with_folder(self, poll_flags_mod, db, tmp_path):
+        """Regenerate: folder deleted locally, stage=prep_in_progress."""
         from datetime import UTC, datetime
 
         folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_160000"
         folder.mkdir(parents=True, exist_ok=True)
         (folder / "resume.pdf").touch()
-
-        delete_calls = []
-        monkeypatch.setattr(
-            poll_flags_mod, "delete_drive_folder", lambda name, subdir="": delete_calls.append((name, subdir))
-        )
 
         job = insert_job(
             db, stage="materials_drafted", folder=str(folder), gdrive_url="https://drive.google.com/folder/abc"
@@ -581,7 +530,6 @@ class TestDashboardRegenerate:
                 import shutil
 
                 shutil.rmtree(f)
-                poll_flags_mod.delete_drive_folder(os.path.basename(f))
             now = datetime.now(UTC).isoformat()
             db.execute(
                 """UPDATE jobs SET stage='prep_in_progress', prep_folder_path=NULL,
@@ -600,7 +548,6 @@ class TestDashboardRegenerate:
         assert row["gdrive_folder_url"] is None
         assert row["apply_flag"] == 1
         assert not folder.exists()
-        assert len(delete_calls) == 1
 
     def test_regenerate_without_folder(self, poll_flags_mod, db):
         """Regenerate when prep_folder_path is NULL → still sets prep_in_progress."""
@@ -623,18 +570,13 @@ class TestDashboardRegenerate:
 
 
 class TestDashboardStatusUpdates:
-    def test_applied_with_folder(self, poll_flags_mod, db, tmp_path, monkeypatch):
+    def test_applied_with_folder(self, poll_flags_mod, db, tmp_path):
         """Applied: stage=applied, folder moves to _applied/."""
         from datetime import UTC, datetime
 
         folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_170000"
         folder.mkdir(parents=True, exist_ok=True)
         (folder / "cover_letter.pdf").touch()
-
-        sync_calls = []
-        monkeypatch.setattr(
-            poll_flags_mod, "sync_folder_to_drive", lambda path, subdir="": sync_calls.append((path, subdir))
-        )
 
         job = insert_job(db, stage="materials_drafted", folder=str(folder))
 
@@ -657,13 +599,11 @@ class TestDashboardStatusUpdates:
             shutil.move(f, dest)
             db.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
             db.commit()
-            poll_flags_mod.sync_folder_to_drive(dest, "_applied")
 
         row = db.execute("SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
         assert row["stage"] == "applied"
         assert "_applied" in row["prep_folder_path"]
         assert os.path.isdir(row["prep_folder_path"])
-        assert len(sync_calls) == 1
 
     def test_applied_without_folder(self, poll_flags_mod, db):
         """Applied without folder: stage=applied, no folder move."""
@@ -814,25 +754,6 @@ class TestWaitlistTab:
         row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
         assert row["stage"] == "scored"
 
-    def test_reject_from_waitlist(self, poll_flags_mod, db, tmp_path, monkeypatch):
-        """Reject from Waitlist tab uses move_drive_folder from _waitlisted to _rejected."""
-        folder = tmp_path / "companies" / "_waitlisted" / "Acme_Ops_2026-04-13_180000"
-        folder.mkdir(parents=True, exist_ok=True)
-
-        move_calls = []
-        monkeypatch.setattr(
-            poll_flags_mod, "move_drive_folder", lambda name, src, dst: move_calls.append((name, src, dst))
-        )
-
-        job = insert_job(db, stage="waitlisted", folder=str(folder))
-        poll_flags_mod.handle_rejection(db, job, "Company Withdrew", source_subdir="_waitlisted")
-
-        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "rejected"
-        assert len(move_calls) == 1
-        assert move_calls[0][1] == "_waitlisted"
-        assert move_calls[0][2] == "_rejected"
-
     def test_rejection_priority_over_reactivate(self, poll_flags_mod, db):
         """Both reject and reactivate set → rejection wins (main() logic)."""
         job = insert_job(db, stage="waitlisted")
@@ -841,7 +762,7 @@ class TestWaitlistTab:
 
         # main() checks reject_val first
         if reject_val:
-            poll_flags_mod.handle_rejection(db, job, reject_val, source_subdir="_waitlisted")
+            poll_flags_mod.handle_rejection(db, job, reject_val)
         elif status_val == "Reactivate":
             poll_flags_mod.handle_reactivate(db, job)
 

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -282,7 +282,7 @@ class TestDBStateTransitions:
         assert row["probability_score"] == 60.0
 
     def test_gdrive_url_stored_on_success(self, db):
-        """Drive URL stored when rclone link succeeds."""
+        """Drive URL stored in DB when gdrive_folder_url is set."""
         job_id = insert_job(
             db, stage="materials_drafted", folder="/home/user/companies/Acme_Ops_Manager_2026-04-13_140000"
         )
@@ -294,12 +294,12 @@ class TestDBStateTransitions:
         row = db.execute("SELECT gdrive_folder_url FROM jobs WHERE id=?", (job_id,)).fetchone()
         assert row["gdrive_folder_url"] == drive_url
 
-    def test_gdrive_url_stays_null_on_failure(self, db):
-        """Drive URL stays NULL when rclone link fails (no update executed)."""
+    def test_gdrive_url_stays_null_when_not_set(self, db):
+        """Drive URL stays NULL when no update is executed."""
         job_id = insert_job(
             db, stage="materials_drafted", folder="/home/user/companies/Acme_Ops_Manager_2026-04-13_140000"
         )
-        # Simulate rclone failure — no UPDATE issued
+        # No UPDATE issued — URL should remain NULL
         row = db.execute("SELECT gdrive_folder_url FROM jobs WHERE id=?", (job_id,)).fetchone()
         assert row["gdrive_folder_url"] is None
 
@@ -370,45 +370,3 @@ class TestFileNaming:
         should_skip = existing and existing["prep_folder_path"] and existing["stage"] == "materials_drafted"
         assert not should_skip
 
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Drive URL Flow Tests
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-class TestDriveURLFlow:
-    """Test the rclone link → DB storage flow logic."""
-
-    def test_rclone_link_success_stores_url(self, db):
-        """Simulate successful rclone link output: returncode=0, stdout starts with http."""
-        job_id = insert_job(
-            db, stage="materials_drafted", folder="/home/user/companies/Acme_Ops_Manager_2026-04-13_140000"
-        )
-        # Simulate: link_rc.returncode == 0, link_rc.stdout.strip().startswith("http")
-        returncode = 0
-        stdout = "https://drive.google.com/drive/folders/abc123\n"
-
-        if returncode == 0 and stdout.strip().startswith("http"):
-            drive_url = stdout.strip()
-            db.execute("UPDATE jobs SET gdrive_folder_url=? WHERE id=?", (drive_url, job_id))
-            db.commit()
-
-        row = db.execute("SELECT gdrive_folder_url FROM jobs WHERE id=?", (job_id,)).fetchone()
-        assert row["gdrive_folder_url"] == "https://drive.google.com/drive/folders/abc123"
-
-    def test_rclone_link_failure_leaves_null(self, db):
-        """Simulate rclone link failure: returncode=4, no URL stored."""
-        job_id = insert_job(
-            db, stage="materials_drafted", folder="/home/user/companies/Acme_Ops_Manager_2026-04-13_140000"
-        )
-        # Simulate: link_rc.returncode == 4
-        returncode = 4
-        stdout = "ERROR: command not found\n"
-
-        if returncode == 0 and stdout.strip().startswith("http"):
-            drive_url = stdout.strip()
-            db.execute("UPDATE jobs SET gdrive_folder_url=? WHERE id=?", (drive_url, job_id))
-            db.commit()
-
-        row = db.execute("SELECT gdrive_folder_url FROM jobs WHERE id=?", (job_id,)).fetchone()
-        assert row["gdrive_folder_url"] is None

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -369,4 +369,3 @@ class TestFileNaming:
 
         should_skip = existing and existing["prep_folder_path"] and existing["stage"] == "materials_drafted"
         assert not should_skip
-

--- a/tests/test_web_folder_resolver.py
+++ b/tests/test_web_folder_resolver.py
@@ -73,3 +73,31 @@ def test_resolve_null_prep_folder_path_returns_none(
         ("fp-nopath",),
     )
     assert resolve_folder("fp-nopath", db, companies_root) is None
+
+
+def test_rejects_absolute_path_outside_root(
+    companies_root: Path, db: sqlite3.Connection, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    outside = tmp_path_factory.mktemp("outside")
+    _seed(db, "fp-outside", str(outside))
+    assert resolve_folder("fp-outside", db, companies_root) is None
+
+
+def test_rejects_dotdot_traversal(
+    companies_root: Path, db: sqlite3.Connection
+) -> None:
+    malicious = str(companies_root / ".." / "outside-root")
+    _seed(db, "fp-traversal", malicious)
+    assert resolve_folder("fp-traversal", db, companies_root) is None
+
+
+def test_rejects_symlink_escaping_root(
+    companies_root: Path,
+    db: sqlite3.Connection,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    outside_target = tmp_path_factory.mktemp("outside_target")
+    link = companies_root / "escape_link"
+    link.symlink_to(outside_target)
+    _seed(db, "fp-symlink", str(link))
+    assert resolve_folder("fp-symlink", db, companies_root) is None

--- a/tests/test_web_folder_resolver.py
+++ b/tests/test_web_folder_resolver.py
@@ -1,4 +1,5 @@
 """Tests for fingerprint → folder path resolution."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -22,9 +23,7 @@ def companies_root(tmp_path: Path) -> Path:
 def db() -> sqlite3.Connection:
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
-    conn.execute(
-        "CREATE TABLE jobs (fingerprint TEXT PRIMARY KEY, prep_folder_path TEXT, stage TEXT)"
-    )
+    conn.execute("CREATE TABLE jobs (fingerprint TEXT PRIMARY KEY, prep_folder_path TEXT, stage TEXT)")
     return conn
 
 
@@ -52,22 +51,16 @@ def test_resolve_applied_folder(companies_root: Path, db: sqlite3.Connection) ->
     assert result == companies_root / "_applied" / "Google_PM_2026-04-15_100000"
 
 
-def test_resolve_unknown_fingerprint_returns_none(
-    companies_root: Path, db: sqlite3.Connection
-) -> None:
+def test_resolve_unknown_fingerprint_returns_none(companies_root: Path, db: sqlite3.Connection) -> None:
     assert resolve_folder("fp-unknown", db, companies_root) is None
 
 
-def test_resolve_folder_missing_on_disk_returns_none(
-    companies_root: Path, db: sqlite3.Connection
-) -> None:
+def test_resolve_folder_missing_on_disk_returns_none(companies_root: Path, db: sqlite3.Connection) -> None:
     _seed(db, "fp-ghost", str(companies_root / "Ghost_Folder_Never_Existed"))
     assert resolve_folder("fp-ghost", db, companies_root) is None
 
 
-def test_resolve_null_prep_folder_path_returns_none(
-    companies_root: Path, db: sqlite3.Connection
-) -> None:
+def test_resolve_null_prep_folder_path_returns_none(companies_root: Path, db: sqlite3.Connection) -> None:
     db.execute(
         "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES (?, NULL, 'scored')",
         ("fp-nopath",),
@@ -83,9 +76,7 @@ def test_rejects_absolute_path_outside_root(
     assert resolve_folder("fp-outside", db, companies_root) is None
 
 
-def test_rejects_dotdot_traversal(
-    companies_root: Path, db: sqlite3.Connection
-) -> None:
+def test_rejects_dotdot_traversal(companies_root: Path, db: sqlite3.Connection) -> None:
     malicious = str(companies_root / ".." / "outside-root")
     _seed(db, "fp-traversal", malicious)
     assert resolve_folder("fp-traversal", db, companies_root) is None

--- a/tests/test_web_folder_resolver.py
+++ b/tests/test_web_folder_resolver.py
@@ -1,0 +1,75 @@
+"""Tests for fingerprint → folder path resolution."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from findajob.web.folder_resolver import resolve_folder
+
+
+@pytest.fixture
+def companies_root(tmp_path: Path) -> Path:
+    (tmp_path / "Meta_SWE_2026-04-20_120000").mkdir()
+    (tmp_path / "_applied" / "Google_PM_2026-04-15_100000").mkdir(parents=True)
+    (tmp_path / "_waitlisted" / "Stripe_DE_2026-04-10_090000").mkdir(parents=True)
+    (tmp_path / "_rejected" / "X_SRE_2026-04-01_080000").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE jobs (fingerprint TEXT PRIMARY KEY, prep_folder_path TEXT, stage TEXT)"
+    )
+    return conn
+
+
+def _seed(db: sqlite3.Connection, fp: str, folder: str, stage: str = "materials_drafted") -> None:
+    db.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES (?, ?, ?)",
+        (fp, folder, stage),
+    )
+
+
+def test_resolve_active_folder(companies_root: Path, db: sqlite3.Connection) -> None:
+    _seed(db, "fp-active", str(companies_root / "Meta_SWE_2026-04-20_120000"))
+    result = resolve_folder("fp-active", db, companies_root)
+    assert result == companies_root / "Meta_SWE_2026-04-20_120000"
+
+
+def test_resolve_applied_folder(companies_root: Path, db: sqlite3.Connection) -> None:
+    _seed(
+        db,
+        "fp-applied",
+        str(companies_root / "_applied" / "Google_PM_2026-04-15_100000"),
+        stage="applied",
+    )
+    result = resolve_folder("fp-applied", db, companies_root)
+    assert result == companies_root / "_applied" / "Google_PM_2026-04-15_100000"
+
+
+def test_resolve_unknown_fingerprint_returns_none(
+    companies_root: Path, db: sqlite3.Connection
+) -> None:
+    assert resolve_folder("fp-unknown", db, companies_root) is None
+
+
+def test_resolve_folder_missing_on_disk_returns_none(
+    companies_root: Path, db: sqlite3.Connection
+) -> None:
+    _seed(db, "fp-ghost", str(companies_root / "Ghost_Folder_Never_Existed"))
+    assert resolve_folder("fp-ghost", db, companies_root) is None
+
+
+def test_resolve_null_prep_folder_path_returns_none(
+    companies_root: Path, db: sqlite3.Connection
+) -> None:
+    db.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES (?, NULL, 'scored')",
+        ("fp-nopath",),
+    )
+    assert resolve_folder("fp-nopath", db, companies_root) is None

--- a/tests/test_web_integration.py
+++ b/tests/test_web_integration.py
@@ -3,6 +3,7 @@
 Spins up a FastAPI TestClient against a tmpdir `companies/` tree and a
 scratch SQLite. Validates all routes together.
 """
+
 from __future__ import annotations
 
 import sqlite3

--- a/tests/test_web_integration.py
+++ b/tests/test_web_integration.py
@@ -1,0 +1,85 @@
+"""End-to-end integration tests for the materials viewer.
+
+Spins up a FastAPI TestClient against a tmpdir `companies/` tree and a
+scratch SQLite. Validates all routes together.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def world(tmp_path: Path) -> dict:
+    companies = tmp_path / "companies"
+    companies.mkdir()
+
+    active = companies / "Meta_SWE_2026-04-20_120000"
+    active.mkdir()
+    (active / "tailored_resume.docx").write_bytes(b"PK\x03\x04fake")
+    (active / "cover_letter.md").write_text("# Cover\n\nBody.\n")
+
+    applied = companies / "_applied" / "Google_PM_2026-04-15_100000"
+    applied.mkdir(parents=True)
+    (applied / "notes.txt").write_text("applied on 2026-04-15\n")
+
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """CREATE TABLE jobs (
+            fingerprint TEXT PRIMARY KEY,
+            prep_folder_path TEXT,
+            stage TEXT,
+            title TEXT,
+            company TEXT,
+            score INTEGER,
+            created_at TEXT,
+            applied_date TEXT
+        )"""
+    )
+    conn.executemany(
+        "INSERT INTO jobs VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("fp-active", str(active), "materials_drafted", "SWE", "Meta", 8, "2026-04-20", None),
+            ("fp-applied", str(applied), "applied", "PM", "Google", 7, "2026-04-15", "2026-04-15"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    app = create_app(companies_root=companies, db_path=db)
+    return {"client": TestClient(app), "companies": companies, "db": db}
+
+
+def test_full_flow(world: dict) -> None:
+    client = world["client"]
+
+    r = client.get("/healthz")
+    assert r.status_code == 200
+
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "Meta" in r.text
+    assert "Google" in r.text
+
+    r = client.get("/materials/fp-active")
+    assert r.status_code == 200
+    assert "tailored_resume.docx" in r.text
+    assert "cover_letter.md" in r.text
+
+    r = client.get("/materials/fp-active/cover_letter.md")
+    assert r.status_code == 200
+    assert "<h1>Cover</h1>" in r.text
+
+    r = client.get("/materials/fp-active/tailored_resume.docx")
+    assert r.status_code == 200
+    assert "attachment" in r.headers.get("content-disposition", "")
+
+    r = client.get("/materials/fp-applied/notes.txt")
+    assert r.status_code == 200
+    assert "applied on 2026-04-15" in r.text

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,0 +1,48 @@
+"""Unit tests for the web viewer routes."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def companies_root(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    p = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(p)
+    conn.execute(
+        """CREATE TABLE jobs (
+            fingerprint TEXT PRIMARY KEY,
+            prep_folder_path TEXT,
+            stage TEXT,
+            title TEXT,
+            company TEXT,
+            score INTEGER,
+            created_at TEXT,
+            applied_date TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+    return p
+
+
+@pytest.fixture
+def client(companies_root: Path, db_path: Path) -> TestClient:
+    app = create_app(companies_root=companies_root, db_path=db_path)
+    return TestClient(app)
+
+
+def test_healthz_returns_ok(client: TestClient) -> None:
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.text == "ok"

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -74,3 +74,121 @@ def test_folder_route_lists_files(
 def test_folder_route_404_on_unknown_fingerprint(client: TestClient) -> None:
     r = client.get("/materials/fp-does-not-exist")
     assert r.status_code == 404
+
+
+def test_file_serve_markdown_rendered_inline(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    folder = companies_root / "Company_X_2026-04-20_130000"
+    folder.mkdir()
+    (folder / "notes.md").write_text("# Hello\n\n```python\nprint('hi')\n```\n")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES ('fp-md', ?, 'materials_drafted')",
+        (str(folder),),
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/materials/fp-md/notes.md")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    assert "<h1>Hello</h1>" in r.text
+    assert "<code>print" in r.text
+
+
+def test_file_serve_docx_as_attachment(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    folder = companies_root / "Company_Y_2026-04-20_140000"
+    folder.mkdir()
+    (folder / "resume.docx").write_bytes(b"PK\x03\x04fake-docx-bytes")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES ('fp-docx', ?, 'materials_drafted')",
+        (str(folder),),
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/materials/fp-docx/resume.docx")
+    assert r.status_code == 200
+    assert "attachment" in r.headers.get("content-disposition", "")
+    assert "resume.docx" in r.headers.get("content-disposition", "")
+
+
+def test_file_serve_txt_inline(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    folder = companies_root / "Company_Z_2026-04-20_150000"
+    folder.mkdir()
+    (folder / "raw.txt").write_text("plain text body\n")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES ('fp-txt', ?, 'materials_drafted')",
+        (str(folder),),
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/materials/fp-txt/raw.txt")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/plain")
+    assert "plain text body" in r.text
+
+
+def test_file_serve_404_on_unknown_filename(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    folder = companies_root / "Company_W_2026-04-20_160000"
+    folder.mkdir()
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES ('fp-empty', ?, 'materials_drafted')",
+        (str(folder),),
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/materials/fp-empty/nonexistent.md")
+    assert r.status_code == 404
+
+
+def test_file_serve_rejects_traversal(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    folder = companies_root / "Company_T_2026-04-20_170000"
+    folder.mkdir()
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES ('fp-t', ?, 'materials_drafted')",
+        (str(folder),),
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/materials/fp-t/..%2Fescape")
+    assert r.status_code == 404
+
+
+def test_file_serve_markdown_escapes_raw_html(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    folder = companies_root / "Company_XSS_2026-04-20_180000"
+    folder.mkdir()
+    (folder / "bad.md").write_text("# Title\n\n<script>alert('x')</script>\n")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage) VALUES ('fp-xss', ?, 'materials_drafted')",
+        (str(folder),),
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/materials/fp-xss/bad.md")
+    assert r.status_code == 200
+    assert "<script>" not in r.text

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -46,3 +46,31 @@ def test_healthz_returns_ok(client: TestClient) -> None:
     r = client.get("/healthz")
     assert r.status_code == 200
     assert r.text == "ok"
+
+
+def test_folder_route_lists_files(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    folder = companies_root / "Meta_SWE_2026-04-20_120000"
+    folder.mkdir()
+    (folder / "tailored_resume.docx").write_bytes(b"docx-bytes")
+    (folder / "cover_letter.md").write_text("# Hello\n")
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage, title, company) "
+        "VALUES (?, ?, 'materials_drafted', 'SWE', 'Meta')",
+        ("fp-1", str(folder)),
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/materials/fp-1")
+    assert r.status_code == 200
+    assert "tailored_resume.docx" in r.text
+    assert "cover_letter.md" in r.text
+
+
+def test_folder_route_404_on_unknown_fingerprint(client: TestClient) -> None:
+    r = client.get("/materials/fp-does-not-exist")
+    assert r.status_code == 404

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,4 +1,5 @@
 """Unit tests for the web viewer routes."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -48,9 +49,7 @@ def test_healthz_returns_ok(client: TestClient) -> None:
     assert r.text == "ok"
 
 
-def test_folder_route_lists_files(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_folder_route_lists_files(client: TestClient, companies_root: Path, db_path: Path) -> None:
     folder = companies_root / "Meta_SWE_2026-04-20_120000"
     folder.mkdir()
     (folder / "tailored_resume.docx").write_bytes(b"docx-bytes")
@@ -76,9 +75,7 @@ def test_folder_route_404_on_unknown_fingerprint(client: TestClient) -> None:
     assert r.status_code == 404
 
 
-def test_file_serve_markdown_rendered_inline(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_file_serve_markdown_rendered_inline(client: TestClient, companies_root: Path, db_path: Path) -> None:
     folder = companies_root / "Company_X_2026-04-20_130000"
     folder.mkdir()
     (folder / "notes.md").write_text("# Hello\n\n```python\nprint('hi')\n```\n")
@@ -98,9 +95,7 @@ def test_file_serve_markdown_rendered_inline(
     assert "<code>print" in r.text
 
 
-def test_file_serve_docx_as_attachment(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_file_serve_docx_as_attachment(client: TestClient, companies_root: Path, db_path: Path) -> None:
     folder = companies_root / "Company_Y_2026-04-20_140000"
     folder.mkdir()
     (folder / "resume.docx").write_bytes(b"PK\x03\x04fake-docx-bytes")
@@ -119,9 +114,7 @@ def test_file_serve_docx_as_attachment(
     assert "resume.docx" in r.headers.get("content-disposition", "")
 
 
-def test_file_serve_txt_inline(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_file_serve_txt_inline(client: TestClient, companies_root: Path, db_path: Path) -> None:
     folder = companies_root / "Company_Z_2026-04-20_150000"
     folder.mkdir()
     (folder / "raw.txt").write_text("plain text body\n")
@@ -140,9 +133,7 @@ def test_file_serve_txt_inline(
     assert "plain text body" in r.text
 
 
-def test_file_serve_404_on_unknown_filename(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_file_serve_404_on_unknown_filename(client: TestClient, companies_root: Path, db_path: Path) -> None:
     folder = companies_root / "Company_W_2026-04-20_160000"
     folder.mkdir()
     conn = sqlite3.connect(db_path)
@@ -157,9 +148,7 @@ def test_file_serve_404_on_unknown_filename(
     assert r.status_code == 404
 
 
-def test_file_serve_rejects_traversal(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_file_serve_rejects_traversal(client: TestClient, companies_root: Path, db_path: Path) -> None:
     folder = companies_root / "Company_T_2026-04-20_170000"
     folder.mkdir()
     conn = sqlite3.connect(db_path)
@@ -174,9 +163,7 @@ def test_file_serve_rejects_traversal(
     assert r.status_code == 404
 
 
-def test_file_serve_markdown_escapes_raw_html(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_file_serve_markdown_escapes_raw_html(client: TestClient, companies_root: Path, db_path: Path) -> None:
     folder = companies_root / "Company_XSS_2026-04-20_180000"
     folder.mkdir()
     (folder / "bad.md").write_text("# Title\n\n<script>alert('x')</script>\n")
@@ -194,9 +181,7 @@ def test_file_serve_markdown_escapes_raw_html(
     assert "<script>" not in r.text
 
 
-def test_index_groups_jobs_by_stage(
-    client: TestClient, companies_root: Path, db_path: Path
-) -> None:
+def test_index_groups_jobs_by_stage(client: TestClient, companies_root: Path, db_path: Path) -> None:
     for folder_name in ("M1", "_applied/M2", "_waitlisted/M3", "_rejected/M4"):
         (companies_root / folder_name).mkdir(parents=True)
 
@@ -227,9 +212,7 @@ def test_index_groups_jobs_by_stage(
     assert "RejCo" in r.text
 
 
-def test_default_app_uses_env_vars(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_default_app_uses_env_vars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     from findajob.web.app import default_app
 
     companies = tmp_path / "companies"

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -192,3 +192,36 @@ def test_file_serve_markdown_escapes_raw_html(
     r = client.get("/materials/fp-xss/bad.md")
     assert r.status_code == 200
     assert "<script>" not in r.text
+
+
+def test_index_groups_jobs_by_stage(
+    client: TestClient, companies_root: Path, db_path: Path
+) -> None:
+    for folder_name in ("M1", "_applied/M2", "_waitlisted/M3", "_rejected/M4"):
+        (companies_root / folder_name).mkdir(parents=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO jobs (fingerprint, prep_folder_path, stage, title, company, score, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            ("fp-a", str(companies_root / "M1"), "materials_drafted", "SWE", "InFlightCo", 8, "2026-04-20"),
+            ("fp-b", str(companies_root / "_applied" / "M2"), "applied", "PM", "AppliedCo", 7, "2026-04-15"),
+            ("fp-c", str(companies_root / "_waitlisted" / "M3"), "waitlisted", "DE", "WaitCo", 6, "2026-04-10"),
+            ("fp-d", str(companies_root / "_rejected" / "M4"), "rejected", "SRE", "RejCo", 5, "2026-04-01"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "In flight" in r.text
+    assert "InFlightCo" in r.text
+    assert "Applied" in r.text
+    assert "AppliedCo" in r.text
+    assert "Waitlisted" in r.text
+    assert "WaitCo" in r.text
+    # Rejected is in a <details>; content is still rendered in HTML
+    assert "<details>" in r.text
+    assert "RejCo" in r.text

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -225,3 +225,28 @@ def test_index_groups_jobs_by_stage(
     # Rejected is in a <details>; content is still rendered in HTML
     assert "<details>" in r.text
     assert "RejCo" in r.text
+
+
+def test_default_app_uses_env_vars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from findajob.web.app import default_app
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    db_path = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE jobs (fingerprint TEXT, prep_folder_path TEXT, stage TEXT, "
+        "title TEXT, company TEXT, score INTEGER, created_at TEXT, applied_date TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("COMPANIES_ROOT", str(companies))
+    monkeypatch.setenv("DB_PATH", str(db_path))
+
+    app = default_app()
+    client = TestClient(app)
+    r = client.get("/healthz")
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary

- Ships src/findajob/web/ — FastAPI viewer on per-stack host port.
- Retires rclone + Google Drive sync entirely (closes #29 as part of the same change).
- Tagged migration-required; one-time operator stack update documented in docs/setup/state-migration.md.

## Closes

- Closes #59
- Closes #29 (rclone retirement was part of #59's acceptance criteria)

## Spec / Plan

- Spec: docs/superpowers/specs/2026-04-20-web-materials-viewer-design.md
- Plan: docs/superpowers/plans/2026-04-20-web-materials-viewer.md

## Test plan

- [x] pytest -x green (469 tests)
- [x] ruff check . green
- [x] mypy green (20 pre-existing errors in unrelated files; none introduced by this branch)
- [x] Container smoke script (scripts/test_container_integration.sh) extended with viewer + rclone-absent checks
- [ ] Post-merge: deploy on both operator stack and Alice Doe stack; curl /healthz on each
- [ ] Post-merge: dogfood for 24h; confirm rclone timer absence doesn't break any workflow