### PR TITLE
fix(entrypoint): assert aichat-ng config readable before scheduler starts (#161)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,15 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Smoke — aichat-ng executes
-        run: docker run --rm findajob:ci-smoke aichat-ng --version
+        run: docker run --rm -e HOME=/app findajob:ci-smoke aichat-ng --version
 
       - name: Smoke — supercronic validates the crontab
-        run: docker run --rm findajob:ci-smoke supercronic -test /app/crontab
+        run: docker run --rm -e HOME=/app findajob:ci-smoke supercronic -test /app/crontab
 
       - name: Smoke — Python package imports
         run: |
           docker run --rm \
+            -e HOME=/app \
             -e JSP_BASE=/app \
             findajob:ci-smoke \
             python3 -c "import findajob; import findajob.paths; print(findajob.paths.BASE)"
@@ -67,6 +68,7 @@ jobs:
       - name: Smoke — entrypoint creates runtime user without error
         run: |
           docker run --rm \
+            -e HOME=/app \
             -e PUID=1001 -e PGID=1001 \
             findajob:ci-smoke \
             id findajob
@@ -76,6 +78,7 @@ jobs:
           mkdir -p /tmp/test-entrypoint-logs
           sudo touch /tmp/test-entrypoint-logs/pipeline.jsonl
           owner=$(docker run --rm \
+            -e HOME=/app \
             -e PUID=1001 -e PGID=1001 \
             -v /tmp/test-entrypoint-logs:/app/logs \
             findajob:ci-smoke \

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -13,6 +13,8 @@
 #      bundled-config.
 #   3. Chown bind-mounted writable dirs to findajob:findajob if they're
 #      not already owned correctly.
+#   3b. Assert aichat-ng config.yaml is readable by the runtime user — exits
+#      with a clear diagnostic if missing (e.g., HOME not set in compose.yaml).
 #   4. Drop privileges and exec the CMD (default: supercronic /app/crontab).
 #
 # Env:
@@ -88,7 +90,20 @@ for dir in /app/data /app/logs /app/companies /app/config /app/candidate_context
     fi
 done
 
-# --- 3b. Initialize DB schema (idempotent) --------------------------------
+# --- 3b. Assert aichat-ng config is readable before scheduler starts ------
+# Fails fast if config.yaml is missing or unreadable by the runtime user.
+# Most common cause: HOME not set to /app in compose.yaml, so the seeding
+# in step 2b wrote to /root/.config/aichat_ng/ instead of the bind-mount.
+if ! gosu "$PUID:$PGID" test -r "$AICHAT_CFG_DIR/config.yaml" 2>/dev/null; then
+    echo "FATAL: aichat-ng config not found or not readable at $AICHAT_CFG_DIR/config.yaml (UID $PUID)" >&2
+    echo "  HOME=$HOME  AICHAT_CFG_DIR=$AICHAT_CFG_DIR" >&2
+    echo "  Ensure HOME: /app is set in compose.yaml environment:" >&2
+    echo "    environment:" >&2
+    echo "      HOME: /app" >&2
+    exit 1
+fi
+
+# --- 3c. Initialize DB schema (idempotent) --------------------------------
 # CREATE TABLE IF NOT EXISTS so re-runs on populated DBs are no-ops.
 # Runs as $PUID:$PGID so the resulting pipeline.db is owned correctly.
 if [ -w /app/data ]; then


### PR DESCRIPTION
## Summary

- Adds a fail-fast health check to `ops/entrypoint.sh` after the seeding and chown steps: verifies that `config.yaml` is readable by the runtime user (`$PUID`) before supercronic starts
- On failure, exits with a clear diagnostic including `HOME`, `AICHAT_CFG_DIR`, and the exact compose.yaml fix needed
- Fixes the silent failure mode that caused #161: Amy's initial stack was deployed without `HOME: /app` in compose.yaml (before PR #110 added it to the example), so seeding wrote to `/root/.config/aichat_ng/` instead of the bind-mounted `/app/.config/aichat_ng/` — triage ran, found no config, scored all 258 jobs as NULL

## Root cause (resolved in #161)

Amy's `compose.yaml` was copied from the example before `9e997ab` (PR #110, 2026-04-20) added `HOME: /app`. Without it, `AICHAT_CFG_DIR="${HOME:-/root}/.config/aichat_ng"` resolved to `/root/.config/aichat_ng/` — inside the container, not on the bind-mount. The bind-mount at `./state/aichat_ng:/app/.config/aichat_ng` stayed empty. triage at 07:01 UTC on 2026-04-22 failed all 258 scoring calls. Operator fixed compose.yaml and restarted at ~13:23 UTC; 158 null-score `manual_review` jobs remain and will drain on the next triage cycle (07:00 UTC 2026-04-23).

## Test plan

- [ ] Local: run entrypoint with `HOME` unset (or set to `/root`) — container should exit with FATAL diagnostic
- [ ] Local: run entrypoint with `HOME: /app` and a seeded bind-mount — container should start normally
- [ ] Deploy updated image to Amy's stack; verify clean start in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)