### PR TITLE
fix(triage): log triage_sync_failed when sync_sheet exits non-zero (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+
+- `triage.py` now captures the exit code of the `sync_sheet.py` subprocess and emits a `triage_sync_failed` event with the return code when sync crashes non-zero. Previously `check=False` swallowed the failure, leaving only a `sync_complete not seen in 25h` warning as the eventual signal. The new event is picked up by `notify.py health-check`'s generic error matcher immediately (#145).
+
 ## [0.1.4] — 2026-04-22
 
 Bugfix patch: reliability and diagnostics fixes surfaced during the generalization beta (Alice Doe / #20). Fixes silent triage crashes, stuck prep cycles, a bad Gmail OAuth client type, and several web and sheet inconsistencies. Operators with a "TVs and Limited Input devices" OAuth client must rotate to a Desktop-type client before pulling (see Migration required below).

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -530,8 +530,30 @@ def main():
         noise_skipped=noise_count,
     )
 
-    subprocess.run([sys.executable, f"{BASE}/scripts/sync_sheet.py"], check=False)
+    _run_sync_sheet()
     notify(f"Triage done: {new_count} new, {dupe_count} dupes, {scored_count} scored ({SCORE_WORKERS} workers)")
+
+
+def _run_sync_sheet():
+    """Run sync_sheet.py as a subprocess and surface a non-zero exit.
+
+    sync_sheet.py logs its own ``sync_failed`` event for exceptions raised
+    inside its main ``try:`` block, but pre-try failures (missing creds
+    file, sqlite3 connect failure, import-time crash) bypass that log.
+    Capturing the return code here guarantees an observable signal in
+    ``pipeline.jsonl`` regardless of where sync_sheet died.
+
+    Returns the exit code. Does not raise — triage's DB work is already
+    complete by the time this runs, and we still want the final notify()
+    ntfy ping to fire so the operator sees the run finished.
+    """
+    result = subprocess.run(
+        [sys.executable, f"{BASE}/scripts/sync_sheet.py"],
+        check=False,
+    )
+    if result.returncode != 0:
+        log_event("triage_sync_failed", returncode=result.returncode)
+    return result.returncode
 
 
 def notify(message):

--- a/tests/test_triage_sync_exit.py
+++ b/tests/test_triage_sync_exit.py
@@ -1,0 +1,66 @@
+"""Tests for _run_sync_sheet() exit-code handling in triage.py (#145).
+
+Previously triage.py called sync_sheet.py with subprocess.run(..., check=False)
+and discarded the return code, so a crashed sync was invisible from the
+triage side. _run_sync_sheet() now logs triage_sync_failed on non-zero exit.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_triage():
+    spec = importlib.util.spec_from_file_location("triage", SCRIPTS_DIR / "triage.py")
+    mod = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, {"findajob.scoring": MagicMock()}):
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            pass
+    return mod
+
+
+def test_sync_failure_logs_triage_sync_failed():
+    """Non-zero exit from sync_sheet.py emits a triage_sync_failed event."""
+    triage = _load_triage()
+    events: list[dict] = []
+
+    def fake_log_event(event, **kwargs):
+        events.append({"event": event, **kwargs})
+
+    fake_result = MagicMock(returncode=2)
+    with (
+        patch.object(triage.subprocess, "run", return_value=fake_result) as mock_run,
+        patch.object(triage, "log_event", fake_log_event),
+    ):
+        rc = triage._run_sync_sheet()
+
+    assert mock_run.call_count == 1
+    assert rc == 2
+    failed = [e for e in events if e["event"] == "triage_sync_failed"]
+    assert len(failed) == 1
+    assert failed[0]["returncode"] == 2
+
+
+def test_sync_success_emits_no_failure_event():
+    """Zero exit from sync_sheet.py emits no triage_sync_failed event."""
+    triage = _load_triage()
+    events: list[dict] = []
+
+    def fake_log_event(event, **kwargs):
+        events.append({"event": event, **kwargs})
+
+    fake_result = MagicMock(returncode=0)
+    with (
+        patch.object(triage.subprocess, "run", return_value=fake_result),
+        patch.object(triage, "log_event", fake_log_event),
+    ):
+        rc = triage._run_sync_sheet()
+
+    assert rc == 0
+    assert not any(e["event"] == "triage_sync_failed" for e in events)


### PR DESCRIPTION
## Summary

- Closes #145. triage.py's \`subprocess.run(sync_sheet.py, check=False)\` previously discarded the return code, so a crashed sync left no caller-side signal in \`pipeline.jsonl\`.
- Extracts the invocation into \`_run_sync_sheet()\` which captures the exit code and emits \`triage_sync_failed\` with the returncode on non-zero.
- sync_sheet.py's own \`sync_failed\` event only covers exceptions inside its \`try:\` block — pre-try failures (missing creds, sqlite3 connect errors, import-time crashes) bypass that log entirely. The new event closes that gap unconditionally.

## Why not "move sync out of triage into poll_flags"?

The issue offered that as an alternative. It would cleanly de-dup the sync orchestration, but at the cost of adding up-to-10-min latency between triage completing and the Dashboard reflecting it — a minor degradation for Brock's 06:15 morning-stats flow. Chose the narrow additive fix; the move-to-poll_flags refactor can be a follow-up if the operational cost ever shows up.

## Observability path

\`notify.py health-check\` already has a generic matcher for any event with \`"failed"\` in keys or \`"error"\` in the event name (notify.py:204), so \`triage_sync_failed\` surfaces in the next health-check run without needing a dedicated branch in notify.py. If prettier formatting is wanted later, that's a small follow-up.

## Test plan

- [x] \`uv run pytest tests/test_triage_sync_exit.py\` — new tests for both rc=0 and rc≠0 paths
- [x] \`uv run pytest\` — full suite (527 passed)
- [x] \`uv run ruff check scripts/triage.py tests/test_triage_sync_exit.py\`
- [x] \`uv run mypy scripts/triage.py\` — pre-existing unrelated error on line 163 only; no new errors introduced
- [ ] On docker.lan: after merge + image rebuild, grep \`pipeline.jsonl\` for \`triage_sync_failed\` events over the next week to confirm zero false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)