### PR TITLE
fix(web): dashboard filter uses relevance_score not fit_score

### DIFF
--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -27,9 +27,8 @@ def _filter_clause(q: str) -> tuple[str, list[str]]:
 
 
 _DASHBOARD_COLS = [
-    ("Score", "fit_score"),
-    ("Prob", "probability_score"),
     ("Rel", "relevance_score"),
+    ("Likelihood", "interview_likelihood"),
     ("Title", "title"),
     ("Company", "company"),
     ("Location", "location"),
@@ -41,10 +40,10 @@ _DASHBOARD_COLS = [
 ]
 
 _DASHBOARD_SORTABLE = {c for _, c in _DASHBOARD_COLS}
-_DASHBOARD_DEFAULT_SORT = "fit_score"
+_DASHBOARD_DEFAULT_SORT = "relevance_score"
 
 _DASHBOARD_WHERE = (
-    "(fit_score >= 7 AND stage IN ('scored','manual_review')) OR stage IN ('prep_in_progress','materials_drafted')"
+    "(relevance_score >= 7 AND stage IN ('scored','manual_review')) OR stage IN ('prep_in_progress','materials_drafted')"
 )
 
 
@@ -59,7 +58,7 @@ def dashboard(
     order = "DESC" if desc else "ASC"
     rows = db.execute(
         f"SELECT fingerprint, title, company, location, remote_status, known_contacts, "
-        f"comp_estimate, ai_notes, fit_score, probability_score, relevance_score, "
+        f"comp_estimate, ai_notes, relevance_score, interview_likelihood, "
         f"stage, created_at, stage_updated FROM jobs WHERE {_DASHBOARD_WHERE} "
         f"ORDER BY {sort_col} {order}"
     ).fetchall()
@@ -335,7 +334,7 @@ def dashboard_rows(
     filter_sql, params = _filter_clause(q)
     rows = db.execute(
         f"SELECT fingerprint, title, company, location, remote_status, known_contacts, "
-        f"comp_estimate, ai_notes, fit_score, probability_score, relevance_score, "
+        f"comp_estimate, ai_notes, relevance_score, interview_likelihood, "
         f"stage, created_at, stage_updated FROM jobs WHERE ({_DASHBOARD_WHERE}) {filter_sql} "
         f"ORDER BY {sort_col} {order}",
         params,

--- a/tests/test_web_board_dashboard.py
+++ b/tests/test_web_board_dashboard.py
@@ -15,20 +15,20 @@ def client(tmp_path: Path) -> TestClient:
     conn = sqlite3.connect(db)
     conn.execute(
         "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "fit_score REAL, probability_score REAL, relevance_score INTEGER, "
+        "relevance_score INTEGER, interview_likelihood INTEGER, "
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
         "ai_notes TEXT, created_at TEXT, stage_updated TEXT)"
     )
     conn.execute(
-        "INSERT INTO jobs (fingerprint, title, company, stage, fit_score) "
-        "VALUES ('fp1','Senior DC Ops','Meta','scored',7.5)"
+        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score) "
+        "VALUES ('fp1','Senior DC Ops','Meta','scored',8)"
     )
     conn.execute(
-        "INSERT INTO jobs (fingerprint, title, company, stage, fit_score) "
-        "VALUES ('fp2','NPI PM','Google','materials_drafted',8.0)"
+        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score) "
+        "VALUES ('fp2','NPI PM','Google','materials_drafted',9)"
     )
     conn.execute(
-        "INSERT INTO jobs (fingerprint, title, company, stage, fit_score) VALUES ('fp3','Junior','Acme','scored',3.0)"
+        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score) VALUES ('fp3','Junior','Acme','scored',3)"
     )
     conn.commit()
     conn.close()

--- a/tests/test_web_board_filter.py
+++ b/tests/test_web_board_filter.py
@@ -15,9 +15,8 @@ def client(tmp_path: Path) -> TestClient:
     conn = sqlite3.connect(db)
     conn.execute(
         "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "fit_score REAL, location TEXT, remote_status TEXT, known_contacts TEXT, "
-        "comp_estimate TEXT, ai_notes TEXT, created_at TEXT, stage_updated TEXT, "
-        "probability_score REAL, relevance_score INTEGER)"
+        "relevance_score INTEGER, interview_likelihood INTEGER, location TEXT, remote_status TEXT, "
+        "known_contacts TEXT, comp_estimate TEXT, ai_notes TEXT, created_at TEXT, stage_updated TEXT)"
     )
     for fp, title, company in [
         ("fp1", "NPI PM", "Meta"),
@@ -25,7 +24,7 @@ def client(tmp_path: Path) -> TestClient:
         ("fp3", "TPM", "Meta"),
     ]:
         conn.execute(
-            "INSERT INTO jobs (fingerprint, title, company, stage, fit_score) VALUES (?, ?, ?, 'scored', 8.0)",
+            "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score) VALUES (?, ?, ?, 'scored', 8)",
             (fp, title, company),
         )
     conn.commit()

--- a/tests/test_web_board_sort.py
+++ b/tests/test_web_board_sort.py
@@ -15,7 +15,7 @@ def client(tmp_path: Path) -> TestClient:
     conn = sqlite3.connect(db)
     conn.execute(
         "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "fit_score REAL, probability_score REAL, relevance_score INTEGER, "
+        "relevance_score INTEGER, interview_likelihood INTEGER, "
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
         "ai_notes TEXT, user_notes TEXT, score_flag_reason TEXT, source TEXT, url TEXT, "
         "created_at TEXT, stage_updated TEXT)"
@@ -25,9 +25,9 @@ def client(tmp_path: Path) -> TestClient:
         "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
     )
     # Three scored jobs spanning score values, passing the Dashboard WHERE
-    for fp, company, score in [("fp-a", "Alpha", 9.0), ("fp-b", "Bravo", 7.5), ("fp-c", "Charlie", 8.2)]:
+    for fp, company, score in [("fp-a", "Alpha", 9), ("fp-b", "Bravo", 7), ("fp-c", "Charlie", 8)]:
         conn.execute(
-            "INSERT INTO jobs (fingerprint, title, company, stage, fit_score, created_at) "
+            "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score, created_at) "
             "VALUES (?, 't', ?, 'scored', ?, '2026-04-01')",
             (fp, company, score),
         )
@@ -38,20 +38,20 @@ def client(tmp_path: Path) -> TestClient:
     return TestClient(create_app(companies_root=companies, db_path=db))
 
 
-def test_dashboard_sort_by_fit_score_desc(client: TestClient) -> None:
-    r = client.get("/board/dashboard?sort=fit_score&desc=1")
+def test_dashboard_sort_by_relevance_score_desc(client: TestClient) -> None:
+    r = client.get("/board/dashboard?sort=relevance_score&desc=1")
     assert r.status_code == 200
-    # Highest fit_score row (Alpha, 9.0) should appear before Charlie (8.2) before Bravo (7.5)
+    # Highest relevance_score (Alpha, 9) before Charlie (8) before Bravo (7)
     i_alpha = r.text.find("Alpha")
     i_charlie = r.text.find("Charlie")
     i_bravo = r.text.find("Bravo")
     assert 0 < i_alpha < i_charlie < i_bravo, (
-        f"Expected Alpha < Charlie < Bravo in desc-by-fit_score order, got positions {i_alpha}, {i_charlie}, {i_bravo}"
+        f"Expected Alpha < Charlie < Bravo in desc-by-relevance_score order, got positions {i_alpha}, {i_charlie}, {i_bravo}"
     )
 
 
-def test_dashboard_sort_by_fit_score_asc(client: TestClient) -> None:
-    r = client.get("/board/dashboard?sort=fit_score&desc=0")
+def test_dashboard_sort_by_relevance_score_asc(client: TestClient) -> None:
+    r = client.get("/board/dashboard?sort=relevance_score&desc=0")
     assert r.status_code == 200
     i_alpha = r.text.find("Alpha")
     i_charlie = r.text.find("Charlie")
@@ -60,7 +60,7 @@ def test_dashboard_sort_by_fit_score_asc(client: TestClient) -> None:
 
 
 def test_dashboard_unknown_sort_falls_back_to_default(client: TestClient) -> None:
-    # default sort is fit_score DESC (per _DASHBOARD_DEFAULT_SORT)
+    # default sort is relevance_score DESC (per _DASHBOARD_DEFAULT_SORT)
     r = client.get("/board/dashboard?sort=not_a_real_column&desc=1")
     assert r.status_code == 200
     # Should not crash; rows render

--- a/tests/test_web_nav.py
+++ b/tests/test_web_nav.py
@@ -15,7 +15,7 @@ def client(tmp_path: Path) -> TestClient:
     conn = sqlite3.connect(db)
     conn.execute(
         "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "fit_score REAL, probability_score REAL, relevance_score INTEGER, "
+        "fit_score REAL, probability_score REAL, relevance_score INTEGER, interview_likelihood INTEGER, "
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
         "ai_notes TEXT, user_notes TEXT, score_flag_reason TEXT, source TEXT, url TEXT, "
         "created_at TEXT, stage_updated TEXT)"


### PR DESCRIPTION
## Summary

- `_DASHBOARD_WHERE` was filtering on `fit_score >= 7`, but `fit_score` is only written by `prep_application.py` — triage-scored jobs always have `fit_score = NULL`
- Switches the filter, default sort column, and display columns (`Rel`/`Likelihood`) to the actual triage outputs: `relevance_score` and `interview_likelihood`
- Removes `fit_score`/`probability_score` from the dashboard column set; they're prep-time outputs and showing NULL for every triage job is misleading
- Confirmed cause on Alice Doe's stack: 241 scored jobs, 0 dashboard rows

## Test plan

- [x] `test_web_board_dashboard.py` — fixtures updated to insert `relevance_score`; filter threshold passes score=8, fails score=3
- [x] `test_web_board_sort.py` — sort tests updated to `relevance_score`
- [x] `test_web_board_filter.py` — fixtures updated
- [x] `test_web_nav.py` — schema includes `interview_likelihood`; all nav links still resolve 200
- [x] 520/520 passing

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)