### PR TITLE
fix(poll_flags): auto-reset stale prep_in_progress jobs after 60min (#163)

### DIFF
--- a/scripts/poll_flags.py
+++ b/scripts/poll_flags.py
@@ -184,6 +184,35 @@ def main():
     conn = sqlite3.connect(DB_PATH, timeout=30)
     conn.row_factory = sqlite3.Row
 
+    # ── Stale-prep cleanup ────────────────────────────────────────────────────
+    # If a job has been stuck in prep_in_progress for more than STALE_PREP_MINUTES,
+    # the prep subprocess was killed (container restart, OOM, timeout) without being
+    # able to reset the stage itself. Reset it to scored so the user can re-flag.
+    STALE_PREP_MINUTES = 60
+    stale_jobs = conn.execute(
+        """
+        SELECT id, title, company FROM jobs
+        WHERE stage = 'prep_in_progress'
+          AND stage_updated < datetime('now', ?)
+        """,
+        (f"-{STALE_PREP_MINUTES} minutes",),
+    ).fetchall()
+    for stale in stale_jobs:
+        now = datetime.now(UTC).isoformat()
+        conn.execute(
+            "UPDATE jobs SET stage='scored', stage_updated=?, updated_at=? WHERE id=?",
+            (now, now, stale["id"]),
+        )
+        conn.commit()
+        write_audit(conn, stale["id"], "stage", "prep_in_progress", "scored")
+        log_event(
+            "prep_stale_reset",
+            job_id=stale["id"],
+            company=stale["company"],
+            title=stale["title"],
+            stale_minutes=STALE_PREP_MINUTES,
+        )
+
     flagged_jobs = []
     rejected_count = 0
     not_selected_count = 0


### PR DESCRIPTION
## Summary

- Adds a stale-prep cleanup pass at the start of each `poll_flags.py` cycle
- Any job stuck in `prep_in_progress` for >60 minutes is reset to `scored` and a `prep_stale_reset` event is logged
- Guards against the scenario where a prep subprocess is killed (container restart, OOM, SIGKILL) before it can reset its own stage

## Root cause of #163

The UN Evaluation Officer P4 job on Alice Doe's stack got stuck via this sequence:
1. `aichat_failure` on resume_quality_check at 13:43 UTC caused the cover letter writer subprocess to hang
2. Container restarted at 15:56 UTC, killing the hanging prep process (SIGKILL — Python exception handler can't run)
3. Stage remained `prep_in_progress` indefinitely; poll_flags correctly skipped re-triggering but had no recovery path

## What was fixed manually (Alice Doe stack)
- Job stage reset to `scored` (DB: `6cb2072e`, `relevance_score: 8`, ready to re-flag for prep)
- 3 orphan prep folders deleted: `United Nations_Evaluation_Officer_P4_2026-04-22_062{632,904}` and `_064002`

## Test plan

- [ ] 525 tests pass ✓
- [ ] Deploy to both stacks; verify next `poll_flags` run logs `prep_stale_reset` for zero jobs (no stale jobs remaining)
- [ ] If a job gets stuck in prep_in_progress, verify it auto-resets within 70 minutes (60min threshold + next poll cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)