### PR TITLE
feat(web): foundation — top nav + /materials move + routes/ package split (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ### Added
 - `sync_sheet.py` now hyperlinks the company cell on Dashboard, Applied, Waitlist, and Rejected Applications tabs into the materials viewer when a new `FINDAJOB_MATERIALS_BASE_URL` env var is set (e.g., `http://docker.lan:8090`). Stages without folders and unset env var render as plain text (no 404s). Stale "Drive hyperlink" annotations removed from `CLAUDE.md`, `docs/google-sheets.md`, and `setup_sheets.py` (#130).
+- Web viewer now has a top nav and landing page. Materials folder index moved from `/` to `/materials/`; deep links `/materials/{fingerprint}` and `/materials/{fingerprint}/{filename}` unchanged. Placeholder pages for board, ingest, tools, config, docs fill in as features land (#60).
 
 ### Migration required
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,17 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 <repo>/.github/workflows/ci.yml            # CI: ruff + mypy + pytest on every push
 ```
 
+### Web Frontend Architecture
+
+Lives at `src/findajob/web/`. One file per URL group in `routes/` (e.g. `routes/materials.py`, `routes/board.py`, `routes/landing.py`). Shared partials (`_nav.html`, `_job_row.html`) live in `templates/`.
+
+Foundational decisions (from `docs/superpowers/specs/2026-04-21-web-frontend-14b-design.md`):
+- Server-rendered HTML + HTMX (no SPA)
+- Grouped URL IA — top-nav = `/`, `/board/`, `/materials/`, `/ingest/`, `/tools/`, `/config/`, `/docs/`
+- Tailwind via CDN + `static/app.css` design tokens
+- URL query params for UI state (not cookies/localStorage)
+- Alpine.js added only when ephemeral client state is needed
+
 ---
 
 ## Critical Architecture Rules

--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -82,6 +82,9 @@ VPN this is reachable from any device. The viewer is read-only — it displays p
 contents grouped by stage (staged, applied, waitlisted, rejected), renders Markdown inline,
 and offers `.docx` files for download.
 
+The viewer has a top nav linking all feature groups. `/` is a pipeline-at-a-glance landing
+page with stage counts; `/materials/` is the prep-folder index (previously served at `/`).
+
 ```bash
 # Quick smoke test after first deploy
 curl http://docker.lan:8090/healthz    # expect: ok

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 from fastapi import Depends, FastAPI  # noqa: F401 — Depends used in Task 6
+from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from findajob.web.routes import materials as _materials_routes
@@ -18,6 +19,9 @@ def create_app(*, companies_root: Path, db_path: Path) -> FastAPI:
     app = FastAPI(title="findajob materials viewer", docs_url=None, redoc_url=None)
 
     templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+    static_dir = Path(__file__).parent / "static"
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
     app.state.companies_root = companies_root
     app.state.db_path = db_path

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from fastapi import Depends, FastAPI  # noqa: F401 — Depends used in Task 6
 from fastapi.templating import Jinja2Templates
 
-from findajob.web import routes
+from findajob.web.routes import materials as _materials_routes
+from findajob.web.routes import router as _aggregated_router
 
 
 def create_app(*, companies_root: Path, db_path: Path) -> FastAPI:
@@ -30,8 +31,8 @@ def create_app(*, companies_root: Path, db_path: Path) -> FastAPI:
         finally:
             conn.close()
 
-    app.dependency_overrides.setdefault(routes.get_db, get_db)
-    app.include_router(routes.router)
+    app.dependency_overrides.setdefault(_materials_routes.get_db, get_db)
+    app.include_router(_aggregated_router)
     return app
 
 

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -1,4 +1,5 @@
 """Aggregates all sub-module routers into a single `router` the app includes."""
+
 from fastapi import APIRouter
 
 from findajob.web.routes import board, healthz, landing, materials

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -1,0 +1,10 @@
+"""Aggregates all sub-module routers into a single `router` the app includes."""
+from fastapi import APIRouter
+
+from findajob.web.routes import board, healthz, landing, materials
+
+router = APIRouter()
+router.include_router(materials.router)
+router.include_router(healthz.router)
+router.include_router(landing.router)
+router.include_router(board.router)

--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -1,0 +1,4 @@
+"""Stub — real handlers added in a later task."""
+from fastapi import APIRouter
+
+router = APIRouter()

--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -1,4 +1,5 @@
 """Stub — real handlers added in a later task."""
+
 from fastapi import APIRouter
 
 router = APIRouter()

--- a/src/findajob/web/routes/healthz.py
+++ b/src/findajob/web/routes/healthz.py
@@ -1,4 +1,5 @@
 """Health check endpoint."""
+
 from pathlib import Path
 
 from fastapi import APIRouter, Request

--- a/src/findajob/web/routes/healthz.py
+++ b/src/findajob/web/routes/healthz.py
@@ -1,0 +1,15 @@
+"""Health check endpoint."""
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import Response
+
+router = APIRouter()
+
+
+@router.get("/healthz", response_class=Response)
+def healthz(request: Request) -> Response:
+    root: Path = request.app.state.companies_root
+    if not root.is_dir():
+        return Response(content="companies/ missing", status_code=503, media_type="text/plain")
+    return Response(content="ok", status_code=200, media_type="text/plain")

--- a/src/findajob/web/routes/landing.py
+++ b/src/findajob/web/routes/landing.py
@@ -39,3 +39,29 @@ def landing(
         name="landing.html",
         context={"ordered": ordered},
     )
+
+
+_PLACEHOLDERS = [
+    ("/board/", "Board", "Dashboard, Applied, Review, Waitlist, Archive will live here.", "#60"),
+    ("/ingest/", "Ingest", "Manual job form and synthetic JD submission.", "#79"),
+    ("/tools/", "Tools", "Doctor, stats, scoreboard.", ""),
+    ("/config/", "Config", "Roles, prefilter rules, feedback tuning.", ""),
+    ("/docs/", "Docs", "User-facing documentation.", ""),
+]
+
+
+def _make_placeholder(path: str, label: str, hint: str, issue: str):
+    @router.get(path, response_class=HTMLResponse)
+    def _handler(request: Request) -> HTMLResponse:
+        templates = request.app.state.templates
+        return templates.TemplateResponse(
+            request=request,
+            name="placeholders/coming_soon.html",
+            context={"label": label, "hint": hint, "issue": issue},
+        )
+    _handler.__name__ = f"placeholder_{label.lower()}"
+    return _handler
+
+
+for _p, _l, _h, _i in _PLACEHOLDERS:
+    _make_placeholder(_p, _l, _h, _i)

--- a/src/findajob/web/routes/landing.py
+++ b/src/findajob/web/routes/landing.py
@@ -1,4 +1,5 @@
 """Landing page at / and placeholder groups."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -59,6 +60,7 @@ def _make_placeholder(path: str, label: str, hint: str, issue: str):
             name="placeholders/coming_soon.html",
             context={"label": label, "hint": hint, "issue": issue},
         )
+
     _handler.__name__ = f"placeholder_{label.lower()}"
     return _handler
 

--- a/src/findajob/web/routes/landing.py
+++ b/src/findajob/web/routes/landing.py
@@ -1,0 +1,4 @@
+"""Stub — real handlers added in a later task."""
+from fastapi import APIRouter
+
+router = APIRouter()

--- a/src/findajob/web/routes/landing.py
+++ b/src/findajob/web/routes/landing.py
@@ -1,4 +1,41 @@
-"""Stub — real handlers added in a later task."""
-from fastapi import APIRouter
+"""Landing page at / and placeholder groups."""
+from __future__ import annotations
+
+import sqlite3
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from findajob.web.routes.materials import get_db
 
 router = APIRouter()
+
+
+_STAGES_ORDER = [
+    "scored",
+    "manual_review",
+    "prep_in_progress",
+    "materials_drafted",
+    "applied",
+    "interview",
+    "offer",
+    "waitlisted",
+    "rejected",
+    "not_selected",
+]
+
+
+@router.get("/", response_class=HTMLResponse)
+def landing(
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    rows = db.execute("SELECT stage, COUNT(*) AS n FROM jobs GROUP BY stage").fetchall()
+    counts = {r["stage"]: r["n"] for r in rows}
+    ordered = [(s, counts.get(s, 0)) for s in _STAGES_ORDER]
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="landing.html",
+        context={"ordered": ordered},
+    )

--- a/src/findajob/web/routes/materials.py
+++ b/src/findajob/web/routes/materials.py
@@ -43,8 +43,8 @@ def _fetch_section(db: sqlite3.Connection, where: str, order: str) -> list[sqlit
     ).fetchall()
 
 
-@router.get("/", response_class=HTMLResponse)
-def index(request: Request, db: sqlite3.Connection = Depends(get_db)) -> HTMLResponse:  # noqa: B008
+@router.get("/materials/", response_class=HTMLResponse)
+def materials_index(request: Request, db: sqlite3.Connection = Depends(get_db)) -> HTMLResponse:  # noqa: B008
     sections = []
     for name, where, order in _INDEX_QUERY_SECTIONS:
         rows = _fetch_section(db, where, order)

--- a/src/findajob/web/routes/materials.py
+++ b/src/findajob/web/routes/materials.py
@@ -59,7 +59,7 @@ def index(request: Request, db: sqlite3.Connection = Depends(get_db)) -> HTMLRes
     templates = request.app.state.templates
     return templates.TemplateResponse(
         request=request,
-        name="index.html",
+        name="materials/index.html",
         context={"sections": sections, "rejected": rejected},
     )
 
@@ -79,7 +79,7 @@ def folder_view(
     templates = request.app.state.templates
     return templates.TemplateResponse(
         request=request,
-        name="folder.html",
+        name="materials/folder.html",
         context={
             "fingerprint": fingerprint,
             "folder_name": folder.name,

--- a/src/findajob/web/routes/materials.py
+++ b/src/findajob/web/routes/materials.py
@@ -20,7 +20,9 @@ def get_db() -> sqlite3.Connection:  # pragma: no cover — overridden in app fa
 
 def _render_markdown(text: str) -> str:
     html = md_lib.markdown(text, extensions=["fenced_code", "tables"], output_format="html")
+    # Strip class attributes added by fenced_code (e.g. class="language-python")
     html = re.sub(r' class="[^"]*"', "", html)
+    # Neutralize raw script tags that Python-Markdown passes through unchanged
     html = re.sub(r"<(/?script)", r"&lt;\1", html, flags=re.IGNORECASE)
     return html
 

--- a/src/findajob/web/routes/materials.py
+++ b/src/findajob/web/routes/materials.py
@@ -1,4 +1,5 @@
 """Materials viewer routes: /, /materials/{fp}, /materials/{fp}/{file}."""
+
 from __future__ import annotations
 
 import re

--- a/src/findajob/web/routes/materials.py
+++ b/src/findajob/web/routes/materials.py
@@ -1,5 +1,4 @@
-"""Route handlers for the materials viewer."""
-
+"""Materials viewer routes: /, /materials/{fp}, /materials/{fp}/{file}."""
 from __future__ import annotations
 
 import re
@@ -7,7 +6,7 @@ import sqlite3
 from pathlib import Path
 
 import markdown as md_lib
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
 
 from findajob.web.folder_resolver import resolve_folder
@@ -19,103 +18,16 @@ def get_db() -> sqlite3.Connection:  # pragma: no cover — overridden in app fa
     raise NotImplementedError("DB dependency must be overridden by create_app()")
 
 
-@router.get("/healthz", response_class=Response)
-def healthz(request: Request) -> Response:
-    root: Path = request.app.state.companies_root
-    if not root.is_dir():
-        return Response(content="companies/ missing", status_code=503, media_type="text/plain")
-    return Response(content="ok", status_code=200, media_type="text/plain")
-
-
-@router.get("/materials/{fingerprint}", response_class=HTMLResponse)
-def folder_view(
-    fingerprint: str,
-    request: Request,
-    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
-) -> HTMLResponse:
-    root: Path = request.app.state.companies_root
-    folder = resolve_folder(fingerprint, db, root)
-    if folder is None:
-        raise HTTPException(status_code=404, detail="folder not found")
-
-    row = db.execute("SELECT title, company, stage FROM jobs WHERE fingerprint = ?", (fingerprint,)).fetchone()
-
-    files = sorted(p.name for p in folder.iterdir() if p.is_file())
-    templates = request.app.state.templates
-    return templates.TemplateResponse(
-        request=request,
-        name="folder.html",
-        context={
-            "fingerprint": fingerprint,
-            "folder_name": folder.name,
-            "title": row["title"] if row else "",
-            "company": row["company"] if row else "",
-            "stage": row["stage"] if row else "",
-            "files": files,
-        },
-    )
-
-
 def _render_markdown(text: str) -> str:
     html = md_lib.markdown(text, extensions=["fenced_code", "tables"], output_format="html")
-    # Strip class attributes added by fenced_code (e.g. class="language-python")
     html = re.sub(r' class="[^"]*"', "", html)
-    # Neutralize raw script tags that Python-Markdown passes through unchanged
     html = re.sub(r"<(/?script)", r"&lt;\1", html, flags=re.IGNORECASE)
     return html
 
 
-@router.get("/materials/{fingerprint}/{filename}")
-def file_serve(
-    fingerprint: str,
-    filename: str,
-    request: Request,
-    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
-):
-    root: Path = request.app.state.companies_root
-    folder = resolve_folder(fingerprint, db, root)
-    if folder is None:
-        raise HTTPException(status_code=404, detail="folder not found")
-
-    candidate = (folder / filename).resolve()
-    try:
-        candidate.relative_to(folder.resolve())
-    except ValueError:
-        raise HTTPException(status_code=404, detail="invalid filename") from None
-    if not candidate.is_file():
-        raise HTTPException(status_code=404, detail="file not found")
-
-    ext = candidate.suffix.lower()
-    if ext == ".md":
-        body = candidate.read_text(encoding="utf-8", errors="replace")
-        templates = request.app.state.templates
-        return templates.TemplateResponse(
-            request=request,
-            name="base.html",
-            context={"_rendered_md": _render_markdown(body)},
-            headers={"content-type": "text/html; charset=utf-8"},
-        )
-    if ext == ".txt":
-        return PlainTextResponse(content=candidate.read_text(encoding="utf-8", errors="replace"))
-    # Everything else (.docx, .pdf, unknown) → attachment
-    return FileResponse(
-        path=candidate,
-        filename=candidate.name,
-        headers={"content-disposition": f'attachment; filename="{candidate.name}"'},
-    )
-
-
 _INDEX_QUERY_SECTIONS = [
-    (
-        "In flight",
-        "stage IN ('materials_drafted', 'prep_in_progress')",
-        "created_at DESC",
-    ),
-    (
-        "Applied",
-        "stage IN ('applied', 'interview', 'offer')",
-        "COALESCE(stage_updated, created_at) DESC",
-    ),
+    ("In flight", "stage IN ('materials_drafted', 'prep_in_progress')", "created_at DESC"),
+    ("Applied", "stage IN ('applied', 'interview', 'offer')", "COALESCE(stage_updated, created_at) DESC"),
     ("Waitlisted", "stage = 'waitlisted'", "created_at DESC"),
 ]
 _REJECTED_CLAUSE = "stage IN ('rejected', 'not_selected')"
@@ -136,17 +48,79 @@ def index(request: Request, db: sqlite3.Connection = Depends(get_db)) -> HTMLRes
         rows = _fetch_section(db, where, order)
         overflow = len(rows) > _PER_SECTION_CAP
         sections.append({"name": name, "rows": rows[:_PER_SECTION_CAP], "overflow": overflow})
-
     rejected_rows = _fetch_section(db, _REJECTED_CLAUSE, "created_at DESC")
     rejected = {
         "rows": rejected_rows[:_PER_SECTION_CAP],
         "overflow": len(rejected_rows) > _PER_SECTION_CAP,
         "count": len(rejected_rows) if len(rejected_rows) <= _PER_SECTION_CAP else f"{_PER_SECTION_CAP}+",
     }
-
     templates = request.app.state.templates
     return templates.TemplateResponse(
         request=request,
         name="index.html",
         context={"sections": sections, "rejected": rejected},
+    )
+
+
+@router.get("/materials/{fingerprint}", response_class=HTMLResponse)
+def folder_view(
+    fingerprint: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    root: Path = request.app.state.companies_root
+    folder = resolve_folder(fingerprint, db, root)
+    if folder is None:
+        raise HTTPException(status_code=404, detail="folder not found")
+    row = db.execute("SELECT title, company, stage FROM jobs WHERE fingerprint = ?", (fingerprint,)).fetchone()
+    files = sorted(p.name for p in folder.iterdir() if p.is_file())
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="folder.html",
+        context={
+            "fingerprint": fingerprint,
+            "folder_name": folder.name,
+            "title": row["title"] if row else "",
+            "company": row["company"] if row else "",
+            "stage": row["stage"] if row else "",
+            "files": files,
+        },
+    )
+
+
+@router.get("/materials/{fingerprint}/{filename}")
+def file_serve(
+    fingerprint: str,
+    filename: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+):
+    root: Path = request.app.state.companies_root
+    folder = resolve_folder(fingerprint, db, root)
+    if folder is None:
+        raise HTTPException(status_code=404, detail="folder not found")
+    candidate = (folder / filename).resolve()
+    try:
+        candidate.relative_to(folder.resolve())
+    except ValueError:
+        raise HTTPException(status_code=404, detail="invalid filename") from None
+    if not candidate.is_file():
+        raise HTTPException(status_code=404, detail="file not found")
+    ext = candidate.suffix.lower()
+    if ext == ".md":
+        body = candidate.read_text(encoding="utf-8", errors="replace")
+        templates = request.app.state.templates
+        return templates.TemplateResponse(
+            request=request,
+            name="base.html",
+            context={"_rendered_md": _render_markdown(body)},
+            headers={"content-type": "text/html; charset=utf-8"},
+        )
+    if ext == ".txt":
+        return PlainTextResponse(content=candidate.read_text(encoding="utf-8", errors="replace"))
+    return FileResponse(
+        path=candidate,
+        filename=candidate.name,
+        headers={"content-disposition": f'attachment; filename="{candidate.name}"'},
     )

--- a/src/findajob/web/static/app.css
+++ b/src/findajob/web/static/app.css
@@ -1,0 +1,22 @@
+/* Design tokens matching the Google Sheet's conditional formatting palette. */
+:root {
+  --color-applied-fresh: #c6e6b9;  /* 0–6 days, green */
+  --color-applied-week:  #fff3b0;  /* 7–13 days, yellow */
+  --color-applied-stale: #f4b7b0;  /* 14–20 days, red */
+  --color-applied-cold:  #d6d6d6;  /* 21+ days, gray */
+  --color-offer:         #ffd700;  /* gold */
+  --color-interviewing:  #c8a2d8;  /* purple */
+  --color-ghosted:       #d6d6d6;  /* gray */
+  --color-contact-amber: #ffbf00;
+}
+
+/* Apply via Tailwind arbitrary-value utilities: bg-[var(--color-applied-fresh)] */
+
+.row-applied-fresh  { background-color: var(--color-applied-fresh); }
+.row-applied-week   { background-color: var(--color-applied-week); }
+.row-applied-stale  { background-color: var(--color-applied-stale); }
+.row-applied-cold   { background-color: var(--color-applied-cold); }
+.row-offer          { background-color: var(--color-offer); }
+.row-interviewing   { background-color: var(--color-interviewing); }
+.row-ghosted        { background-color: var(--color-ghosted); }
+.cell-contact-amber { background-color: var(--color-contact-amber); }

--- a/src/findajob/web/templates/_nav.html
+++ b/src/findajob/web/templates/_nav.html
@@ -1,0 +1,26 @@
+{# Top navigation. Highlights the active group via aria-current="page". #}
+{% set groups = [
+  ("/", "Home"),
+  ("/board/dashboard", "Board"),
+  ("/materials/", "Materials"),
+  ("/ingest/", "Ingest"),
+  ("/tools/", "Tools"),
+  ("/config/", "Config"),
+  ("/docs/", "Docs"),
+] %}
+<nav class="bg-slate-800 text-slate-100 px-4 py-2 shadow-sm">
+  <ul class="flex gap-4 items-center">
+    <li class="font-bold mr-4">findajob</li>
+    {% for href, label in groups %}
+      {% set active = request.url.path == href
+           or (href != "/" and request.url.path.startswith(href)) %}
+      <li>
+        <a href="{{ href }}"
+           {% if active %}aria-current="page"{% endif %}
+           class="px-2 py-1 rounded {% if active %}bg-slate-600{% else %}hover:bg-slate-700{% endif %}">
+          {{ label }}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/src/findajob/web/templates/_nav.html
+++ b/src/findajob/web/templates/_nav.html
@@ -1,7 +1,7 @@
 {# Top navigation. Highlights the active group via aria-current="page". #}
 {% set groups = [
   ("/", "Home"),
-  ("/board/dashboard", "Board"),
+  ("/board/", "Board"),
   ("/materials/", "Materials"),
   ("/ingest/", "Ingest"),
   ("/tools/", "Tools"),

--- a/src/findajob/web/templates/base.html
+++ b/src/findajob/web/templates/base.html
@@ -1,30 +1,19 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{% block title %}findajob materials{% endblock %}</title>
-  <style>
-    body { font-family: -apple-system, system-ui, sans-serif; max-width: 960px; margin: 2em auto; padding: 0 1em; color: #222; }
-    a { color: #0366d6; text-decoration: none; }
-    a:hover { text-decoration: underline; }
-    h1, h2 { border-bottom: 1px solid #eee; padding-bottom: 0.3em; }
-    ul { padding-left: 1.2em; }
-    li { margin: 0.3em 0; }
-    .meta { color: #666; font-size: 0.9em; }
-    .stage { color: #0366d6; }
-    .score { color: #22863a; font-weight: 600; }
-    details summary { cursor: pointer; color: #666; }
-    pre, code { font-family: ui-monospace, monospace; background: #f6f8fa; }
-    pre { padding: 1em; overflow-x: auto; }
-    code { padding: 0.1em 0.3em; border-radius: 3px; }
-  </style>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}findajob{% endblock %}</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/htmx.org@2" defer></script>
+  <link rel="stylesheet" href="/static/app.css">
 </head>
-<body>
-{% if _rendered_md is defined %}
-  <p><a href="javascript:history.back()">← back</a></p>
-  {{ _rendered_md | safe }}
-{% else %}
-  {% block body %}{% endblock %}
-{% endif %}
+<body class="bg-slate-50 text-slate-900" hx-boost="true">
+  {% block nav %}{% include "_nav.html" %}{% endblock %}
+  <main class="max-w-6xl mx-auto px-4 py-6">
+    {% if _rendered_md is defined and _rendered_md %}{{ _rendered_md | safe }}{% endif %}
+    {% block content %}{% endblock %}
+    {% block body %}{% endblock %}
+  </main>
 </body>
 </html>

--- a/src/findajob/web/templates/landing.html
+++ b/src/findajob/web/templates/landing.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}findajob — pipeline{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Pipeline at a glance</h1>
+<div class="grid grid-cols-2 md:grid-cols-5 gap-3">
+  {% for stage, n in ordered %}
+    <div class="bg-white rounded-md shadow-sm p-4 flex flex-col items-center">
+      <div class="text-3xl font-mono">{{ n }}</div>
+      <div class="text-xs uppercase tracking-wide text-slate-500 mt-1">{{ stage }}</div>
+    </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/src/findajob/web/templates/materials/folder.html
+++ b/src/findajob/web/templates/materials/folder.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ company }} — {{ title }}{% endblock %}
 {% block content %}
-<p><a href="/">← back to index</a></p>
+<p><a href="/materials/">← back to index</a></p>
 <h1>{{ company }} — {{ title }}</h1>
 <p class="meta">{{ folder_name }} · <span class="stage">{{ stage }}</span></p>
 <ul>

--- a/src/findajob/web/templates/materials/folder.html
+++ b/src/findajob/web/templates/materials/folder.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}{{ company }} — {{ title }}{% endblock %}
-{% block body %}
+{% block content %}
 <p><a href="/">← back to index</a></p>
 <h1>{{ company }} — {{ title }}</h1>
 <p class="meta">{{ folder_name }} · <span class="stage">{{ stage }}</span></p>

--- a/src/findajob/web/templates/materials/index.html
+++ b/src/findajob/web/templates/materials/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}findajob — materials{% endblock %}
-{% block body %}
+{% block content %}
 <h1>findajob materials</h1>
 
 {% for section in sections %}

--- a/src/findajob/web/templates/placeholders/coming_soon.html
+++ b/src/findajob/web/templates/placeholders/coming_soon.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}{{ label }} — Coming soon{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-2">{{ label }}</h1>
+<p class="text-slate-600">Coming soon. {{ hint }}
+{% if issue %}Tracking: <a class="underline" href="https://github.com/brockamer/findajob/issues/{{ issue[1:] }}">{{ issue }}</a>.{% endif %}
+</p>
+{% endblock %}

--- a/tests/test_web_integration.py
+++ b/tests/test_web_integration.py
@@ -95,7 +95,7 @@ def test_full_flow(world: dict) -> None:
     r = client.get("/healthz")
     assert r.status_code == 200
 
-    r = client.get("/")
+    r = client.get("/materials/")
     assert r.status_code == 200
     assert "Meta" in r.text
     assert "Google" in r.text

--- a/tests/test_web_landing.py
+++ b/tests/test_web_landing.py
@@ -1,4 +1,5 @@
 """Landing page shows stage counts."""
+
 import sqlite3
 from pathlib import Path
 
@@ -45,13 +46,16 @@ def test_landing_nav_home_active(client: TestClient) -> None:
     assert 'aria-current="page"' in r.text
 
 
-@pytest.mark.parametrize("path,label,issue", [
-    ("/board/", "Board", "#60"),
-    ("/ingest/", "Ingest", "#79"),
-    ("/tools/", "Tools", ""),
-    ("/config/", "Config", ""),
-    ("/docs/", "Docs", ""),
-])
+@pytest.mark.parametrize(
+    "path,label,issue",
+    [
+        ("/board/", "Board", "#60"),
+        ("/ingest/", "Ingest", "#79"),
+        ("/tools/", "Tools", ""),
+        ("/config/", "Config", ""),
+        ("/docs/", "Docs", ""),
+    ],
+)
 def test_placeholder_renders(client: TestClient, path: str, label: str, issue: str) -> None:
     r = client.get(path)
     assert r.status_code == 200

--- a/tests/test_web_landing.py
+++ b/tests/test_web_landing.py
@@ -43,3 +43,17 @@ def test_landing_nav_home_active(client: TestClient) -> None:
     r = client.get("/")
     assert r.status_code == 200
     assert 'aria-current="page"' in r.text
+
+
+@pytest.mark.parametrize("path,label,issue", [
+    ("/board/", "Board", "#60"),
+    ("/ingest/", "Ingest", "#79"),
+    ("/tools/", "Tools", ""),
+    ("/config/", "Config", ""),
+    ("/docs/", "Docs", ""),
+])
+def test_placeholder_renders(client: TestClient, path: str, label: str, issue: str) -> None:
+    r = client.get(path)
+    assert r.status_code == 200
+    assert "Coming soon" in r.text
+    assert label in r.text

--- a/tests/test_web_landing.py
+++ b/tests/test_web_landing.py
@@ -1,0 +1,45 @@
+"""Landing page shows stage counts."""
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "fit_score REAL, created_at TEXT, stage_updated TEXT)"
+    )
+    for stage, n in [("scored", 5), ("applied", 2), ("rejected", 3)]:
+        for i in range(n):
+            conn.execute(
+                "INSERT INTO jobs (fingerprint, title, company, stage, created_at) "
+                "VALUES (?, 't', 'c', ?, '2026-01-01')",
+                (f"fp-{stage}-{i}", stage),
+            )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    app = create_app(companies_root=companies, db_path=db)
+    return TestClient(app)
+
+
+def test_landing_shows_stage_counts(client: TestClient) -> None:
+    r = client.get("/")
+    assert r.status_code == 200
+    assert ">5<" in r.text and "scored" in r.text
+    assert ">2<" in r.text and "applied" in r.text
+    assert ">3<" in r.text and "rejected" in r.text
+
+
+def test_landing_nav_home_active(client: TestClient) -> None:
+    r = client.get("/")
+    assert r.status_code == 200
+    assert 'aria-current="page"' in r.text

--- a/tests/test_web_nav.py
+++ b/tests/test_web_nav.py
@@ -31,7 +31,7 @@ def test_nav_present_on_landing(client: TestClient) -> None:
     assert r.status_code == 200
     assert 'href="/"' in r.text
     assert 'href="/materials/"' in r.text
-    assert 'href="/board/dashboard"' in r.text
+    assert 'href="/board/"' in r.text
     assert 'href="/ingest/"' in r.text
     assert 'href="/tools/"' in r.text
     assert 'href="/config/"' in r.text
@@ -42,3 +42,10 @@ def test_materials_index_moved(client: TestClient) -> None:
     r = client.get("/materials/")
     assert r.status_code == 200
     assert "In flight" in r.text or "Applied" in r.text or "Rejected" in r.text
+
+
+def test_every_nav_link_resolves(client: TestClient) -> None:
+    """Regression: every href in the top nav returns 200, not 404."""
+    for path in ["/", "/materials/", "/board/", "/ingest/", "/tools/", "/config/", "/docs/"]:
+        r = client.get(path)
+        assert r.status_code == 200, f"Nav link {path} returned {r.status_code}"

--- a/tests/test_web_nav.py
+++ b/tests/test_web_nav.py
@@ -25,7 +25,8 @@ def client(tmp_path: Path) -> TestClient:
 
 
 def test_nav_present_on_landing(client: TestClient) -> None:
-    r = client.get("/")
+    # / has no handler yet (landing arrives in Task 6); test nav on /materials/ in the meantime.
+    r = client.get("/materials/")
     assert r.status_code == 200
     assert 'href="/"' in r.text
     assert 'href="/materials/"' in r.text
@@ -34,3 +35,9 @@ def test_nav_present_on_landing(client: TestClient) -> None:
     assert 'href="/tools/"' in r.text
     assert 'href="/config/"' in r.text
     assert 'href="/docs/"' in r.text
+
+
+def test_materials_index_moved(client: TestClient) -> None:
+    r = client.get("/materials/")
+    assert r.status_code == 200
+    assert "In flight" in r.text or "Applied" in r.text or "Rejected" in r.text

--- a/tests/test_web_nav.py
+++ b/tests/test_web_nav.py
@@ -1,4 +1,5 @@
 """_nav.html partial highlights the current route."""
+
 import sqlite3
 from pathlib import Path
 

--- a/tests/test_web_nav.py
+++ b/tests/test_web_nav.py
@@ -1,0 +1,36 @@
+"""_nav.html partial highlights the current route."""
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "fit_score REAL, created_at TEXT, stage_updated TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    app = create_app(companies_root=companies, db_path=db)
+    return TestClient(app)
+
+
+def test_nav_present_on_landing(client: TestClient) -> None:
+    r = client.get("/")
+    assert r.status_code == 200
+    assert 'href="/"' in r.text
+    assert 'href="/materials/"' in r.text
+    assert 'href="/board/dashboard"' in r.text
+    assert 'href="/ingest/"' in r.text
+    assert 'href="/tools/"' in r.text
+    assert 'href="/config/"' in r.text
+    assert 'href="/docs/"' in r.text

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -236,7 +236,7 @@ def test_index_groups_jobs_by_stage(client: TestClient, companies_root: Path, db
     conn.commit()
     conn.close()
 
-    r = client.get("/")
+    r = client.get("/materials/")
     assert r.status_code == 200
     assert "In flight" in r.text
     assert "InFlightCo" in r.text

--- a/tests/test_web_routes_package.py
+++ b/tests/test_web_routes_package.py
@@ -10,6 +10,6 @@ def test_router_is_apirouter():
 def test_routes_include_healthz_and_materials_and_landing():
     paths = [r.path for r in aggregated.routes]
     assert "/healthz" in paths
-    assert "/" in paths  # materials_index, pre-rename
+    assert "/materials/" in paths  # materials_index after Task 5 rename
     assert "/materials/{fingerprint}" in paths
     assert "/materials/{fingerprint}/{filename}" in paths

--- a/tests/test_web_routes_package.py
+++ b/tests/test_web_routes_package.py
@@ -1,0 +1,15 @@
+"""Router package aggregates all sub-module routers and exposes a single `router`."""
+from findajob.web.routes import router as aggregated
+
+
+def test_router_is_apirouter():
+    from fastapi import APIRouter
+    assert isinstance(aggregated, APIRouter)
+
+
+def test_routes_include_healthz_and_materials_and_landing():
+    paths = [r.path for r in aggregated.routes]
+    assert "/healthz" in paths
+    assert "/" in paths  # materials_index, pre-rename
+    assert "/materials/{fingerprint}" in paths
+    assert "/materials/{fingerprint}/{filename}" in paths

--- a/tests/test_web_routes_package.py
+++ b/tests/test_web_routes_package.py
@@ -1,9 +1,11 @@
 """Router package aggregates all sub-module routers and exposes a single `router`."""
+
 from findajob.web.routes import router as aggregated
 
 
 def test_router_is_apirouter():
     from fastapi import APIRouter
+
     assert isinstance(aggregated, APIRouter)
 
 


### PR DESCRIPTION
## Summary

PR 1 of 2 for #60 (Web frontend 14b — read-only pipeline UI).

- New top nav (7 feature groups) with active-link highlighting via `aria-current="page"`.
- Landing page at `/` showing per-stage row counts as a card grid.
- Materials folder index moved from `/` to `/materials/`; deep links `/materials/{fingerprint}` and `/materials/{fingerprint}/{filename}` unchanged.
- `routes.py` (153-line monolith) split into a `routes/` package with one file per URL group: `materials.py`, `healthz.py`, `landing.py`, `board.py` (board is a stub filled in PR 2).
- Tailwind + HTMX loaded from CDN in `base.html`. `static/app.css` holds Sheet-palette design tokens mounted at `/static/*`.
- Coming-soon placeholder pages for `/board/`, `/ingest/`, `/tools/`, `/config/`, `/docs/`.

Plan: [`docs/superpowers/plans/2026-04-21-web-frontend-14b.md`](docs/superpowers/plans/2026-04-21-web-frontend-14b.md)
Spec: [`docs/superpowers/specs/2026-04-21-web-frontend-14b-design.md`](docs/superpowers/specs/2026-04-21-web-frontend-14b-design.md)

PR 2 (board pages — dashboard/applied/review/waitlist/archive with sort, filter, conditional formatting) follows after this merges.

## Test plan

- [x] 486 pytest green (up from 464), includes:
  - `tests/test_web_routes_package.py` — routes/ aggregator structure
  - `tests/test_web_nav.py` — nav presence, active link, every href resolves (regression gate)
  - `tests/test_web_landing.py` — landing + 5 placeholder routes
  - Existing `tests/test_web_routes.py`, `test_web_folder_resolver.py`, `test_web_integration.py` carried forward
- [x] ruff + mypy clean on `src/findajob/web/` and `tests/`
- [ ] Manual smoke against docker.lan after merge: click every nav link, confirm landing shows stage counts, confirm `/materials/` and `/materials/{fp}` still work

No \`migration-required\` — operators pull \`:latest\` and the new UI appears with no manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)