### PR TITLE
fix(auth): remove device flow — Gmail scopes rejected by Google

### DIFF
--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -118,13 +118,29 @@ Then `docker compose up -d` to restart with the new env. Full migration writeup 
 
 ## 4. Initial auth: Gmail (optional)
 
+Gmail ingestion uses a loopback OAuth flow that requires an SSH tunnel — Google's device flow (`google.com/device`) does not support Gmail scopes. If you skip this step, Gmail ingestion is automatically disabled and the pipeline falls back to Greenhouse/Ashby/Lever feeds and RapidAPI.
+
+### Prerequisites
+
+- In [Google Cloud Console](https://console.cloud.google.com/), create an OAuth 2.0 client of type **Desktop app** (not "TVs and Limited Input devices" — that type rejects Gmail scopes). Download the JSON and save it as `state/config/gmail_oauth_client.json`.
+
+### One-time token flow
+
+**Step 1 — open an SSH tunnel** (keep this terminal open):
+
 ```bash
-docker compose --profile setup run --rm gmail-auth
+ssh -L 8080:localhost:8080 <your-docker-host>
 ```
 
-You'll see `Open this URL on any browser: https://www.google.com/device`. Enter the code, sign in, grant Gmail.readonly. Token is saved to `state/config/gmail_token.json`.
+**Step 2 — in another terminal, run the auth container**:
 
-If you skip this step, Gmail ingestion is automatically disabled — the pipeline falls back to Greenhouse/Ashby/Lever feeds and RapidAPI.
+```bash
+docker compose --profile setup run --rm -p 8080:8080 gmail-auth
+```
+
+**Step 3** — copy the URL printed by the container, open it in your browser, sign in, and grant Gmail.readonly access. The container exits automatically when consent is granted.
+
+Token is saved to `state/config/gmail_token.json` (chmod 600). Close the SSH tunnel once the container exits.
 
 ## 5. Deploy
 
@@ -229,5 +245,5 @@ A local rollback via `.env` pin doesn't affect other users on `:v0.1`.
 
 - Container fails to start: `docker compose logs scheduler` usually points at the issue.
 - Supercronic prints "schedule invalid": a crontab syntax error. Check `ops/crontab` for recent changes.
-- Gmail ingestion silently disabled: re-run `docker compose --profile setup run --rm gmail-auth` to refresh the token.
+- Gmail ingestion silently disabled: re-run the token flow from step 4 (`ssh -L 8080:localhost:8080 <host>` + `docker compose --profile setup run --rm -p 8080:8080 gmail-auth`).
 - For anything else, open an issue at https://github.com/brockamer/findajob/issues.

--- a/docs/superpowers/specs/archived/2026-04/2026-04-17-docker-compose-design.md
+++ b/docs/superpowers/specs/archived/2026-04/2026-04-17-docker-compose-design.md
@@ -197,7 +197,7 @@ Two modes:
 Writes token to `/app/config/gmail_token.json` (bind-mounted, chmod 600). Existing scripts (`triage.py`, `notify.py`, `backfill_jd.py`) check for token file presence and skip Gmail work gracefully when absent — no hard failure. This makes Gmail opt-in: the credential file IS the enable flag.
 
 One-time Google Cloud setup (Daniel's task, documented):
-1. Create OAuth client of type "TVs and Limited Input devices"
+1. Create OAuth client of type "TVs and Limited Input devices" _(historically incorrect — this type rejects Gmail scopes with `invalid_scope`; use Desktop app. Fixed in #115.)_
 2. Add dogfooders as test users (100-user limit is far beyond need)
 3. Download client JSON to each user's `state/config/gmail_oauth_client.json`
 

--- a/ops/compose.yaml.example
+++ b/ops/compose.yaml.example
@@ -41,7 +41,7 @@ services:
       JSP_BASE: /app
     volumes:
       - ./state/config:/app/config
-    command: python3 scripts/gmail_auth.py --mode=device
+    command: python3 scripts/gmail_auth.py
     networks:
       - findajob-network
 

--- a/scripts/gmail_auth.py
+++ b/scripts/gmail_auth.py
@@ -2,25 +2,18 @@
 # scripts/gmail_auth.py
 """
 Gmail OAuth helper — standalone script run once per instance to mint
-the Gmail API token that triage.py, backfill_jd.py, and notify.py use.
+the Gmail API token that triage.py and notify.py use.
 
-Two modes:
-  --mode=device  (default)  OAuth 2.0 Limited Input Device flow.
-                            Prints google.com/device URL + code; polls
-                            for user consent. No callback, no port.
-                            Used in v0.1.0.
-  --mode=local              InstalledAppFlow.run_local_server on --port.
-                            Requires the redirect URI to be authorized on
-                            the OAuth client. NOT USED in v0.1.0 — present
-                            for v0.2.0 when #59 lands with reverse-proxy
-                            routing.
+Uses OAuth 2.0 loopback flow (InstalledAppFlow). Requires:
+  1. A "Desktop app" OAuth client from Google Cloud Console (not "TVs and
+     Limited Input devices" — that client type blocks Gmail scopes).
+  2. An SSH tunnel so the browser redirect reaches the container callback.
+
+See docs/setup/install-docker.md for the full step-by-step.
 
 Writes credentials to --token-out (default: /app/config/gmail_token.json),
 which is bind-mounted into the container and subsequently read by
 fetchers.py on every scheduled run.
-
-Usage inside the scheduler container:
-  docker compose --profile setup run --rm gmail-auth
 """
 
 from __future__ import annotations
@@ -36,13 +29,7 @@ GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="gmail_auth",
-        description="Mint a Gmail API token via device or local flow.",
-    )
-    p.add_argument(
-        "--mode",
-        choices=["device", "local"],
-        default="device",
-        help="OAuth flow type. device = limited-input (default); local = callback server.",
+        description="Mint a Gmail API token via loopback OAuth flow.",
     )
     p.add_argument(
         "--client-secrets",
@@ -58,89 +45,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--port",
         type=int,
         default=8080,
-        help="Port for --mode=local callback server (ignored for device mode).",
+        help="Port for callback server. Forward via SSH tunnel from your laptop.",
     )
     return p
 
 
-def run_device(client_secrets: str):
-    """
-    OAuth 2.0 Limited Input Device flow.
-
-    User opens google.com/device on any browser, enters the code we print,
-    signs in, grants scopes. We poll until consent and return credentials.
-    """
-    # Imported lazily so --help works even without the google libs installed
-    import json
-    import time
-
-    import requests
-    from google.oauth2.credentials import Credentials
-
-    with open(client_secrets) as f:
-        secrets = json.load(f)
-    installed = secrets.get("installed") or secrets.get("web") or {}
-    client_id = installed["client_id"]
-    client_secret = installed["client_secret"]
-
-    # Step 1: ask Google for a device code
-    r = requests.post(
-        "https://oauth2.googleapis.com/device/code",
-        data={"client_id": client_id, "scope": " ".join(GMAIL_SCOPES)},
-        timeout=30,
-    )
-    r.raise_for_status()
-    dev = r.json()
-
-    print()
-    print(f"  Open this URL on any browser: {dev['verification_url']}")
-    print(f"  Enter this code:              {dev['user_code']}")
-    print()
-    print(f"  Waiting for consent (expires in {dev['expires_in']}s)...")
-    print()
-
-    # Step 2: poll the token endpoint until the user completes consent
-    interval = int(dev.get("interval", 5))
-    deadline = time.time() + int(dev["expires_in"])
-    while time.time() < deadline:
-        time.sleep(interval)
-        r = requests.post(
-            "https://oauth2.googleapis.com/token",
-            data={
-                "client_id": client_id,
-                "client_secret": client_secret,
-                "device_code": dev["device_code"],
-                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-            },
-            timeout=30,
-        )
-        body = r.json()
-        if r.ok:
-            return Credentials(
-                token=body["access_token"],
-                refresh_token=body.get("refresh_token"),
-                token_uri="https://oauth2.googleapis.com/token",
-                client_id=client_id,
-                client_secret=client_secret,
-                scopes=GMAIL_SCOPES,
-            )
-        if body.get("error") == "authorization_pending":
-            continue
-        if body.get("error") == "slow_down":
-            interval += 5
-            continue
-        # Any other error is terminal
-        raise SystemExit(f"Device flow failed: {body}")
-
-    raise SystemExit("Device flow timed out waiting for user consent.")
-
-
 def run_local(client_secrets: str, port: int):
     """
-    OAuth 2.0 callback flow — listens on 0.0.0.0:port for the redirect.
+    OAuth 2.0 loopback callback flow.
 
-    Requires the OAuth client to list the corresponding http://host:port/...
-    as an authorized redirect URI. Not used in v0.1.0.
+    Listens on 0.0.0.0:port for the redirect. Requires an SSH tunnel so
+    the browser redirect reaches the container. See install-docker.md.
     """
     from google_auth_oauthlib.flow import InstalledAppFlow
 
@@ -159,15 +74,12 @@ def main(argv: list[str] | None = None) -> int:
     if not os.path.exists(args.client_secrets):
         print(
             f"ERROR: OAuth client file not found: {args.client_secrets}\n"
-            f"Download the client JSON from Google Cloud Console and place it at that path.",
+            "Download the client JSON from Google Cloud Console and place it at that path.",
             file=sys.stderr,
         )
         raise SystemExit(2)
 
-    if args.mode == "device":
-        creds = run_device(args.client_secrets)
-    else:
-        creds = run_local(args.client_secrets, args.port)
+    creds = run_local(args.client_secrets, args.port)
 
     out = Path(args.token_out)
     out.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_gmail_auth.py
+++ b/tests/test_gmail_auth.py
@@ -2,8 +2,9 @@
 """
 Tests for scripts/gmail_auth.py — the standalone OAuth helper.
 
-Scope: argparse + mode dispatch. Actual OAuth calls are mocked — we don't
-exercise Google's endpoints from unit tests.
+Scope: argparse + flow dispatch. Actual OAuth calls are mocked.
+Device flow was removed in #115 — Gmail scopes are excluded from
+Google's device authorization grant (invalid_scope).
 """
 
 import sys
@@ -15,12 +16,6 @@ import pytest
 # Make scripts/ importable
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
-
-# tests/test_sync_sheet.py stubs google.oauth2 in sys.modules at import time.
-# When that file is collected before this one, the polling-loop tests below
-# can't lazy-import google.oauth2.credentials. Pre-seed a stub of our own so
-# the from-import in run_device resolves regardless of test ordering.
-sys.modules.setdefault("google.oauth2.credentials", MagicMock())
 
 
 @pytest.fixture
@@ -34,78 +29,42 @@ def fake_client_secrets(tmp_path):
     return p
 
 
-def test_default_mode_is_device():
-    """Running with no --mode flag should default to device flow."""
+def test_default_port_is_8080():
     import gmail_auth
 
     parser = gmail_auth.build_parser()
     args = parser.parse_args([])
-    assert args.mode == "device"
+    assert args.port == 8080
 
 
-def test_mode_flag_accepts_device_and_local():
+def test_port_flag_overrides_default():
     import gmail_auth
 
     parser = gmail_auth.build_parser()
-    assert parser.parse_args(["--mode", "device"]).mode == "device"
-    assert parser.parse_args(["--mode", "local"]).mode == "local"
+    args = parser.parse_args(["--port", "9090"])
+    assert args.port == 9090
 
 
-def test_mode_flag_rejects_unknown():
+def test_mode_arg_no_longer_accepted():
+    """--mode=device is gone; passing it should error."""
     import gmail_auth
 
     parser = gmail_auth.build_parser()
     with pytest.raises(SystemExit):
-        parser.parse_args(["--mode", "magic"])
+        parser.parse_args(["--mode", "device"])
 
 
-def test_run_dispatches_to_device_mode(fake_client_secrets, tmp_path):
-    """--mode=device should call run_device and write the token file."""
-    import gmail_auth
-
-    token_path = tmp_path / "gmail_token.json"
-    mock_creds = MagicMock()
-    mock_creds.to_json.return_value = '{"token": "fake"}'
-
-    with (
-        patch.object(gmail_auth, "run_device", return_value=mock_creds) as m_device,
-        patch.object(gmail_auth, "run_local") as m_local,
-    ):
-        gmail_auth.main(
-            [
-                "--mode",
-                "device",
-                "--client-secrets",
-                str(fake_client_secrets),
-                "--token-out",
-                str(token_path),
-            ]
-        )
-
-    m_device.assert_called_once()
-    m_local.assert_not_called()
-    assert token_path.read_text() == '{"token": "fake"}'
-    # Token file is the long-lived OAuth credential — must be 0600 to keep
-    # other container users from reading it.
-    assert (token_path.stat().st_mode & 0o777) == 0o600
-
-
-def test_run_dispatches_to_local_mode(fake_client_secrets, tmp_path):
-    """--mode=local should call run_local, not run_device."""
+def test_run_calls_local_flow(fake_client_secrets, tmp_path):
+    """main() should call run_local and write the token file."""
     import gmail_auth
 
     token_path = tmp_path / "gmail_token.json"
     mock_creds = MagicMock()
     mock_creds.to_json.return_value = '{"token": "fake-local"}'
 
-    with (
-        patch.object(gmail_auth, "run_local", return_value=mock_creds) as m_local,
-        patch.object(gmail_auth, "run_device") as m_device,
-    ):
+    with patch.object(gmail_auth, "run_local", return_value=mock_creds) as m_local:
         gmail_auth.main(
             [
-                "--mode",
-                "local",
                 "--client-secrets",
                 str(fake_client_secrets),
                 "--token-out",
@@ -115,102 +74,9 @@ def test_run_dispatches_to_local_mode(fake_client_secrets, tmp_path):
             ]
         )
 
-    m_local.assert_called_once()
-    m_device.assert_not_called()
-
-
-def _device_code_response():
-    """Mock response for the initial /device/code POST."""
-    resp = MagicMock()
-    resp.raise_for_status.return_value = None
-    resp.json.return_value = {
-        "device_code": "dev-xyz",
-        "user_code": "ABCD-EFGH",
-        "verification_url": "https://www.google.com/device",
-        "expires_in": 600,
-        "interval": 0,  # zero so test doesn't actually sleep
-    }
-    return resp
-
-
-def _token_response(ok: bool, body: dict):
-    resp = MagicMock()
-    resp.ok = ok
-    resp.json.return_value = body
-    return resp
-
-
-def test_device_flow_retries_on_authorization_pending(fake_client_secrets, tmp_path):
-    """Polling continues while Google returns authorization_pending, succeeds when granted."""
-    import gmail_auth
-
-    token_path = tmp_path / "gmail_token.json"
-    success_body = {"access_token": "tok", "refresh_token": "ref"}
-
-    with (
-        patch("requests.post") as m_post,
-        patch("google.oauth2.credentials.Credentials") as m_creds_cls,
-    ):
-        m_post.side_effect = [
-            _device_code_response(),
-            _token_response(False, {"error": "authorization_pending"}),
-            _token_response(True, success_body),
-        ]
-        mock_creds = MagicMock()
-        mock_creds.to_json.return_value = '{"token": "tok"}'
-        m_creds_cls.return_value = mock_creds
-
-        gmail_auth.main(
-            [
-                "--mode",
-                "device",
-                "--client-secrets",
-                str(fake_client_secrets),
-                "--token-out",
-                str(token_path),
-            ]
-        )
-
-    # 1 device-code call + 2 token polls = 3 POSTs
-    assert m_post.call_count == 3
-    assert token_path.read_text() == '{"token": "tok"}'
-
-
-def test_device_flow_bumps_interval_on_slow_down(fake_client_secrets, tmp_path):
-    """slow_down response should increase the polling interval."""
-    import gmail_auth
-
-    token_path = tmp_path / "gmail_token.json"
-    success_body = {"access_token": "tok", "refresh_token": "ref"}
-    sleep_calls: list[float] = []
-
-    with (
-        patch("requests.post") as m_post,
-        patch("time.sleep", side_effect=sleep_calls.append),
-        patch("google.oauth2.credentials.Credentials") as m_creds_cls,
-    ):
-        m_post.side_effect = [
-            _device_code_response(),
-            _token_response(False, {"error": "slow_down"}),
-            _token_response(True, success_body),
-        ]
-        mock_creds = MagicMock()
-        mock_creds.to_json.return_value = '{"token": "tok"}'
-        m_creds_cls.return_value = mock_creds
-
-        gmail_auth.main(
-            [
-                "--mode",
-                "device",
-                "--client-secrets",
-                str(fake_client_secrets),
-                "--token-out",
-                str(token_path),
-            ]
-        )
-
-    # Two sleeps: first at base interval (0), second after slow_down bumps it (+5)
-    assert sleep_calls == [0, 5]
+    m_local.assert_called_once_with(str(fake_client_secrets), 8080)
+    assert token_path.read_text() == '{"token": "fake-local"}'
+    assert (token_path.stat().st_mode & 0o777) == 0o600
 
 
 def test_missing_client_secrets_errors(tmp_path):
@@ -223,8 +89,6 @@ def test_missing_client_secrets_errors(tmp_path):
     with pytest.raises(SystemExit) as exc_info:
         gmail_auth.main(
             [
-                "--mode",
-                "device",
                 "--client-secrets",
                 str(missing_client),
                 "--token-out",


### PR DESCRIPTION
## Summary

- Google's device authorization grant (`google.com/device`) excludes Gmail scopes — any attempt returns `invalid_scope` before user interaction. This is firm Google policy, not a config issue.
- Remove `run_device()` and `--mode` argument entirely. `gmail_auth.py` now has one flow: loopback (`InstalledAppFlow`).
- `ops/compose.yaml.example` `gmail-auth` service command drops `--mode=device`.
- `docs/setup/install-docker.md` section 4 rewritten: Desktop-type OAuth client + SSH tunnel + `docker compose run -p 8080:8080`.
- Archived spec line 200 annotated as historically incorrect.

## Migration required

**Existing testers with a "TVs and Limited Input devices" OAuth client must rotate to a Desktop-type client.** The old client type cannot authorize Gmail scopes in any flow. Steps:
1. In Google Cloud Console, create a new OAuth 2.0 client → type: **Desktop app**
2. Download new JSON → overwrite `state/config/gmail_oauth_client.json`
3. Re-run Gmail auth using the SSH tunnel flow in the updated `install-docker.md`

Deployments with a pre-existing `gmail_token.json` (minted under any working flow) are unaffected until the token expires.

## Test plan

- [x] 517/517 tests pass (net -3: removed 8 device-mode tests, added 5 loopback tests)
- [x] `test_mode_arg_no_longer_accepted` verifies `--mode=device` now errors
- [x] `ruff` clean
- [ ] End-to-end SSH tunnel flow needs verification on docker.lan before AC #2 is fully met

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)