### PR TITLE
fix(ops): inject API keys at config seed time; fix misleading comment (#154)

### DIFF
--- a/ops/aichat-ng/config.yaml.example
+++ b/ops/aichat-ng/config.yaml.example
@@ -2,10 +2,10 @@
 # is absent. Re-pulling :v0.1.x will NOT overwrite your local edits; delete
 # the file first if you want to re-seed from this template.
 #
-# API keys come from state/data/.env via ${VAR} substitution that
-# aichat-ng performs at load time. Customize this file for operator-
-# specific settings (default model, keybindings, REPL prefs, custom
-# clients); never paste keys directly into the YAML.
+# API key placeholders (${VAR}) are substituted by ops/entrypoint.sh at
+# seed time from the container environment. Do not paste keys directly
+# into this template — they are injected once when config.yaml is first
+# created and live only in the gitignored state/aichat_ng/config.yaml.
 #
 # See https://github.com/sigoden/aichat/blob/main/config.example.yaml
 # for the full set of supported options.

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -62,6 +62,13 @@ if [ -d /opt/findajob/bundled-aichat ]; then
     fi
     if [ ! -f "$AICHAT_CFG_DIR/config.yaml" ] && [ -f /opt/findajob/bundled-aichat/config.yaml.example ]; then
         cp /opt/findajob/bundled-aichat/config.yaml.example "$AICHAT_CFG_DIR/config.yaml"
+        # aichat-ng does not perform ${VAR} substitution at load time — inject keys now.
+        for _var in OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY \
+                    OPENROUTER_API_KEY PERPLEXITY_API_KEY GROQ_API_KEY XAI_API_KEY; do
+            _val="${!_var}"
+            sed -i "s|\${${_var}}|${_val}|g" "$AICHAT_CFG_DIR/config.yaml"
+        done
+        unset _var _val
     fi
 fi
 


### PR DESCRIPTION
## Summary

- `ops/entrypoint.sh`: after seeding `config.yaml` from the template, immediately substitutes all `${API_KEY_VAR}` placeholders from the container environment — aichat-ng does not do this substitution itself at load time
- `ops/aichat-ng/config.yaml.example`: comment corrected to say keys are injected by entrypoint at seed time, not by aichat-ng at load time

## Background

Discovered in #153: Amy's fresh container had a seeded `config.yaml` with literal `${GOOGLE_API_KEY}` as the api_key, which the Gemini API rejected. Brock's container only worked because he had manually hardcoded his keys long ago.

## Test plan

- [ ] `bash -n ops/entrypoint.sh` passes (syntax OK)
- [ ] All 523 unit tests pass
- [ ] Fresh container smoke: delete `state/aichat_ng/config.yaml`, restart stack, verify `aichat-ng -m gemini:gemini-3-flash-preview 'say: ok'` succeeds without manual key patching

🤖 Generated with [Claude Code](https://claude.com/claude-code)