### PR TITLE
fix(ops): reconcile deep file ownership in entrypoint chown loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,14 @@ jobs:
             -e PUID=1001 -e PGID=1001 \
             findajob:ci-smoke \
             id findajob
+
+      - name: Smoke — entrypoint reconciles root-owned file inside managed dir
+        run: |
+          mkdir -p /tmp/test-entrypoint-logs
+          sudo touch /tmp/test-entrypoint-logs/pipeline.jsonl
+          owner=$(docker run --rm \
+            -e PUID=1001 -e PGID=1001 \
+            -v /tmp/test-entrypoint-logs:/app/logs \
+            findajob:ci-smoke \
+            stat -c '%u' /app/logs/pipeline.jsonl)
+          [ "$owner" = "1001" ] || { echo "FAIL: expected owner 1001, got $owner"; exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 - Web viewer now has a top nav and landing page. Materials folder index moved from `/` to `/materials/`; deep links `/materials/{fingerprint}` and `/materials/{fingerprint}/{filename}` unchanged. Placeholder pages for board, ingest, tools, config, docs fill in as features land (#60).
 - `/board/dashboard`, `/board/applied`, `/board/review`, `/board/waitlist`, `/board/archive` render the same content as the corresponding Google Sheet tabs, reading directly from the database. Archive covers all jobs (10k+) with HTMX infinite-scroll pagination, obsoleting Sheet1's archival filter. Per-tab text filter via HTMX, URL-param sort, Sheet-matching conditional formatting (Applied row-age buckets, Offer gold, Interviewing purple, known-contacts amber), and Applied's company cell hyperlinks into the materials viewer when `FINDAJOB_MATERIALS_BASE_URL` is set. `sync_sheet.py` continues to update Sheets in parallel during the 14b → 14c → 14d migration (#60).
 
+### Fixed
+- Container entrypoint now reconciles file and subdirectory ownership inside each writable dir (data, logs, companies, config, candidate\_context, aichat config), not just the top-level inode. A root-owned file created by `docker exec` (default user: root) is now corrected on the next container restart, preventing `PermissionError` crash-loops in supercronic jobs (#139).
+
 ### Migration required
 
 Operators whose deployed `compose.yaml` was copied from `ops/compose.yaml.example` on v0.1.2 or earlier need two edits to opt into the company-cell hyperlinks (#133). Fresh installs from the current template are unaffected.

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -69,11 +69,13 @@ if [ ! -e "$AICHAT_CFG_DIR/roles" ]; then
     ln -s /app/config/roles "$AICHAT_CFG_DIR/roles"
 fi
 
-# --- 3. Chown writable dirs if ownership doesn't already match -----------
+# --- 3. Chown writable dirs if any content doesn't match PUID:PGID --------
+# Uses find to detect mismatched files/subdirs inside each dir, not just the
+# top-level inode — prevents a root-owned file created by `docker exec` (as
+# root) from surviving container restarts uncorrected.
 for dir in /app/data /app/logs /app/companies /app/config /app/candidate_context "$AICHAT_CFG_DIR"; do
     if [ -d "$dir" ]; then
-        current_owner="$(stat -c %u "$dir" 2>/dev/null || echo 0)"
-        if [ "$current_owner" != "$PUID" ]; then
+        if find "$dir" ! -user "$PUID" -print -quit 2>/dev/null | grep -q .; then
             chown -R "$PUID:$PGID" "$dir" || true
         fi
     fi


### PR DESCRIPTION
Closes #139.

## Summary

- `ops/entrypoint.sh` section 3: replace per-dir `stat` guard (checks top-level inode only) with a `find`-based content scan. Any file or subdir inside a managed dir that isn't owned by `PUID` now triggers `chown -R`, including files created inside a correctly-owned dir by a root `docker exec`.
- CI `docker-build-smoke`: new smoke step seeds a root-owned `pipeline.jsonl` in a bind-mounted `/app/logs`, starts the container with `stat` as CMD, asserts owner == `1001`.
- `CHANGELOG.md`: one-liner under `[Unreleased] ### Fixed`. No `migration-required`: fix is transparent on image pull.

## Test plan

- [ ] CI `docker-build-smoke` passes — new smoke step verifies ownership reconciliation end-to-end
- [ ] Existing smoke steps unaffected (aichat-ng, supercronic, Python imports, runtime user creation)
- [ ] `pytest tests/ -v` green (no Python changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)