### PR TITLE
fix(poll): eliminate prep-sync race — single post-prep sync_sheet call

### DIFF
--- a/scripts/poll_flags.py
+++ b/scripts/poll_flags.py
@@ -473,11 +473,6 @@ def main():
     if flagged_jobs:
         need_sync = True
 
-    children = []  # Popen handles to wait on before exit
-
-    if need_sync:
-        children.append(subprocess.Popen([sys.executable, f"{BASE}/scripts/sync_sheet.py"]))
-
     if folders_moved:
         log_event("folder_moves_completed", count=folders_moved)
 
@@ -492,7 +487,8 @@ def main():
             review_promoted=review_promoted,
             review_rejected=review_rejected,
         )
-        for proc in children:
+        if need_sync:
+            proc = subprocess.Popen([sys.executable, f"{BASE}/scripts/sync_sheet.py"])
             try:
                 proc.wait(timeout=120)
             except subprocess.TimeoutExpired:
@@ -514,7 +510,9 @@ def main():
 
     # Launch prep for each flagged job in parallel, then wait for all to finish.
     # Cap at 3 per cycle to avoid exhausting API rate limits / quotas.
+    # --no-sync suppresses per-prep sync_sheet calls; one consolidated sync runs below.
     MAX_CONCURRENT_PREPS = 3
+    children = []  # Popen handles for prep children
     for job in flagged_jobs[:MAX_CONCURRENT_PREPS]:
         children.append(
             subprocess.Popen(
@@ -525,6 +523,7 @@ def main():
                     job["title"],
                     job["url"],
                     job["id"],
+                    "--no-sync",
                 ],
             )
         )
@@ -546,14 +545,30 @@ def main():
             jobs=[f"{j['company']} - {j['title']}" for j in deferred],
         )
 
-    # Wait for all child processes (sync_sheet + preps) so systemd tracks them
-    # properly and no orphaned processes accumulate.
+    # Wait for all prep children before syncing, so the sheet sees all stage updates.
     for proc in children:
         try:
             proc.wait(timeout=600)
         except subprocess.TimeoutExpired:
             log_event("child_timeout", pid=proc.pid)
             proc.kill()
+
+    # Single consolidated sync after all preps finish — eliminates last-write-wins race.
+    sync_proc = subprocess.Popen([sys.executable, f"{BASE}/scripts/sync_sheet.py"])
+    try:
+        sync_proc.wait(timeout=120)
+    except subprocess.TimeoutExpired:
+        log_event("child_timeout", pid=sync_proc.pid)
+        sync_proc.kill()
+
+    db_count_conn = sqlite3.connect(DB_PATH, timeout=10)
+    dashboard_rows = db_count_conn.execute(
+        "SELECT COUNT(*) FROM jobs WHERE "
+        "(relevance_score >= 7 AND stage IN ('scored','manual_review')) "
+        "OR stage IN ('prep_in_progress','materials_drafted')"
+    ).fetchone()[0]
+    db_count_conn.close()
+    log_event("sync_complete", dashboard_db_rows=dashboard_rows)
 
 
 if __name__ == "__main__":

--- a/scripts/prep_application.py
+++ b/scripts/prep_application.py
@@ -484,8 +484,9 @@ Generated: {date}
 
     conn.close()
 
-    # ── Step 9: Sync sheets (single call, after everything is ready) ──
-    subprocess.run([sys.executable, f"{BASE}/scripts/sync_sheet.py"], check=False)
+    # ── Step 9: Sync sheets — skipped when poll_flags orchestrates a post-prep sync ──
+    if "--no-sync" not in sys.argv:
+        subprocess.run([sys.executable, f"{BASE}/scripts/sync_sheet.py"], check=False)
 
     print(f"PREP_COMPLETE:{outdir}")
 

--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -43,7 +43,8 @@ _DASHBOARD_SORTABLE = {c for _, c in _DASHBOARD_COLS}
 _DASHBOARD_DEFAULT_SORT = "relevance_score"
 
 _DASHBOARD_WHERE = (
-    "(relevance_score >= 7 AND stage IN ('scored','manual_review')) OR stage IN ('prep_in_progress','materials_drafted')"
+    "(relevance_score >= 7 AND stage IN ('scored','manual_review'))"
+    " OR stage IN ('prep_in_progress','materials_drafted')"
 )
 
 

--- a/tests/test_web_board_dashboard.py
+++ b/tests/test_web_board_dashboard.py
@@ -28,7 +28,8 @@ def client(tmp_path: Path) -> TestClient:
         "VALUES ('fp2','NPI PM','Google','materials_drafted',9)"
     )
     conn.execute(
-        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score) VALUES ('fp3','Junior','Acme','scored',3)"
+        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score) "
+        "VALUES ('fp3','Junior','Acme','scored',3)"
     )
     conn.commit()
     conn.close()

--- a/tests/test_web_board_sort.py
+++ b/tests/test_web_board_sort.py
@@ -46,7 +46,8 @@ def test_dashboard_sort_by_relevance_score_desc(client: TestClient) -> None:
     i_charlie = r.text.find("Charlie")
     i_bravo = r.text.find("Bravo")
     assert 0 < i_alpha < i_charlie < i_bravo, (
-        f"Expected Alpha < Charlie < Bravo in desc-by-relevance_score order, got positions {i_alpha}, {i_charlie}, {i_bravo}"
+        "Expected Alpha < Charlie < Bravo in desc-by-relevance_score order,"
+        f" got positions {i_alpha}, {i_charlie}, {i_bravo}"
     )
 
 


### PR DESCRIPTION
## Summary

- **Root cause:** `poll_flags.py` launches up to 3 `prep_application.py` children in parallel; each called `sync_sheet.py` on completion. Last-write-wins from a stale DB snapshot — preps that finished first wrote a sheet that didn't include the others' `materials_drafted` updates.
- **Fix:** Add `--no-sync` flag to `prep_application.py`. `poll_flags` passes `--no-sync` to each spawned prep child, suppressing per-prep syncs. A single `sync_sheet` call runs after all prep children have exited, so the sheet always sees all stage updates together.
- **Preserves manual paths:** `manual_prep.py` and `ingest_form.py` call `prep_application.py` without `--no-sync` — they continue to sync on completion as before (no race risk since they run one prep at a time).
- **Observability:** adds `log_event("sync_complete", dashboard_db_rows=N)` after each post-prep sync.

## Ordering (load-bearing claim)

```
poll_flags:
  for each flagged job:
    Popen(prep_application ... --no-sync)   ← no per-prep sync
  
  for each child:
    child.wait(timeout=600)                  ← all preps done

  Popen(sync_sheet).wait(timeout=120)       ← one sync sees all updates
  log_event("sync_complete", ...)
```

## Test plan

- [x] 520/520 tests pass — no regressions
- [x] `ruff` and `mypy` clean on both changed files
- [ ] Manual verification: flag 2+ jobs on Dashboard in the same poll cycle, confirm all appear after next sync

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)