### PR TITLE
fix(prep): audit + log every stage rollback from prep_in_progress (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ### Fixed
 
+- `prep_application.py` failure paths (missing candidate files, empty-output validation, unhandled exception) now share a `reset_prep_to_scored()` helper that writes an `audit_log` entry and emits a `prep_failed_reset` event before rolling stage back to `scored`. Without the audit entry the 60-min stale-prep reset couldn't distinguish real hangs from silent error-path resets, and a transient upstream outage (e.g. today's 15-min Anthropic/Gemini auth blip) could loop forever with only the forward half of each transition visible in the audit trail. `poll_flags.py`'s deferred-over-concurrency-cap reset uses the same helper (#172).
 - `triage.py` now captures the exit code of the `sync_sheet.py` subprocess and emits a `triage_sync_failed` event with the return code when sync crashes non-zero. Previously `check=False` swallowed the failure, leaving only a `sync_complete not seen in 25h` warning as the eventual signal. The new event is picked up by `notify.py health-check`'s generic error matcher immediately (#145).
 
 ## [0.1.4] — 2026-04-22

--- a/scripts/poll_flags.py
+++ b/scripts/poll_flags.py
@@ -15,7 +15,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 from findajob.paths import BASE
-from findajob.utils import is_valid_company, log_event, write_audit
+from findajob.utils import is_valid_company, log_event, reset_prep_to_scored, write_audit
 
 DB_PATH = f"{BASE}/data/pipeline.db"
 SA_FILE = f"{BASE}/config/gsheets_creds.json"
@@ -562,13 +562,8 @@ def main():
         # Reset deferred jobs back to scored so next poll cycle picks them up
         deferred = flagged_jobs[MAX_CONCURRENT_PREPS:]
         deferred_conn = sqlite3.connect(DB_PATH, timeout=30)
-        now = datetime.now(UTC).isoformat()
         for job in deferred:
-            deferred_conn.execute(
-                "UPDATE jobs SET stage='scored', stage_updated=?, updated_at=? WHERE id=?",
-                (now, now, job["id"]),
-            )
-        deferred_conn.commit()
+            reset_prep_to_scored(deferred_conn, job["id"], reason="deferred_over_concurrency_cap")
         deferred_conn.close()
         log_event(
             "prep_deferred",

--- a/scripts/prep_application.py
+++ b/scripts/prep_application.py
@@ -19,6 +19,7 @@ from findajob.utils import (
     load_env,
     log_event,
     read_file_prefix,
+    reset_prep_to_scored,
     write_audit,
 )
 
@@ -206,12 +207,7 @@ def main():
     if missing_files:
         log_event("prep_missing_candidate_files", job_id=job_id, company=company, missing="; ".join(missing_files))
         shutil.rmtree(outdir, ignore_errors=True)
-        now = datetime.now(UTC).isoformat()
-        conn.execute(
-            "UPDATE jobs SET stage='scored', prep_folder_path=NULL, stage_updated=?, updated_at=? WHERE id=?",
-            (now, now, job_id),
-        )
-        conn.commit()
+        reset_prep_to_scored(conn, job_id, reason="missing_candidate_files")
         notify(f"PREP ABORTED (missing candidate files): {company} — {title}\n{'; '.join(missing_files)}")
         return
 
@@ -468,12 +464,7 @@ Generated: {date}
             failures="; ".join(validation_failures),
         )
         shutil.rmtree(outdir, ignore_errors=True)
-        now = datetime.now(UTC).isoformat()
-        conn.execute(
-            "UPDATE jobs SET stage='scored', prep_folder_path=NULL, stage_updated=?, updated_at=? WHERE id=?",
-            (now, now, job_id),
-        )
-        conn.commit()
+        reset_prep_to_scored(conn, job_id, reason="validation_failed")
         notify(f"PREP FAILED (empty files): {company} — {title}\n{'; '.join(validation_failures)}")
         return
 
@@ -522,11 +513,7 @@ if __name__ == "__main__":
         )
         try:
             conn = sqlite3.connect(DB_PATH, timeout=30)
-            conn.execute(
-                "UPDATE jobs SET stage='scored', updated_at=? WHERE id=? AND stage='prep_in_progress'",
-                (datetime.now(UTC).isoformat(), job_id),
-            )
-            conn.commit()
+            reset_prep_to_scored(conn, job_id, reason=f"exception:{type(exc).__name__}")
             conn.close()
         except Exception:
             pass  # DB recovery is best-effort

