### PR TITLE
fix(sheet): link company cells to materials viewer (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+- `sync_sheet.py` now hyperlinks the company cell on Dashboard, Applied, Waitlist, and Rejected Applications tabs into the materials viewer when a new `FINDAJOB_MATERIALS_BASE_URL` env var is set (e.g., `http://docker.lan:8090`). Stages without folders and unset env var render as plain text (no 404s). Stale "Drive hyperlink" annotations removed from `CLAUDE.md`, `docs/google-sheets.md`, and `setup_sheets.py` (#130).
+
 ## [0.1.2] — 2026-04-21
 
 Retires the Google Drive / rclone folder-browsing surface in favor of a local FastAPI web viewer served per stack. The container image loses the `rclone` apt package (~50 MB smaller), gains a uvicorn co-process, and publishes a new `FINDAJOB_MATERIALS_PORT` — each stack picks its own. Operators with `FINDAJOB_JOBSYNC_ENABLED=true` on v0.1.x need a one-time stack update; fresh-install testers are unaffected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,7 +243,7 @@ Low-score old jobs from non-target companies stay in DB only.
 `STATUS(dropdown) | REJECT_REASON(dropdown) | fingerprint(hidden) | fit_score | probability_score | relevance_score | title(hyperlink) | company | location | remote | contacts | comp | notes | date`
 
 **Applied** — post-application queue (A–N), filter: `stage IN (applied, interview, offer)`. This is the UI for managing jobs you've submitted and are waiting to hear back on:
-`STATUS(dropdown) | REJECT_REASON(dropdown) | fingerprint(hidden) | title(hyperlink) | company(Drive hyperlink) | applied_date | days_since_applied(formula) | stage | user_notes | known_contacts | location | remote | comp | ai_notes`
+`STATUS(dropdown) | REJECT_REASON(dropdown) | fingerprint(hidden) | title(hyperlink) | company(viewer hyperlink) | applied_date | days_since_applied(formula) | stage | user_notes | known_contacts | location | remote | comp | ai_notes`
 - `STATUS` options (col A): `Interviewing` / `Offer` / `Ghosted` / `Not Selected` / `Withdrew`
 - `days_since_applied` = live `=IF(F2="","",TODAY()-F2)` formula — no re-sync needed
 - Row color by priority: Offer→gold, Interviewing→purple, Ghosted OR >=21d→gray, 14–20d→red, 7–13d→yellow, 0–6d→green

--- a/docs/google-sheets.md
+++ b/docs/google-sheets.md
@@ -53,7 +53,7 @@ Columns A–N:
 | E | probability_score | System |
 | F | relevance_score | System |
 | G | title (hyperlink) | System |
-| H | company | System (hyperlink to Drive folder when prepped) |
+| H | company | System (plain text on Sheet1; hyperlinks into the materials viewer on Dashboard/Applied/Waitlist/Rejected Applications when `FINDAJOB_MATERIALS_BASE_URL` is set) |
 | I | location | System |
 | J | remote_status | System |
 | K | known_contacts | System |
@@ -124,7 +124,7 @@ Columns A–N:
 | B | REJECT_REASON | You (dropdown — same 11 options as Dashboard) |
 | C | fingerprint (hidden) | System |
 | D | title (hyperlink to JD) | System |
-| E | company (hyperlink to Drive folder) | System |
+| E | company (hyperlinks into materials viewer when `FINDAJOB_MATERIALS_BASE_URL` is set) | System |
 | F | applied_date | System (from `audit_log` first `applied` transition) |
 | G | days_since_applied | Live `=IF(F2="","",TODAY()-F2)` formula |
 | H | stage | System (`applied` / `interview` / `offer`) |
@@ -221,7 +221,7 @@ Columns A–H:
 | Col | Field |
 |---|---|
 | A | title (hyperlink) |
-| B | company (hyperlink to Drive folder if available) |
+| B | company (hyperlinks into materials viewer when `FINDAJOB_MATERIALS_BASE_URL` is set) |
 | C | reject_reason |
 | D | applied_date |
 | E | rejected_date |

--- a/ops/compose.yaml.example
+++ b/ops/compose.yaml.example
@@ -18,6 +18,7 @@ services:
       HOME: /app
       JSP_BASE: /app
       FINDAJOB_TRIAGE_TIMEOUT: ${FINDAJOB_TRIAGE_TIMEOUT:-7200}
+      FINDAJOB_MATERIALS_BASE_URL: ${FINDAJOB_MATERIALS_BASE_URL:-}
     volumes:
       - ./state/data:/app/data
       - ./state/config:/app/config

--- a/ops/stack.env.example
+++ b/ops/stack.env.example
@@ -24,6 +24,12 @@ PGID=1000
 # Current allocation starts at 8090 and increments per stack.
 FINDAJOB_MATERIALS_PORT=8090
 
+# Base URL of the materials viewer as reachable from the user's browser.
+# sync_sheet.py uses this to hyperlink company cells on Dashboard/Applied/
+# Waitlist/Rejected Applications into the viewer. Unset → plain text, no
+# crash. Match the hostname + FINDAJOB_MATERIALS_PORT of this stack.
+FINDAJOB_MATERIALS_BASE_URL=http://docker.lan:8090
+
 # Triage timeout in seconds. Default 7200 (2h) is generous for steady
 # state (~30-45min typical). For fresh installs with a large first feed
 # pull, bump to 21600 (6h) for the first week, then drop back.

--- a/scripts/setup_sheets.py
+++ b/scripts/setup_sheets.py
@@ -1212,7 +1212,7 @@ def main():
         col_width(applied_id, 0, 120),  # A: STATUS
         col_width(applied_id, 1, 140),  # B: REJECT_REASON
         col_width(applied_id, 3, 280),  # D: title (hyperlink)
-        col_width(applied_id, 4, 150),  # E: company (Drive hyperlink)
+        col_width(applied_id, 4, 150),  # E: company (hyperlinks into materials viewer)
         col_width(applied_id, 5, 100),  # F: applied_date
         col_width(applied_id, 6, 70),  # G: days_since_applied
         col_width(applied_id, 7, 90),  # H: stage

--- a/scripts/sync_sheet.py
+++ b/scripts/sync_sheet.py
@@ -495,9 +495,7 @@ def sync_waitlist(svc, conn):
                 sheet_row.append(hyperlink(row["url"], row["title"]))
             elif header == "company":
                 sheet_row.append(
-                    materials_company_cell(
-                        row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL
-                    )
+                    materials_company_cell(row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL)
                 )
             elif header == "blocking_app":
                 co = (row["company"] or "").strip().lower()
@@ -618,9 +616,7 @@ def sync_applied(svc, conn):
         # Live formula so "days_since_applied" updates without re-sync.
         days_formula = f'=IF(F{i}="","",TODAY()-F{i})' if applied_date else ""
         title_cell = hyperlink(row["url"], row["title"]) if row["url"] else safe_str(row["title"])
-        company_cell = materials_company_cell(
-            row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL
-        )
+        company_cell = materials_company_cell(row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL)
         sheet_rows.append(
             [
                 status,
@@ -693,9 +689,7 @@ def sync_rejected_apps(svc, conn):
     for row in rows:
         sheet_row = [
             hyperlink(row["url"], row["title"]),
-            materials_company_cell(
-                row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL
-            ),
+            materials_company_cell(row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL),
             safe_str(row["reject_reason"] or ""),
             safe_str(applied_dates.get(row["id"], "")),
             safe_str(row["rejected_date"][:10] if row["rejected_date"] else ""),

--- a/scripts/sync_sheet.py
+++ b/scripts/sync_sheet.py
@@ -8,6 +8,7 @@ Sync SQLite → Google Sheets.
              poll_flags.py reads STATUS + REJECT_REASON from Dashboard and Review tabs.
 """
 
+import os
 import sqlite3
 from pathlib import Path
 
@@ -16,12 +17,19 @@ from googleapiclient.discovery import build
 
 from findajob.config_loader import is_company_of_interest
 from findajob.paths import BASE
-from findajob.utils import log_event
+from findajob.utils import load_env, log_event
+
+load_env()
 
 DB_PATH = f"{BASE}/data/pipeline.db"
 SA_FILE = f"{BASE}/config/gsheets_creds.json"
 with open(f"{BASE}/config/sheet_id.txt") as f:
     SHEET_ID = f.read().strip()
+
+# Base URL for the materials viewer that hyperlinks company cells into.
+# Set per stack (e.g., http://docker.lan:8090 matching FINDAJOB_MATERIALS_PORT).
+# Unset → company cells render as plain text.
+MATERIALS_BASE_URL = os.getenv("FINDAJOB_MATERIALS_BASE_URL", "").strip()
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
 
@@ -106,6 +114,36 @@ def hyperlink(url, label):
     if not safe_url:
         return safe_label
     return f'=HYPERLINK("{safe_url}","{safe_label}")'
+
+
+# Stages where a companies/ folder exists on disk and the materials viewer
+# can render it. Used to decide whether the Sheet's company cell should
+# hyperlink into the viewer.
+_FOLDER_STAGES = frozenset(
+    {
+        "prep_in_progress",
+        "materials_drafted",
+        "applied",
+        "interview",
+        "offer",
+        "not_selected",
+        "waitlisted",
+        "rejected",
+    }
+)
+
+
+def materials_company_cell(company, fingerprint, stage, base_url):
+    """Return either a =HYPERLINK formula to the materials viewer or plain text.
+
+    Hyperlinks only when `base_url` is set AND `stage` is one where a folder
+    exists on disk. Missing base_url → plain text (no viewer configured for
+    this stack). Non-folder stage → plain text (viewer would 404).
+    """
+    if not base_url or stage not in _FOLDER_STAGES:
+        return safe_str(company)
+    url = f"{base_url.rstrip('/')}/materials/{fingerprint}"
+    return hyperlink(url, company)
 
 
 def safe_str(val):
@@ -282,6 +320,12 @@ def sync_dashboard(svc, conn):
         # Replace plain title with a HYPERLINK formula pointing to the JD URL
         title_idx = DASH_HEADERS.index("title")
         sheet_row[title_idx] = hyperlink(row["url"], row["title"])
+        # Replace plain company with a HYPERLINK into the materials viewer
+        # (only hyperlinks when a folder exists on disk and base URL is set)
+        company_idx = DASH_HEADERS.index("company")
+        sheet_row[company_idx] = materials_company_cell(
+            row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL
+        )
         sheet_rows.append(sheet_row)
 
     svc.spreadsheets().values().clear(spreadsheetId=SHEET_ID, range="Dashboard!A2:N10000").execute()
@@ -449,6 +493,12 @@ def sync_waitlist(svc, conn):
                 sheet_row.append(safe_str(pending_rejects.get(fp, row["reject_reason"] or "")))
             elif header == "title":
                 sheet_row.append(hyperlink(row["url"], row["title"]))
+            elif header == "company":
+                sheet_row.append(
+                    materials_company_cell(
+                        row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL
+                    )
+                )
             elif header == "blocking_app":
                 co = (row["company"] or "").strip().lower()
                 sheet_row.append(safe_str(active_by_company.get(co, "")))
@@ -469,7 +519,8 @@ def sync_waitlist(svc, conn):
 # ── Applied: post-application queue (stage in applied/interview/offer) ───────
 # Col A: STATUS (Interviewing/Offer/Ghosted/Not Selected/Withdrew),
 # Col B: REJECT_REASON, Col C: fingerprint (hidden).
-# Title → hyperlink to JD; Company → hyperlink to Drive folder.
+# Title → hyperlink to JD; Company → hyperlink to materials viewer folder
+# (when FINDAJOB_MATERIALS_BASE_URL is set and the row's stage has a folder).
 # Col F: applied_date, Col G: days_since_applied (live TODAY() formula).
 APPLIED_HEADERS = [
     "STATUS",
@@ -567,7 +618,9 @@ def sync_applied(svc, conn):
         # Live formula so "days_since_applied" updates without re-sync.
         days_formula = f'=IF(F{i}="","",TODAY()-F{i})' if applied_date else ""
         title_cell = hyperlink(row["url"], row["title"]) if row["url"] else safe_str(row["title"])
-        company_cell = safe_str(row["company"])
+        company_cell = materials_company_cell(
+            row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL
+        )
         sheet_rows.append(
             [
                 status,
@@ -640,7 +693,9 @@ def sync_rejected_apps(svc, conn):
     for row in rows:
         sheet_row = [
             hyperlink(row["url"], row["title"]),
-            safe_str(row["company"]),
+            materials_company_cell(
+                row["company"], row["fingerprint"], row["stage"], MATERIALS_BASE_URL
+            ),
             safe_str(row["reject_reason"] or ""),
             safe_str(applied_dates.get(row["id"], "")),
             safe_str(row["rejected_date"][:10] if row["rejected_date"] else ""),

--- a/tests/test_sync_sheet.py
+++ b/tests/test_sync_sheet.py
@@ -29,6 +29,7 @@ with patch("builtins.open", side_effect=_patched_open):
         S1_LOOKUP,
         build_row,
         hyperlink,
+        materials_company_cell,
         safe_str,
     )
 
@@ -243,45 +244,94 @@ class TestBuildRowSheet1:
 
 
 # ---------------------------------------------------------------------------
-# Dashboard company hyperlink logic (replicating sync_dashboard conditional)
+# materials_company_cell() — hyperlinks company name to the web materials viewer
 # ---------------------------------------------------------------------------
 
 
-def _company_cell(row):
-    """Replicate the sync_dashboard conditional for company hyperlink."""
-    gdrive_url = row["gdrive_folder_url"] if "gdrive_folder_url" in row.keys() else None
-    if row["stage"] == "materials_drafted" and gdrive_url and str(gdrive_url).startswith("http"):
-        return hyperlink(gdrive_url, row["company"])
-    return safe_str(row["company"])
+class TestMaterialsCompanyCell:
+    """materials_company_cell builds =HYPERLINK when a folder exists and
+    FINDAJOB_MATERIALS_BASE_URL is set; otherwise returns plain company text."""
 
-
-class TestDashboardCompanyHyperlink:
-    def test_materials_drafted_with_gdrive_url(self):
-        row = _make_row(
-            stage="materials_drafted",
-            gdrive_folder_url="https://drive.google.com/folder/xyz",
+    def test_folder_stage_with_base_url_returns_hyperlink(self):
+        result = materials_company_cell(
             company="Acme Corp",
+            fingerprint="abc123",
+            stage="applied",
+            base_url="http://docker.lan:8090",
         )
-        result = _company_cell(row)
-        assert result == '=HYPERLINK("https://drive.google.com/folder/xyz","Acme Corp")'
+        assert result == '=HYPERLINK("http://docker.lan:8090/materials/abc123","Acme Corp")'
 
-    def test_materials_drafted_no_gdrive_url(self):
-        row = _make_row(
+    def test_materials_drafted_stage_returns_hyperlink(self):
+        result = materials_company_cell(
+            company="Acme",
+            fingerprint="fp-1",
             stage="materials_drafted",
-            gdrive_folder_url="",
-            company="Acme Corp",
+            base_url="http://docker.lan:8090",
         )
-        result = _company_cell(row)
-        assert result == "Acme Corp"
+        assert result == '=HYPERLINK("http://docker.lan:8090/materials/fp-1","Acme")'
 
-    def test_scored_with_gdrive_url_no_hyperlink(self):
-        row = _make_row(
+    def test_waitlisted_stage_returns_hyperlink(self):
+        result = materials_company_cell(
+            company="Acme",
+            fingerprint="fp-w",
+            stage="waitlisted",
+            base_url="http://docker.lan:8090",
+        )
+        assert result == '=HYPERLINK("http://docker.lan:8090/materials/fp-w","Acme")'
+
+    def test_scored_stage_no_folder_returns_plain(self):
+        result = materials_company_cell(
+            company="Acme Corp",
+            fingerprint="abc123",
             stage="scored",
-            gdrive_folder_url="https://drive.google.com/folder/xyz",
-            company="Acme Corp",
+            base_url="http://docker.lan:8090",
         )
-        result = _company_cell(row)
         assert result == "Acme Corp"
+
+    def test_manual_review_stage_no_folder_returns_plain(self):
+        result = materials_company_cell(
+            company="Acme",
+            fingerprint="fp-m",
+            stage="manual_review",
+            base_url="http://docker.lan:8090",
+        )
+        assert result == "Acme"
+
+    def test_empty_base_url_returns_plain(self):
+        result = materials_company_cell(
+            company="Acme Corp",
+            fingerprint="abc123",
+            stage="applied",
+            base_url="",
+        )
+        assert result == "Acme Corp"
+
+    def test_none_base_url_returns_plain(self):
+        result = materials_company_cell(
+            company="Acme Corp",
+            fingerprint="abc123",
+            stage="applied",
+            base_url=None,
+        )
+        assert result == "Acme Corp"
+
+    def test_trailing_slash_on_base_url_is_handled(self):
+        result = materials_company_cell(
+            company="Acme",
+            fingerprint="fp-1",
+            stage="applied",
+            base_url="http://docker.lan:8090/",
+        )
+        assert result == '=HYPERLINK("http://docker.lan:8090/materials/fp-1","Acme")'
+
+    def test_company_name_with_double_quote_is_escaped(self):
+        result = materials_company_cell(
+            company='O"Reilly Media',
+            fingerprint="fp-q",
+            stage="applied",
+            base_url="http://docker.lan:8090",
+        )
+        assert result == '=HYPERLINK("http://docker.lan:8090/materials/fp-q","O""Reilly Media")'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Company names on Dashboard, Applied, Waitlist, and Rejected Applications now hyperlink into the materials viewer when `FINDAJOB_MATERIALS_BASE_URL` is set (e.g. `http://docker.lan:8090`).
- Unset env var → plain text, no crash. Non-folder stages (scored, manual_review) → plain text, no 404.
- Stale "Drive hyperlink" annotations from the pre-v0.1.2 rclone/Drive era removed from `CLAUDE.md`, `docs/google-sheets.md`, `setup_sheets.py`, and the `sync_sheet.py` docstring.

Closes #130.

## Test plan
- [x] 9 new unit tests in `tests/test_sync_sheet.py::TestMaterialsCompanyCell` cover: env+folder-stage → link, env+no-folder-stage → plain, no env → plain, trailing-slash URL, quoted company name
- [x] Full test suite green (463 passed, +9 new; web tests skipped locally due to fastapi not in dev venv — CI runs them)
- [x] ruff clean, mypy clean
- [ ] Manual smoke on docker.lan after merge: set `FINDAJOB_MATERIALS_BASE_URL=http://docker.lan:8090` in the stack `.env`, restart, run `sync_sheet.py`, click a company cell on Applied → viewer folder opens