### PR TITLE
fix(triage): log pipeline_crash with traceback on unhandled exception (#162)

### DIFF
--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -13,6 +13,7 @@ import sqlite3
 import subprocess
 import sys
 import time
+import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
@@ -560,4 +561,8 @@ def notify(message):
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        log_event("pipeline_crash", error=str(e), traceback=traceback.format_exc())
+        raise


### PR DESCRIPTION
## Summary

- Adds `import traceback` and wraps the `main()` call in `__main__` with a top-level `try/except Exception`
- On any uncaught exception, logs a `pipeline_crash` event with `error` and `traceback` fields before re-raising
- Re-raise preserves the non-zero exit code so supercronic sees the failure

## Why

On 2026-04-22T07:02 UTC, triage fetched 7492 jobs then died silently — no `pipeline_error`, no traceback, no `pipeline_complete`. Health check flagged the missing `pipeline_complete` but there was nothing to diagnose. This ensures the next silent crash leaves a record in `logs/pipeline.jsonl`.

## Test plan

- [ ] 525 existing tests pass (`uv run pytest tests/ -q`) ✓
- [ ] Deploy to operator stack; verify next triage completes normally (no `pipeline_crash` event)
- [ ] To verify the catch path: `docker exec ... python3 -c "import scripts.triage"` and inspect log output on a forced exception (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)