--- a/src/findajob/utils.py
+++ b/src/findajob/utils.py
@@ -37,6 +37,35 @@ def write_audit(
     conn.commit()
 
 
+def reset_prep_to_scored(
+    conn: sqlite3.Connection,
+    job_id: str,
+    reason: str,
+) -> bool:
+    """Roll a failed prep attempt back from prep_in_progress to scored.
+
+    Guards on stage='prep_in_progress' so a job that raced ahead to
+    materials_drafted or was moved to applied isn't clobbered. Writes both an
+    audit_log entry and a prep_failed_reset event — without the audit entry,
+    the 60-min stale-prep reset can't distinguish real hangs from silent
+    error-path resets (see #172).
+
+    Returns True if the reset actually happened.
+    """
+    now = datetime.now(UTC).isoformat()
+    cur = conn.execute(
+        "UPDATE jobs SET stage='scored', prep_folder_path=NULL, "
+        "stage_updated=?, updated_at=? WHERE id=? AND stage='prep_in_progress'",
+        (now, now, job_id),
+    )
+    conn.commit()
+    if cur.rowcount == 0:
+        return False
+    write_audit(conn, job_id, "stage", "prep_in_progress", "scored")
+    log_event("prep_failed_reset", job_id=job_id, reason=reason)
+    return True
+
+
 # ── Environment loading ──────────────────────────────────────────────────────
 
 

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -488,9 +488,7 @@ class TestResetPrepToScored:
         did_reset = reset_prep_to_scored(db, job_id, reason="test_reason")
 
         assert did_reset is False
-        row = db.execute(
-            "SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job_id,)
-        ).fetchone()
+        row = db.execute("SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job_id,)).fetchone()
         assert row["stage"] == "materials_drafted"
         assert row["prep_folder_path"] == "/keep/me"
         audit = db.execute("SELECT 1 FROM audit_log WHERE job_id=?", (job_id,)).fetchall()

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -403,3 +403,110 @@ class TestMissingCandidateFilesAbort:
         # Stage should still be whatever it was before (prep_in_progress → scored after abort)
         row = db.execute("SELECT stage FROM jobs WHERE id=?", (job_id,)).fetchone()
         assert row["stage"] != "materials_drafted"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# reset_prep_to_scored — shared failure-rollback helper (issue #172)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestResetPrepToScored:
+    """Every prep_application.py failure path (missing files, validation, unhandled
+    exception) used to bounce stage back to 'scored' without write_audit, hiding
+    the reverse half of each transition and defeating the 60-min stale-reset.
+
+    The shared helper reset_prep_to_scored() exists to make that invariant
+    enforceable in one place."""
+
+    def _redirect_log(self, monkeypatch, tmp_path):
+        # log_event writes to findajob.paths.BASE/logs/pipeline.jsonl — redirect
+        # so tests don't append to the real log.
+        from findajob import utils
+
+        monkeypatch.setattr(utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
+
+    def test_resets_stage_and_clears_folder(self, db, tmp_path, monkeypatch):
+        from findajob.utils import reset_prep_to_scored
+
+        self._redirect_log(monkeypatch, tmp_path)
+        job_id = insert_job(db, stage="prep_in_progress", folder="/tmp/some/path")
+
+        did_reset = reset_prep_to_scored(db, job_id, reason="test_reason")
+
+        assert did_reset is True
+        row = db.execute(
+            "SELECT stage, prep_folder_path, stage_updated FROM jobs WHERE id=?",
+            (job_id,),
+        ).fetchone()
+        assert row["stage"] == "scored"
+        assert row["prep_folder_path"] is None
+        assert row["stage_updated"] is not None
+
+    def test_writes_audit_entry(self, db, tmp_path, monkeypatch):
+        """CORE invariant of #172: every stage transition auditable."""
+        from findajob.utils import reset_prep_to_scored
+
+        self._redirect_log(monkeypatch, tmp_path)
+        job_id = insert_job(db, stage="prep_in_progress")
+
+        reset_prep_to_scored(db, job_id, reason="unit_test")
+
+        audit = db.execute(
+            "SELECT field_changed, old_value, new_value FROM audit_log WHERE job_id=?",
+            (job_id,),
+        ).fetchall()
+        assert len(audit) == 1
+        assert audit[0]["field_changed"] == "stage"
+        assert audit[0]["old_value"] == "prep_in_progress"
+        assert audit[0]["new_value"] == "scored"
+
+    def test_emits_prep_failed_reset_event(self, db, tmp_path, monkeypatch):
+        """Operator monitoring: failure resets must be visible in pipeline.jsonl."""
+        import json
+
+        from findajob.utils import reset_prep_to_scored
+
+        log_path = tmp_path / "events.jsonl"
+        self._redirect_log(monkeypatch, tmp_path)
+        job_id = insert_job(db, stage="prep_in_progress")
+
+        reset_prep_to_scored(db, job_id, reason="validation_failed")
+
+        entries = [json.loads(line) for line in log_path.read_text().splitlines()]
+        resets = [e for e in entries if e["event"] == "prep_failed_reset"]
+        assert len(resets) == 1
+        assert resets[0]["job_id"] == job_id
+        assert resets[0]["reason"] == "validation_failed"
+
+    def test_guards_materials_drafted(self, db, tmp_path, monkeypatch):
+        """Don't clobber a successful prep that raced in before the error path."""
+        from findajob.utils import reset_prep_to_scored
+
+        self._redirect_log(monkeypatch, tmp_path)
+        job_id = insert_job(db, stage="materials_drafted", folder="/keep/me")
+
+        did_reset = reset_prep_to_scored(db, job_id, reason="test_reason")
+
+        assert did_reset is False
+        row = db.execute(
+            "SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job_id,)
+        ).fetchone()
+        assert row["stage"] == "materials_drafted"
+        assert row["prep_folder_path"] == "/keep/me"
+        audit = db.execute("SELECT 1 FROM audit_log WHERE job_id=?", (job_id,)).fetchall()
+        assert len(audit) == 0
+
+    def test_guards_applied(self, db, tmp_path, monkeypatch):
+        """Don't roll back a job the user already submitted."""
+        from findajob.utils import reset_prep_to_scored
+
+        self._redirect_log(monkeypatch, tmp_path)
+        job_id = insert_job(db, stage="applied")
+
+        did_reset = reset_prep_to_scored(db, job_id, reason="test_reason")
+
+        assert did_reset is False
+        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job_id,)).fetchone()
+        assert row["stage"] == "applied"
+        audit = db.execute("SELECT 1 FROM audit_log WHERE job_id=?", (job_id,)).fetchall()
+        assert len(audit) == 0


### PR DESCRIPTION
Fixes #172.

## Problem

All three failure paths in \`scripts/prep_application.py\` — missing candidate files (old line 211), empty-output validation (old line 473), and the top-level exception handler (old line 526) — reset \`stage='scored'\` without calling \`write_audit()\`. Only the success path at line 493 audited.

Same pattern in \`scripts/poll_flags.py\`'s deferred-over-concurrency reset (old line 568) for jobs beyond the \`MAX_CONCURRENT_PREPS=3\` cap.

## Consequences observed 2026-04-22

Amy's stack hit a ~15-min transient Anthropic + Google auth blip at 12:30 UTC. For a single flagged job (\`6cb2072e\`, UN Evaluation Officer P4), the sequence per 10-min \`poll_flags\` cycle was:

1. \`poll_flags\` sees \`STATUS=Flag for Prep\`, sets \`stage=prep_in_progress\` (audited ✓)
2. \`prep_application\` fails validation (empty outputs from the blip), resets \`stage=scored\` (no audit ✗)
3. Next poll sees \`STATUS=Flag for Prep\` (sheet hasn't re-synced), \`stage=scored\` → triggers again

~40 cycles over 6 hours before the loop finally broke. The 60-min stale-prep reset from #168 could never fire — the silent reset beat it back to \`scored\` before every 60-min threshold. The audit log showed only forward transitions (\`scored → prep_in_progress\`), hiding the reverse half entirely.

## Fix

New \`reset_prep_to_scored(conn, job_id, reason)\` helper in \`src/findajob/utils.py\`:

- Guards on \`stage='prep_in_progress'\` so a successful prep that raced in (stage already \`materials_drafted\`) or a user action (stage \`applied\`) doesn't get clobbered.
- Writes the \`audit_log\` entry for the reverse transition.
- Emits a \`prep_failed_reset\` pipeline.jsonl event with the \`reason\`.
- Returns \`True\` if the reset happened, \`False\` if guard rejected.

All four call sites now route through the helper.

## Tests

5 new tests in \`tests/test_prep_pipeline.py::TestResetPrepToScored\` covering happy path, audit entry, log event, and both guard cases (materials_drafted + applied). TDD workflow followed (failing ImportError first, then implementation).

Full suite: 532 passed. Ruff clean. Mypy clean on all three changed files.

## Documentation Impact

- \`CHANGELOG.md\` — added an \`[Unreleased] / Fixed\` bullet describing the behavior change and the observed incident that motivated it.
- No CLAUDE.md / docs/setup changes needed — this is a behavior fix, no new conventions or operator-facing config.
- No spec doc — small targeted fix, didn't warrant one.

## Migration required

No. Audit-log schema, DB schema, config, and compose are all unchanged. Next \`:latest\` pull gets the fix transparently.

## Out of scope

- #171 (sync_sheet silent truncation) — independent bug, separate PR.
- #174 (duplicate prep folders on Regenerate) — independent bug, separate PR.
- The Regenerate path and manual_prep.py also touch stages; not in this PR since those aren't currently failing and the change is scoped to the observed incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)