### PR TITLE
feat(web): 14c PR-A — STATUS + REJECT_REASON web write handlers (#61)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "uvicorn[standard]>=0.32.0",
     "jinja2>=3.1.0",
     "markdown>=3.7",
+    "python-multipart>=0.0.20",
 ]
 
 [project.optional-dependencies]

--- a/scripts/poll_flags.py
+++ b/scripts/poll_flags.py
@@ -3,7 +3,6 @@
 """Poll Google Sheet for APPLY_FLAG + REJECT_REASON changes. Mirror to SQLite. Trigger prep."""
 
 import os
-import re
 import shutil
 import sqlite3
 import subprocess
@@ -14,8 +13,17 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
+from findajob.actions import (
+    handle_not_selected,
+    handle_reactivate,
+    handle_rejection,
+    handle_waitlist,
+    notify_waitlist_resurface,
+    promote_to_scored,
+    reset_prep_to_scored,
+)
 from findajob.paths import BASE
-from findajob.utils import is_valid_company, log_event, reset_prep_to_scored, write_audit
+from findajob.utils import is_valid_company, log_event, write_audit
 
 DB_PATH = f"{BASE}/data/pipeline.db"
 SA_FILE = f"{BASE}/config/gsheets_creds.json"
@@ -23,140 +31,6 @@ with open(f"{BASE}/config/sheet_id.txt") as f:
     SHEET_ID = f.read().strip()
 
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
-
-
-def handle_rejection(conn, job, reason):
-    """Store rejection in DB, write to feedback_log, and move company folder to _rejected.
-    Drops a marker file named {reason}_{date}.txt inside the moved folder.
-    Returns True if a folder was moved."""
-    now = datetime.now(UTC).isoformat()
-    old_stage = job["stage"]
-    conn.execute(
-        "UPDATE jobs SET stage=?, reject_reason=?, updated_at=? WHERE id=?", ("rejected", reason, now, job["id"])
-    )
-    # jd_excerpt: first 500 chars of raw_jd_text for post-hoc analysis
-    jd = conn.execute("SELECT raw_jd_text, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-    jd_excerpt = (jd["raw_jd_text"] or "")[:500] if jd and jd["raw_jd_text"] else ""
-    conn.execute(
-        """INSERT INTO feedback_log (job_id, title, company, relevance_score, reject_reason, jd_excerpt)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (job["id"], job["title"], job["company"], job["relevance_score"], reason, jd_excerpt),
-    )
-
-    # Move company folder to _rejected if it exists
-    folder_moved = False
-    folder = jd["prep_folder_path"] if jd else None
-    if folder and os.path.isdir(folder):
-        rejected_dir = os.path.join(BASE, "companies", "_rejected")
-        os.makedirs(rejected_dir, exist_ok=True)
-        dest = os.path.join(rejected_dir, os.path.basename(folder))
-        shutil.move(folder, dest)
-        # Drop a marker file: filesystem-safe reason + date
-        safe_reason = re.sub(r"[^\w\s-]", "", reason).strip().replace(" ", "_")[:60]
-        date_str = datetime.now().strftime("%Y-%m-%d")
-        open(os.path.join(dest, f"REJECTED_{safe_reason}_{date_str}.txt"), "w").close()
-        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
-        log_event("folder_moved_to_rejected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
-        folder_moved = True
-
-    conn.commit()
-    write_audit(conn, job["id"], "stage", old_stage, "rejected")
-    write_audit(conn, job["id"], "reject_reason", "", reason)
-    log_event("job_rejected", job_id=job["id"], company=job["company"], title=job["title"], reason=reason)
-    return folder_moved
-
-
-def handle_not_selected(conn, job, reason):
-    """Company rejected the application. Sets stage=not_selected, drops a marker file.
-    Does NOT write to feedback_log — company rejections should not feed the scorer.
-    Folder stays in _applied/ (no move). Returns False (no folder moved)."""
-    now = datetime.now(UTC).isoformat()
-    old_stage = job["stage"]
-    conn.execute(
-        "UPDATE jobs SET stage=?, reject_reason=?, updated_at=? WHERE id=?",
-        ("not_selected", reason, now, job["id"]),
-    )
-
-    # Drop marker file in existing folder (stays in _applied/)
-    jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-    folder = jd["prep_folder_path"] if jd else None
-    if folder and os.path.isdir(folder):
-        safe_reason = re.sub(r"[^\w\s-]", "", reason).strip().replace(" ", "_")[:60]
-        date_str = datetime.now().strftime("%Y-%m-%d")
-        open(os.path.join(folder, f"NOT_SELECTED_{safe_reason}_{date_str}.txt"), "w").close()
-        log_event("marker_added_not_selected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
-
-    conn.commit()
-    write_audit(conn, job["id"], "stage", old_stage, "not_selected")
-    write_audit(conn, job["id"], "reject_reason", "", reason)
-    log_event("job_not_selected", job_id=job["id"], company=job["company"], title=job["title"], reason=reason)
-    return False
-
-
-def handle_waitlist(conn, job):
-    """Move job to waitlisted stage and folder to _waitlisted/.
-    Returns True if a folder was moved, False otherwise.
-    Does NOT write to feedback_log — waitlisting is not rejection."""
-    now = datetime.now(UTC).isoformat()
-    old_stage = job["stage"]
-    conn.execute("UPDATE jobs SET stage=?, updated_at=? WHERE id=?", ("waitlisted", now, job["id"]))
-
-    folder_moved = False
-    jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-    folder = jd["prep_folder_path"] if jd else None
-    if folder and os.path.isdir(folder):
-        waitlisted_dir = os.path.join(BASE, "companies", "_waitlisted")
-        os.makedirs(waitlisted_dir, exist_ok=True)
-        dest = os.path.join(waitlisted_dir, os.path.basename(folder))
-        shutil.move(folder, dest)
-        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
-        log_event("folder_moved_to_waitlisted", job_id=job["id"], folder=os.path.basename(folder))
-        folder_moved = True
-
-    conn.commit()
-    write_audit(conn, job["id"], "stage", old_stage, "waitlisted")
-    log_event("job_waitlisted", job_id=job["id"], company=job["company"], title=job["title"])
-    return folder_moved
-
-
-def handle_reactivate(conn, job):
-    """Restore a waitlisted job to scored or materials_drafted.
-    Returns True if a folder was moved back."""
-    now = datetime.now(UTC).isoformat()
-    jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-    folder = jd["prep_folder_path"] if jd else None
-    folder_moved = False
-
-    if folder and os.path.isdir(folder):
-        # Move folder back from _waitlisted/ to companies/
-        dest = os.path.join(BASE, "companies", os.path.basename(folder))
-        shutil.move(folder, dest)
-        conn.execute(
-            "UPDATE jobs SET stage=?, prep_folder_path=?, updated_at=? WHERE id=?",
-            ("materials_drafted", dest, now, job["id"]),
-        )
-        new_stage = "materials_drafted"
-        folder_moved = True
-    else:
-        conn.execute("UPDATE jobs SET stage=?, updated_at=? WHERE id=?", ("scored", now, job["id"]))
-        new_stage = "scored"
-
-    conn.commit()
-    write_audit(conn, job["id"], "stage", "waitlisted", new_stage)
-    log_event("job_reactivated", job_id=job["id"], company=job["company"], title=job["title"], stage=new_stage)
-    return folder_moved
-
-
-def notify_waitlist_resurface(conn, company):
-    """If there are waitlisted jobs at this company, send a notification."""
-    rows = conn.execute("SELECT title FROM jobs WHERE company = ? AND stage = 'waitlisted'", (company,)).fetchall()
-    if not rows:
-        return
-    titles = [r["title"] for r in rows]
-    title = f"Waitlisted jobs at {company}"
-    body = "You just rejected/withdrew from this company. Waitlisted roles:\n" + "\n".join(f"• {t}" for t in titles)
-    subprocess.Popen([sys.executable, f"{BASE}/scripts/notify.py", "send-raw", title, body], start_new_session=True)
-    log_event("waitlist_resurface", company=company, count=len(titles))
 
 
 def main():
@@ -404,8 +278,6 @@ def main():
         if not job or job["stage"] != "manual_review":
             continue
 
-        now = datetime.now(UTC).isoformat()
-
         # Rejection takes priority
         if reject_val:
             if handle_rejection(conn, job, reject_val):
@@ -416,18 +288,7 @@ def main():
 
         # Promote: set score=7, stage=scored → lands on Dashboard for Flag for Prep
         if status_val == "Promote":
-            conn.execute(
-                """
-                UPDATE jobs SET relevance_score=7, stage='scored',
-                       score_status='scored', score_flag_reason='Promoted from Review tab',
-                       stage_updated=?, updated_at=?
-                WHERE id=?
-            """,
-                (now, now, job["id"]),
-            )
-            conn.commit()
-            write_audit(conn, job["id"], "stage", "manual_review", "scored")
-            log_event("review_promoted", job_id=job["id"], company=job["company"], title=job["title"])
+            promote_to_scored(conn, job, reason="Promoted from Review tab")
             review_promoted += 1
 
     if review_promoted or review_rejected:

--- a/scripts/prep_application.py
+++ b/scripts/prep_application.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 
+from findajob.actions import reset_prep_to_scored
 from findajob.paths import AICHAT, BASE, PANDOC
 from findajob.utils import (
     JD_MAX_CHARS,
@@ -20,7 +21,6 @@ from findajob.utils import (
     log_event,
     quarantine_stale_prep_folders,
     read_file_prefix,
-    reset_prep_to_scored,
     write_audit,
 )
 

--- a/src/findajob/actions.py
+++ b/src/findajob/actions.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Stage-transition actions for the job pipeline.
+
+All state transitions that move a job between stages, move its prep folder,
+or drop marker files live here. Invoked from `scripts/poll_flags.py` today and
+from the web POST handlers in `findajob.web.routes.board_actions` (14c).
+
+Every function takes an open `sqlite3.Connection` as its first argument and
+commits itself. Functions return a `bool` indicating whether a folder was
+moved (or, for `reset_prep_to_scored`, whether the reset actually happened).
+"""
+
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+from datetime import UTC, datetime
+from typing import Any
+
+from findajob.paths import BASE
+from findajob.utils import log_event, write_audit
+
+
+def handle_rejection(conn: sqlite3.Connection, job: Any, reason: str) -> bool:
+    """Store rejection in DB, write to feedback_log, and move company folder to _rejected.
+    Drops a marker file named {reason}_{date}.txt inside the moved folder.
+    Returns True if a folder was moved."""
+    now = datetime.now(UTC).isoformat()
+    old_stage = job["stage"]
+    conn.execute(
+        "UPDATE jobs SET stage=?, reject_reason=?, updated_at=? WHERE id=?", ("rejected", reason, now, job["id"])
+    )
+    # jd_excerpt: first 500 chars of raw_jd_text for post-hoc analysis
+    jd = conn.execute("SELECT raw_jd_text, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+    jd_excerpt = (jd["raw_jd_text"] or "")[:500] if jd and jd["raw_jd_text"] else ""
+    conn.execute(
+        """INSERT INTO feedback_log (job_id, title, company, relevance_score, reject_reason, jd_excerpt)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (job["id"], job["title"], job["company"], job["relevance_score"], reason, jd_excerpt),
+    )
+
+    # Move company folder to _rejected if it exists
+    folder_moved = False
+    folder = jd["prep_folder_path"] if jd else None
+    if folder and os.path.isdir(folder):
+        rejected_dir = os.path.join(BASE, "companies", "_rejected")
+        os.makedirs(rejected_dir, exist_ok=True)
+        dest = os.path.join(rejected_dir, os.path.basename(folder))
+        shutil.move(folder, dest)
+        # Drop a marker file: filesystem-safe reason + date
+        safe_reason = re.sub(r"[^\w\s-]", "", reason).strip().replace(" ", "_")[:60]
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        open(os.path.join(dest, f"REJECTED_{safe_reason}_{date_str}.txt"), "w").close()
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
+        log_event("folder_moved_to_rejected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
+        folder_moved = True
+
+    conn.commit()
+    write_audit(conn, job["id"], "stage", old_stage, "rejected")
+    write_audit(conn, job["id"], "reject_reason", "", reason)
+    log_event("job_rejected", job_id=job["id"], company=job["company"], title=job["title"], reason=reason)
+    return folder_moved
+
+
+def handle_not_selected(conn: sqlite3.Connection, job: Any, reason: str) -> bool:
+    """Company rejected the application. Sets stage=not_selected, drops a marker file.
+    Does NOT write to feedback_log — company rejections should not feed the scorer.
+    Folder stays in _applied/ (no move). Returns False (no folder moved)."""
+    now = datetime.now(UTC).isoformat()
+    old_stage = job["stage"]
+    conn.execute(
+        "UPDATE jobs SET stage=?, reject_reason=?, updated_at=? WHERE id=?",
+        ("not_selected", reason, now, job["id"]),
+    )
+
+    # Drop marker file in existing folder (stays in _applied/)
+    jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+    folder = jd["prep_folder_path"] if jd else None
+    if folder and os.path.isdir(folder):
+        safe_reason = re.sub(r"[^\w\s-]", "", reason).strip().replace(" ", "_")[:60]
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        open(os.path.join(folder, f"NOT_SELECTED_{safe_reason}_{date_str}.txt"), "w").close()
+        log_event("marker_added_not_selected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
+
+    conn.commit()
+    write_audit(conn, job["id"], "stage", old_stage, "not_selected")
+    write_audit(conn, job["id"], "reject_reason", "", reason)
+    log_event("job_not_selected", job_id=job["id"], company=job["company"], title=job["title"], reason=reason)
+    return False
+
+
+def handle_waitlist(conn: sqlite3.Connection, job: Any) -> bool:
+    """Move job to waitlisted stage and folder to _waitlisted/.
+    Returns True if a folder was moved, False otherwise.
+    Does NOT write to feedback_log — waitlisting is not rejection."""
+    now = datetime.now(UTC).isoformat()
+    old_stage = job["stage"]
+    conn.execute("UPDATE jobs SET stage=?, updated_at=? WHERE id=?", ("waitlisted", now, job["id"]))
+
+    folder_moved = False
+    jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+    folder = jd["prep_folder_path"] if jd else None
+    if folder and os.path.isdir(folder):
+        waitlisted_dir = os.path.join(BASE, "companies", "_waitlisted")
+        os.makedirs(waitlisted_dir, exist_ok=True)
+        dest = os.path.join(waitlisted_dir, os.path.basename(folder))
+        shutil.move(folder, dest)
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
+        log_event("folder_moved_to_waitlisted", job_id=job["id"], folder=os.path.basename(folder))
+        folder_moved = True
+
+    conn.commit()
+    write_audit(conn, job["id"], "stage", old_stage, "waitlisted")
+    log_event("job_waitlisted", job_id=job["id"], company=job["company"], title=job["title"])
+    return folder_moved
+
+
+def handle_reactivate(conn: sqlite3.Connection, job: Any) -> bool:
+    """Restore a waitlisted job to scored or materials_drafted.
+    Returns True if a folder was moved back."""
+    now = datetime.now(UTC).isoformat()
+    jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+    folder = jd["prep_folder_path"] if jd else None
+    folder_moved = False
+
+    if folder and os.path.isdir(folder):
+        # Move folder back from _waitlisted/ to companies/
+        dest = os.path.join(BASE, "companies", os.path.basename(folder))
+        shutil.move(folder, dest)
+        conn.execute(
+            "UPDATE jobs SET stage=?, prep_folder_path=?, updated_at=? WHERE id=?",
+            ("materials_drafted", dest, now, job["id"]),
+        )
+        new_stage = "materials_drafted"
+        folder_moved = True
+    else:
+        conn.execute("UPDATE jobs SET stage=?, updated_at=? WHERE id=?", ("scored", now, job["id"]))
+        new_stage = "scored"
+
+    conn.commit()
+    write_audit(conn, job["id"], "stage", "waitlisted", new_stage)
+    log_event("job_reactivated", job_id=job["id"], company=job["company"], title=job["title"], stage=new_stage)
+    return folder_moved
+
+
+def notify_waitlist_resurface(conn: sqlite3.Connection, company: str) -> None:
+    """If there are waitlisted jobs at this company, send a notification."""
+    rows = conn.execute("SELECT title FROM jobs WHERE company = ? AND stage = 'waitlisted'", (company,)).fetchall()
+    if not rows:
+        return
+    titles = [r["title"] for r in rows]
+    title = f"Waitlisted jobs at {company}"
+    body = "You just rejected/withdrew from this company. Waitlisted roles:\n" + "\n".join(f"• {t}" for t in titles)
+    subprocess.Popen([sys.executable, f"{BASE}/scripts/notify.py", "send-raw", title, body], start_new_session=True)
+    log_event("waitlist_resurface", company=company, count=len(titles))
+
+
+def reset_prep_to_scored(
+    conn: sqlite3.Connection,
+    job_id: str,
+    reason: str,
+) -> bool:
+    """Roll a failed prep attempt back from prep_in_progress to scored.
+
+    Guards on stage='prep_in_progress' so a job that raced ahead to
+    materials_drafted or was moved to applied isn't clobbered. Writes both an
+    audit_log entry and a prep_failed_reset event — without the audit entry,
+    the 60-min stale-prep reset can't distinguish real hangs from silent
+    error-path resets (see #172).
+
+    Returns True if the reset actually happened.
+    """
+    now = datetime.now(UTC).isoformat()
+    cur = conn.execute(
+        "UPDATE jobs SET stage='scored', prep_folder_path=NULL, "
+        "stage_updated=?, updated_at=? WHERE id=? AND stage='prep_in_progress'",
+        (now, now, job_id),
+    )
+    conn.commit()
+    if cur.rowcount == 0:
+        return False
+    write_audit(conn, job_id, "stage", "prep_in_progress", "scored")
+    log_event("prep_failed_reset", job_id=job_id, reason=reason)
+    return True
+
+
+def promote_to_scored(
+    conn: sqlite3.Connection,
+    job: Any,
+    reason: str = "Promoted from web UI",
+) -> None:
+    """Promote a manual_review job to scored with relevance_score=7.
+
+    Used when the operator marks a Review-tab job as "Promote" — bumps the
+    score so it lands on the Dashboard for a Flag for Prep decision. The
+    caller is responsible for checking that the job's stage is manual_review
+    (handlers return 409 otherwise).
+    """
+    now = datetime.now(UTC).isoformat()
+    old_stage = job["stage"]
+    conn.execute(
+        """UPDATE jobs SET relevance_score=7, stage='scored',
+                score_status='scored', score_flag_reason=?,
+                stage_updated=?, updated_at=?
+           WHERE id=?""",
+        (reason, now, now, job["id"]),
+    )
+    conn.commit()
+    write_audit(conn, job["id"], "stage", old_stage, "scored")
+    log_event("review_promoted", job_id=job["id"], company=job["company"], title=job["title"])

--- a/src/findajob/utils.py
+++ b/src/findajob/utils.py
@@ -38,35 +38,6 @@ def write_audit(
     conn.commit()
 
 
-def reset_prep_to_scored(
-    conn: sqlite3.Connection,
-    job_id: str,
-    reason: str,
-) -> bool:
-    """Roll a failed prep attempt back from prep_in_progress to scored.
-
-    Guards on stage='prep_in_progress' so a job that raced ahead to
-    materials_drafted or was moved to applied isn't clobbered. Writes both an
-    audit_log entry and a prep_failed_reset event — without the audit entry,
-    the 60-min stale-prep reset can't distinguish real hangs from silent
-    error-path resets (see #172).
-
-    Returns True if the reset actually happened.
-    """
-    now = datetime.now(UTC).isoformat()
-    cur = conn.execute(
-        "UPDATE jobs SET stage='scored', prep_folder_path=NULL, "
-        "stage_updated=?, updated_at=? WHERE id=? AND stage='prep_in_progress'",
-        (now, now, job_id),
-    )
-    conn.commit()
-    if cur.rowcount == 0:
-        return False
-    write_audit(conn, job_id, "stage", "prep_in_progress", "scored")
-    log_event("prep_failed_reset", job_id=job_id, reason=reason)
-    return True
-
-
 def quarantine_stale_prep_folders(
     conn: sqlite3.Connection,
     companies_dir: str,

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -2,10 +2,11 @@
 
 from fastapi import APIRouter
 
-from findajob.web.routes import board, healthz, landing, materials
+from findajob.web.routes import board, board_actions, healthz, landing, materials
 
 router = APIRouter()
 router.include_router(materials.router)
 router.include_router(healthz.router)
 router.include_router(landing.router)
 router.include_router(board.router)
+router.include_router(board_actions.router)

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -1,0 +1,104 @@
+"""Board action POST handlers — web write surface for 14c PR-A (#61).
+
+One handler per operator action. Handlers are idempotent (the DB stage is
+re-read before any write), return a re-rendered ``<tr>`` for HTMX
+``outerHTML`` swap, and raise 404 on unknown fingerprint. Prep dispatch
+launches ``prep_application.py`` via ``subprocess.Popen`` with
+``start_new_session=True`` so the HTTP response returns immediately while
+prep keeps running after the request finishes.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from findajob.paths import BASE
+from findajob.utils import log_event, write_audit
+from findajob.web.routes.board import _DASHBOARD_COLS
+from findajob.web.routes.materials import get_db
+
+router = APIRouter()
+
+_DASHBOARD_ROW_SQL = (
+    "SELECT fingerprint, title, company, location, remote_status, known_contacts, "
+    "comp_estimate, ai_notes, relevance_score, interview_likelihood, "
+    "stage, created_at, stage_updated FROM jobs WHERE fingerprint=?"
+)
+
+
+def _fetch_dashboard_row(db: sqlite3.Connection, fingerprint: str) -> sqlite3.Row | None:
+    return db.execute(_DASHBOARD_ROW_SQL, (fingerprint,)).fetchone()
+
+
+def _render_dashboard_row(request: Request, row: sqlite3.Row) -> HTMLResponse:
+    """Render a single dashboard row for HTMX outerHTML swap."""
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="_job_row.html",
+        context={
+            "columns": _DASHBOARD_COLS,
+            "row": row,
+            "tab": "dashboard",
+            "materials_base_url": os.environ.get("FINDAJOB_MATERIALS_BASE_URL", ""),
+        },
+    )
+
+
+@router.post("/board/jobs/{fingerprint}/prep", response_class=HTMLResponse)
+def prep(
+    fingerprint: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    row = _fetch_dashboard_row(db, fingerprint)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Idempotency: already in flight or already prepped — return current row unchanged.
+    if row["stage"] in ("prep_in_progress", "materials_drafted"):
+        return _render_dashboard_row(request, row)
+
+    job = db.execute(
+        "SELECT id, title, company, url, stage FROM jobs WHERE fingerprint=?",
+        (fingerprint,),
+    ).fetchone()
+
+    now = datetime.now(UTC).isoformat()
+    db.execute(
+        "UPDATE jobs SET stage='prep_in_progress', apply_flag=1, "
+        "stage_updated=?, updated_at=? WHERE id=?",
+        (now, now, job["id"]),
+    )
+    db.commit()
+    write_audit(db, job["id"], "stage", job["stage"], "prep_in_progress")
+    log_event(
+        "web_prep_dispatched",
+        job_id=job["id"],
+        company=job["company"],
+        title=job["title"],
+    )
+
+    subprocess.Popen(
+        [
+            sys.executable,
+            f"{BASE}/scripts/prep_application.py",
+            job["company"],
+            job["title"],
+            job["url"],
+            job["id"],
+            "--no-sync",
+        ],
+        start_new_session=True,
+    )
+
+    updated = _fetch_dashboard_row(db, fingerprint)
+    assert updated is not None  # we just updated this row
+    return _render_dashboard_row(request, updated)

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -35,6 +35,42 @@ from findajob.web.routes.materials import get_db
 
 router = APIRouter()
 
+MAX_CONCURRENT_PREPS = 3
+"""Upper bound on simultaneously-running prep subprocesses.
+
+Mirrors scripts/poll_flags.py's cap. Keeps LLM-API spending bounded when the
+operator mass-flags a morning's worth of jobs. When the cap is reached,
+/prep and /regenerate return 429; the dashboard row stays actionable so the
+operator can retry in a few minutes.
+"""
+
+
+def _prep_in_flight(db: sqlite3.Connection) -> int:
+    return db.execute("SELECT COUNT(*) FROM jobs WHERE stage='prep_in_progress'").fetchone()[0]
+
+
+def _prep_queue_full_response() -> HTMLResponse:
+    return HTMLResponse(
+        f"Prep queue full ({MAX_CONCURRENT_PREPS} in flight). Try again in a few minutes.",
+        status_code=429,
+    )
+
+
+def _launch_prep_subprocess(job: sqlite3.Row) -> None:
+    subprocess.Popen(
+        [
+            sys.executable,
+            f"{BASE}/scripts/prep_application.py",
+            job["company"],
+            job["title"],
+            job["url"],
+            job["id"],
+            "--no-sync",
+        ],
+        start_new_session=True,
+    )
+
+
 _DASHBOARD_ROW_SQL = (
     "SELECT fingerprint, title, company, location, remote_status, known_contacts, "
     "comp_estimate, ai_notes, relevance_score, interview_likelihood, "
@@ -160,6 +196,9 @@ def prep(
     if row["stage"] in ("prep_in_progress", "materials_drafted"):
         return _render_dashboard_row(request, row)
 
+    if _prep_in_flight(db) >= MAX_CONCURRENT_PREPS:
+        return _prep_queue_full_response()
+
     job = db.execute(
         "SELECT id, title, company, url, stage FROM jobs WHERE fingerprint=?",
         (fingerprint,),
@@ -180,21 +219,61 @@ def prep(
         title=job["title"],
     )
 
-    subprocess.Popen(
-        [
-            sys.executable,
-            f"{BASE}/scripts/prep_application.py",
-            job["company"],
-            job["title"],
-            job["url"],
-            job["id"],
-            "--no-sync",
-        ],
-        start_new_session=True,
-    )
+    _launch_prep_subprocess(job)
 
     updated = _fetch_dashboard_row(db, fingerprint)
     assert updated is not None  # we just updated this row
+    return _render_dashboard_row(request, updated)
+
+
+@router.post("/board/jobs/{fingerprint}/regenerate", response_class=HTMLResponse)
+def regenerate(
+    fingerprint: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Delete the existing prep folder and re-run prep from scratch."""
+    row = _fetch_dashboard_row(db, fingerprint)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Idempotency: already running — don't clobber a live prep subprocess.
+    if row["stage"] == "prep_in_progress":
+        return _render_dashboard_row(request, row)
+
+    if _prep_in_flight(db) >= MAX_CONCURRENT_PREPS:
+        return _prep_queue_full_response()
+
+    job = db.execute(
+        "SELECT id, title, company, url, stage, prep_folder_path FROM jobs WHERE fingerprint=?",
+        (fingerprint,),
+    ).fetchone()
+
+    folder = job["prep_folder_path"]
+    if folder and os.path.isdir(folder):
+        shutil.rmtree(folder)
+        log_event("folder_removed_for_regen", job_id=job["id"], folder=os.path.basename(folder))
+
+    now = datetime.now(UTC).isoformat()
+    db.execute(
+        "UPDATE jobs SET stage='prep_in_progress', prep_folder_path=NULL, "
+        "gdrive_folder_url=NULL, apply_flag=1, stage_updated=?, updated_at=? "
+        "WHERE id=?",
+        (now, now, job["id"]),
+    )
+    db.commit()
+    write_audit(db, job["id"], "stage", job["stage"], "prep_in_progress")
+    log_event(
+        "web_regen_dispatched",
+        job_id=job["id"],
+        company=job["company"],
+        title=job["title"],
+    )
+
+    _launch_prep_subprocess(job)
+
+    updated = _fetch_dashboard_row(db, fingerprint)
+    assert updated is not None
     return _render_dashboard_row(request, updated)
 
 

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -445,3 +445,36 @@ def not_selected(
     handle_not_selected(db, job, (reason or "").strip() or "Company passed")
     notify_waitlist_resurface(db, job["company"])
     return HTMLResponse("")
+
+
+@router.post("/board/jobs/{fingerprint}/notes", response_class=HTMLResponse)
+def notes(
+    fingerprint: str,
+    request: Request,
+    notes: str = Form(""),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Write free-text user notes for the Applied tab. No audit log entry —
+    notes are rewritten on every keystroke-debounce; audit is noise."""
+    row = db.execute(
+        "SELECT fingerprint, user_notes FROM jobs WHERE fingerprint=?",
+        (fingerprint,),
+    ).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    db.execute(
+        "UPDATE jobs SET user_notes=?, updated_at=datetime('now') WHERE fingerprint=?",
+        (notes, fingerprint),
+    )
+    db.commit()
+    updated = db.execute(
+        "SELECT fingerprint, user_notes FROM jobs WHERE fingerprint=?",
+        (fingerprint,),
+    ).fetchone()
+    assert updated is not None
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="board/_notes_cell.html",
+        context={"row": updated},
+    )

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -20,7 +20,12 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
-from findajob.actions import notify_waitlist_resurface
+from findajob.actions import (
+    handle_reactivate,
+    handle_waitlist,
+    notify_waitlist_resurface,
+    promote_to_scored,
+)
 from findajob.paths import BASE
 from findajob.utils import log_event, write_audit
 from findajob.web.routes.board import _APPLIED_COLS, _DASHBOARD_COLS
@@ -254,4 +259,52 @@ def withdraw(
         return HTMLResponse("")
     _transition_stage(db, job, "withdrawn", event_name="web_withdrawn")
     notify_waitlist_resurface(db, job["company"])
+    return HTMLResponse("")
+
+
+@router.post("/board/jobs/{fingerprint}/waitlist", response_class=HTMLResponse)
+def waitlist(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Defer a job to the Waitlist tab. Returns empty — row leaves the source tab."""
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] == "waitlisted":
+        return HTMLResponse("")
+    handle_waitlist(db, job)
+    return HTMLResponse("")
+
+
+@router.post("/board/jobs/{fingerprint}/reactivate", response_class=HTMLResponse)
+def reactivate(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Restore a waitlisted job to scored or materials_drafted."""
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] != "waitlisted":
+        raise HTTPException(status_code=409, detail="Job is not waitlisted")
+    handle_reactivate(db, job)
+    return HTMLResponse("")
+
+
+@router.post("/board/jobs/{fingerprint}/promote", response_class=HTMLResponse)
+def promote(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Promote a manual_review job onto the Dashboard."""
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] != "manual_review":
+        raise HTTPException(status_code=409, detail="Job is not in manual_review")
+    promote_to_scored(db, job, reason="Promoted from web UI")
     return HTMLResponse("")

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -17,11 +17,13 @@ import subprocess
 import sys
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from findajob.actions import (
+    handle_not_selected,
     handle_reactivate,
+    handle_rejection,
     handle_waitlist,
     notify_waitlist_resurface,
     promote_to_scored,
@@ -307,4 +309,60 @@ def promote(
     if job["stage"] != "manual_review":
         raise HTTPException(status_code=409, detail="Job is not in manual_review")
     promote_to_scored(db, job, reason="Promoted from web UI")
+    return HTMLResponse("")
+
+
+_POST_APPLICATION_STAGES = ("applied", "interview", "offer")
+
+
+def _fetch_rejection_job(db: sqlite3.Connection, fingerprint: str) -> sqlite3.Row | None:
+    """handle_rejection needs relevance_score + prep_folder_path from the row."""
+    return db.execute(
+        "SELECT id, fingerprint, title, company, url, stage, relevance_score, prep_folder_path "
+        "FROM jobs WHERE fingerprint=?",
+        (fingerprint,),
+    ).fetchone()
+
+
+@router.post("/board/jobs/{fingerprint}/reject", response_class=HTMLResponse)
+def reject(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    reason: str = Form(""),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Reject a job. Writes feedback_log, moves prep folder to _rejected/, fires
+    notify_waitlist_resurface. Returns empty — row drops off its source tab."""
+    job = _fetch_rejection_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] == "rejected":
+        return HTMLResponse("")
+    handle_rejection(db, job, (reason or "").strip() or "Other")
+    notify_waitlist_resurface(db, job["company"])
+    return HTMLResponse("")
+
+
+@router.post("/board/jobs/{fingerprint}/not-selected", response_class=HTMLResponse)
+def not_selected(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    reason: str = Form(""),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Mark that the company rejected the application. Drops a marker file in
+    the existing _applied/ folder. Does NOT write feedback_log — company
+    rejections must not contaminate the scorer. Fires notify_waitlist_resurface."""
+    job = _fetch_rejection_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] == "not_selected":
+        return HTMLResponse("")
+    if job["stage"] not in _POST_APPLICATION_STAGES:
+        raise HTTPException(
+            status_code=409,
+            detail="Not Selected only valid for applied/interview/offer stages",
+        )
+    handle_not_selected(db, job, (reason or "").strip() or "Company passed")
+    notify_waitlist_resurface(db, job["company"])
     return HTMLResponse("")

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -11,6 +11,7 @@ prep keeps running after the request finishes.
 from __future__ import annotations
 
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -19,9 +20,10 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
+from findajob.actions import notify_waitlist_resurface
 from findajob.paths import BASE
 from findajob.utils import log_event, write_audit
-from findajob.web.routes.board import _DASHBOARD_COLS
+from findajob.web.routes.board import _APPLIED_COLS, _DASHBOARD_COLS
 from findajob.web.routes.materials import get_db
 
 router = APIRouter()
@@ -50,6 +52,91 @@ def _render_dashboard_row(request: Request, row: sqlite3.Row) -> HTMLResponse:
             "materials_base_url": os.environ.get("FINDAJOB_MATERIALS_BASE_URL", ""),
         },
     )
+
+
+_APPLIED_ROW_SQL = """
+    SELECT j.fingerprint, j.title, j.company, j.stage, j.location, j.remote_status,
+           j.known_contacts, j.comp_estimate, j.ai_notes, j.user_notes, j.created_at,
+           al.applied_date,
+           CAST((julianday('now') - julianday(al.applied_date)) AS INTEGER) AS days_since_applied
+    FROM jobs j
+    LEFT JOIN (
+      SELECT job_id, MIN(changed_at) AS applied_date
+      FROM audit_log
+      WHERE field_changed = 'stage' AND new_value IN ('applied','interview','offer')
+      GROUP BY job_id
+    ) al ON al.job_id = j.id
+    WHERE j.fingerprint = ?
+"""
+
+
+def _fetch_applied_row(db: sqlite3.Connection, fingerprint: str) -> sqlite3.Row | None:
+    return db.execute(_APPLIED_ROW_SQL, (fingerprint,)).fetchone()
+
+
+def _render_applied_row(request: Request, row: sqlite3.Row) -> HTMLResponse:
+    """Render a single Applied-tab row for HTMX outerHTML swap."""
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="_job_row.html",
+        context={
+            "columns": _APPLIED_COLS,
+            "row": row,
+            "tab": "applied",
+            "materials_base_url": os.environ.get("FINDAJOB_MATERIALS_BASE_URL", ""),
+        },
+    )
+
+
+def _transition_stage(
+    db: sqlite3.Connection,
+    job: sqlite3.Row,
+    new_stage: str,
+    event_name: str,
+) -> None:
+    """Apply a plain stage transition: UPDATE, audit, log. No folder work."""
+    now = datetime.now(UTC).isoformat()
+    db.execute(
+        "UPDATE jobs SET stage=?, stage_updated=?, updated_at=? WHERE id=?",
+        (new_stage, now, now, job["id"]),
+    )
+    db.commit()
+    write_audit(db, job["id"], "stage", job["stage"], new_stage)
+    log_event(
+        event_name,
+        job_id=job["id"],
+        company=job["company"],
+        title=job["title"],
+        stage=new_stage,
+    )
+
+
+def _move_folder_to_applied(db: sqlite3.Connection, job: sqlite3.Row) -> bool:
+    """Move a prep folder from companies/ to companies/_applied/.
+
+    Mirrors poll_flags.py's Applied-branch behavior. Returns True if a folder
+    was actually moved.
+    """
+    jd = db.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+    folder = jd["prep_folder_path"] if jd else None
+    if not folder or not os.path.isdir(folder):
+        return False
+    applied_dir = os.path.join(BASE, "companies", "_applied")
+    os.makedirs(applied_dir, exist_ok=True)
+    dest = os.path.join(applied_dir, os.path.basename(folder))
+    shutil.move(folder, dest)
+    db.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
+    db.commit()
+    log_event("folder_moved_to_applied", job_id=job["id"], folder=os.path.basename(folder))
+    return True
+
+
+def _fetch_job(db: sqlite3.Connection, fingerprint: str) -> sqlite3.Row | None:
+    return db.execute(
+        "SELECT id, fingerprint, title, company, url, stage FROM jobs WHERE fingerprint=?",
+        (fingerprint,),
+    ).fetchone()
 
 
 @router.post("/board/jobs/{fingerprint}/prep", response_class=HTMLResponse)
@@ -102,3 +189,69 @@ def prep(
     updated = _fetch_dashboard_row(db, fingerprint)
     assert updated is not None  # we just updated this row
     return _render_dashboard_row(request, updated)
+
+
+@router.post("/board/jobs/{fingerprint}/apply", response_class=HTMLResponse)
+def apply(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001 — kept for handler signature parity
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Move job to the Applied tab. Returns empty body — HTMX removes the dashboard row."""
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] == "applied":
+        return HTMLResponse("")
+    _transition_stage(db, job, "applied", event_name="web_applied")
+    _move_folder_to_applied(db, job)
+    return HTMLResponse("")
+
+
+@router.post("/board/jobs/{fingerprint}/interview", response_class=HTMLResponse)
+def interview(
+    fingerprint: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] != "interview":
+        _transition_stage(db, job, "interview", event_name="web_interview")
+    updated = _fetch_applied_row(db, fingerprint)
+    assert updated is not None
+    return _render_applied_row(request, updated)
+
+
+@router.post("/board/jobs/{fingerprint}/offer", response_class=HTMLResponse)
+def offer(
+    fingerprint: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] != "offer":
+        _transition_stage(db, job, "offer", event_name="web_offer")
+    updated = _fetch_applied_row(db, fingerprint)
+    assert updated is not None
+    return _render_applied_row(request, updated)
+
+
+@router.post("/board/jobs/{fingerprint}/withdraw", response_class=HTMLResponse)
+def withdraw(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Withdraw from the application. Returns empty — row drops off Applied."""
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] == "withdrawn":
+        return HTMLResponse("")
+    _transition_stage(db, job, "withdrawn", event_name="web_withdrawn")
+    notify_waitlist_resurface(db, job["company"])
+    return HTMLResponse("")

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -206,8 +206,7 @@ def prep(
 
     now = datetime.now(UTC).isoformat()
     db.execute(
-        "UPDATE jobs SET stage='prep_in_progress', apply_flag=1, "
-        "stage_updated=?, updated_at=? WHERE id=?",
+        "UPDATE jobs SET stage='prep_in_progress', apply_flag=1, stage_updated=?, updated_at=? WHERE id=?",
         (now, now, job["id"]),
     )
     db.commit()

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -28,5 +28,6 @@
   {% endfor %}
   {% if tab in ('dashboard', 'applied', 'review', 'waitlist') %}
     {% include "board/_status_cell.html" %}
+    {% include "board/_reject_cell.html" %}
   {% endif %}
 </tr>

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -26,19 +26,7 @@
       {% endif %}
     </td>
   {% endfor %}
-  {% if tab == 'dashboard' %}
-    <td class="px-3 py-1 align-top text-sm">
-      {% if row.stage in ('scored', 'manual_review') %}
-        <button type="button"
-                class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
-                hx-post="/board/jobs/{{ row.fingerprint }}/prep"
-                hx-target="closest tr"
-                hx-swap="outerHTML">Flag for Prep</button>
-      {% elif row.stage == 'prep_in_progress' %}
-        <span class="text-xs text-slate-500">Prep in progress…</span>
-      {% elif row.stage == 'materials_drafted' %}
-        <span class="text-xs font-medium text-emerald-700">Ready to Apply</span>
-      {% endif %}
-    </td>
+  {% if tab in ('dashboard', 'applied') %}
+    {% include "board/_status_cell.html" %}
   {% endif %}
 </tr>

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -26,4 +26,19 @@
       {% endif %}
     </td>
   {% endfor %}
+  {% if tab == 'dashboard' %}
+    <td class="px-3 py-1 align-top text-sm">
+      {% if row.stage in ('scored', 'manual_review') %}
+        <button type="button"
+                class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+                hx-post="/board/jobs/{{ row.fingerprint }}/prep"
+                hx-target="closest tr"
+                hx-swap="outerHTML">Flag for Prep</button>
+      {% elif row.stage == 'prep_in_progress' %}
+        <span class="text-xs text-slate-500">Prep in progress…</span>
+      {% elif row.stage == 'materials_drafted' %}
+        <span class="text-xs font-medium text-emerald-700">Ready to Apply</span>
+      {% endif %}
+    </td>
+  {% endif %}
 </tr>

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -26,7 +26,7 @@
       {% endif %}
     </td>
   {% endfor %}
-  {% if tab in ('dashboard', 'applied') %}
+  {% if tab in ('dashboard', 'applied', 'review', 'waitlist') %}
     {% include "board/_status_cell.html" %}
   {% endif %}
 </tr>

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -16,6 +16,9 @@
 {% endif %}
 <tr class="{{ row_classes | join(' ') }}" data-fingerprint="{{ row.fingerprint }}">
   {% for display, field in columns %}
+    {% if tab == 'applied' and field == 'user_notes' %}
+      {% include "board/_notes_cell.html" %}
+    {% else %}
     <td class="px-3 py-1 align-top text-sm
                {% if field == 'known_contacts' and row[field] %}cell-contact-amber{% endif %}
                {% if field == 'remote_status' %}{{ remote_cell_class(row[field]) }}{% endif %}">
@@ -25,6 +28,7 @@
         {{ row[field] }}
       {% endif %}
     </td>
+    {% endif %}
   {% endfor %}
   {% if tab in ('dashboard', 'applied', 'review', 'waitlist') %}
     {% include "board/_status_cell.html" %}

--- a/src/findajob/web/templates/board/_notes_cell.html
+++ b/src/findajob/web/templates/board/_notes_cell.html
@@ -1,0 +1,18 @@
+{#
+  Editable user_notes cell for the Applied tab. Inputs:
+    row — a sqlite3.Row (or dict) with .fingerprint and .user_notes
+  Auto-saves on blur + 800ms after last keystroke. Server responds with a
+  re-rendered <td> (this template) swapped via hx-swap="outerHTML".
+  No audit log entry — notes are free-text and versioned elsewhere.
+#}
+<td class="px-3 py-1 align-top text-sm">
+  <input
+    type="text"
+    class="w-full rounded border-slate-300 bg-white px-2 py-1 text-sm"
+    name="notes"
+    value="{{ row.user_notes or '' }}"
+    hx-post="/board/jobs/{{ row.fingerprint }}/notes"
+    hx-trigger="blur, keyup changed delay:800ms"
+    hx-target="closest td"
+    hx-swap="outerHTML">
+</td>

--- a/src/findajob/web/templates/board/_reject_cell.html
+++ b/src/findajob/web/templates/board/_reject_cell.html
@@ -1,0 +1,37 @@
+{#
+  Reject reason dropdown for Dashboard / Applied / Review / Waitlist tabs.
+  Inputs:
+    row — a sqlite3.Row (or dict)
+    tab — "dashboard" | "applied" | "review" | "waitlist"
+
+  On change, dispatches a POST with the selected reason as form data. Routes
+  to /reject by default; if the status cell flagged the row for Not Selected
+  (applied tab only), routes to /not-selected instead. The flag is carried on
+  tr.dataset.pendingAction to avoid an Alpine dependency.
+#}
+{% set fp = row.fingerprint %}
+<td class="px-3 py-1 align-top text-sm whitespace-nowrap">
+  <select
+    class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+    data-fp="{{ fp }}"
+    onchange="if(this.value){
+      const tr=this.closest('tr');
+      const action=tr.dataset.pendingAction==='not-selected'?'not-selected':'reject';
+      htmx.ajax('POST',`/board/jobs/{{ fp }}/${action}`,{target:tr,swap:'outerHTML',values:{reason:this.value}});
+      this.value='';
+      delete tr.dataset.pendingAction;
+    }">
+    <option value="">— No reason —</option>
+    <option value="Too Senior">Too Senior</option>
+    <option value="Too Junior">Too Junior</option>
+    <option value="Skills Mismatch">Skills Mismatch</option>
+    <option value="Too TPM-Heavy">Too TPM-Heavy</option>
+    <option value="Geography/Onsite">Geography/Onsite</option>
+    <option value="Company Not a Fit">Company Not a Fit</option>
+    <option value="Comp Too Low">Comp Too Low</option>
+    <option value="Low Fit Score">Low Fit Score</option>
+    <option value="Stale/Closed">Stale/Closed</option>
+    <option value="Already Applied">Already Applied</option>
+    <option value="Other">Other</option>
+  </select>
+</td>

--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -31,16 +31,29 @@
       {% endif %}
     </select>
   {% elif tab == 'applied' %}
+    {% if stage == 'not_selected' %}
+      <span class="text-xs text-slate-500">Not Selected</span>
+    {% else %}
     <select
       class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
       data-fp="{{ fp }}"
-      onchange="if(this.value){htmx.ajax('POST', `/board/jobs/{{ fp }}/${this.value}`, {target: this.closest('tr'), swap: 'outerHTML'});this.value='';}">
+      onchange="if(!this.value)return;
+        const tr=this.closest('tr');
+        if(this.value==='not-selected'){
+          tr.dataset.pendingAction='not-selected';
+          this.nextElementSibling && (this.nextElementSibling.textContent='Pick a reason in the Reject cell');
+        } else {
+          htmx.ajax('POST',`/board/jobs/{{ fp }}/${this.value}`,{target:tr,swap:'outerHTML'});
+        }
+        this.value='';">
       <option value="">— Change status —</option>
       {% if stage != 'interview' %}<option value="interview">Interviewing</option>{% endif %}
       {% if stage != 'offer' %}<option value="offer">Offer</option>{% endif %}
       <option value="withdraw">Withdrew</option>
       <option value="not-selected">Not Selected</option>
     </select>
+    <span class="ml-2 text-xs text-slate-500"></span>
+    {% endif %}
   {% elif tab == 'review' %}
     <button type="button"
             class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"

--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -41,5 +41,17 @@
       <option value="withdraw">Withdrew</option>
       <option value="not-selected">Not Selected</option>
     </select>
+  {% elif tab == 'review' %}
+    <button type="button"
+            class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+            hx-post="/board/jobs/{{ fp }}/promote"
+            hx-target="closest tr"
+            hx-swap="outerHTML">Promote</button>
+  {% elif tab == 'waitlist' %}
+    <button type="button"
+            class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+            hx-post="/board/jobs/{{ fp }}/reactivate"
+            hx-target="closest tr"
+            hx-swap="outerHTML">Reactivate</button>
   {% endif %}
 </td>

--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -1,0 +1,45 @@
+{#
+  Status dropdown for the Dashboard and Applied tabs. Inputs:
+    row — a sqlite3.Row (or dict) for the current job
+    tab — "dashboard" | "applied"
+  On selection, dispatches an HTMX POST to /board/jobs/{fp}/{action} where
+  {action} matches the <option value>. Response body replaces the <tr>.
+#}
+{% set fp = row.fingerprint %}
+{% set stage = row.stage %}
+<td class="px-3 py-1 align-top text-sm whitespace-nowrap">
+  {% if tab == 'dashboard' %}
+    {% if stage == 'prep_in_progress' %}
+      <div class="mb-1 text-xs text-slate-500">Prep in progress…</div>
+    {% elif stage == 'materials_drafted' %}
+      <div class="mb-1 text-xs font-medium text-emerald-700">Ready to Apply</div>
+    {% endif %}
+    <select
+      class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+      data-fp="{{ fp }}"
+      onchange="if(this.value){htmx.ajax('POST', `/board/jobs/{{ fp }}/${this.value}`, {target: this.closest('tr'), swap: 'outerHTML'});this.value='';}">
+      <option value="">— Change status —</option>
+      {% if stage in ('scored', 'manual_review') %}
+        <option value="prep">Flag for Prep</option>
+      {% endif %}
+      {% if stage in ('prep_in_progress', 'materials_drafted') %}
+        <option value="regenerate">Regenerate</option>
+      {% endif %}
+      <option value="waitlist">Waitlist</option>
+      {% if stage == 'materials_drafted' %}
+        <option value="apply">Applied</option>
+      {% endif %}
+    </select>
+  {% elif tab == 'applied' %}
+    <select
+      class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+      data-fp="{{ fp }}"
+      onchange="if(this.value){htmx.ajax('POST', `/board/jobs/{{ fp }}/${this.value}`, {target: this.closest('tr'), swap: 'outerHTML'});this.value='';}">
+      <option value="">— Change status —</option>
+      {% if stage != 'interview' %}<option value="interview">Interviewing</option>{% endif %}
+      {% if stage != 'offer' %}<option value="offer">Offer</option>{% endif %}
+      <option value="withdraw">Withdrew</option>
+      <option value="not-selected">Not Selected</option>
+    </select>
+  {% endif %}
+</td>

--- a/src/findajob/web/templates/board/applied.html
+++ b/src/findajob/web/templates/board/applied.html
@@ -13,13 +13,14 @@
         </a>
       </th>
       {% endfor %}
+      <th class="px-3 py-2">Status</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length }}" class="px-3 py-4 text-slate-500">No applied jobs right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No applied jobs right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/applied.html
+++ b/src/findajob/web/templates/board/applied.html
@@ -14,13 +14,14 @@
       </th>
       {% endfor %}
       <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No applied jobs right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 2 }}" class="px-3 py-4 text-slate-500">No applied jobs right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/dashboard.html
+++ b/src/findajob/web/templates/board/dashboard.html
@@ -13,13 +13,14 @@
         </a>
       </th>
       {% endfor %}
+      <th class="px-3 py-2">Action</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length }}" class="px-3 py-4 text-slate-500">No jobs in this view right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No jobs in this view right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/dashboard.html
+++ b/src/findajob/web/templates/board/dashboard.html
@@ -14,13 +14,14 @@
       </th>
       {% endfor %}
       <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No jobs in this view right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 2 }}" class="px-3 py-4 text-slate-500">No jobs in this view right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/dashboard.html
+++ b/src/findajob/web/templates/board/dashboard.html
@@ -13,7 +13,7 @@
         </a>
       </th>
       {% endfor %}
-      <th class="px-3 py-2">Action</th>
+      <th class="px-3 py-2">Status</th>
     </tr>
   </thead>
   <tbody id="rows">

--- a/src/findajob/web/templates/board/review.html
+++ b/src/findajob/web/templates/board/review.html
@@ -13,13 +13,14 @@
         </a>
       </th>
       {% endfor %}
+      <th class="px-3 py-2">Status</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length }}" class="px-3 py-4 text-slate-500">No jobs in manual review right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No jobs in manual review right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/review.html
+++ b/src/findajob/web/templates/board/review.html
@@ -14,13 +14,14 @@
       </th>
       {% endfor %}
       <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No jobs in manual review right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 2 }}" class="px-3 py-4 text-slate-500">No jobs in manual review right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/waitlist.html
+++ b/src/findajob/web/templates/board/waitlist.html
@@ -13,13 +13,14 @@
         </a>
       </th>
       {% endfor %}
+      <th class="px-3 py-2">Status</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length }}" class="px-3 py-4 text-slate-500">No waitlisted jobs right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No waitlisted jobs right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/waitlist.html
+++ b/src/findajob/web/templates/board/waitlist.html
@@ -14,13 +14,14 @@
       </th>
       {% endfor %}
       <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length + 1 }}" class="px-3 py-4 text-slate-500">No waitlisted jobs right now.</td></tr>
+      <tr><td colspan="{{ columns|length + 2 }}" class="px-3 py-4 text-slate-500">No waitlisted jobs right now.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,496 @@
+"""Unit tests for findajob.actions — stage-transition helpers called from poll_flags
+and the web POST handlers.
+
+Every test uses an in-memory SQLite DB and tmp_path for folder operations. The
+module-level BASE reference in findajob.actions is monkeypatched so folder
+moves land in the test's tmp_path, not the real repo.
+"""
+
+import json
+import os
+import sqlite3
+import uuid
+
+import pytest
+
+from findajob import actions, utils
+
+SCHEMA = """
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    location TEXT DEFAULT '',
+    source TEXT NOT NULL DEFAULT 'test',
+    raw_jd_text TEXT,
+    relevance_score INTEGER CHECK(relevance_score BETWEEN 1 AND 10),
+    score_status TEXT CHECK(score_status IN ('scored', 'manual_review', 'needs_info')),
+    score_flag_reason TEXT,
+    stage TEXT DEFAULT 'discovered' CHECK(stage IN (
+        'discovered', 'enriched', 'scored', 'manual_review',
+        'prep_in_progress', 'materials_drafted', 'waitlisted', 'applied',
+        'response_received', 'interview', 'offer', 'rejected', 'not_selected', 'withdrawn'
+    )),
+    stage_updated TEXT,
+    apply_flag INTEGER DEFAULT 0,
+    prep_folder_path TEXT,
+    reject_reason TEXT DEFAULT '',
+    fit_score REAL,
+    probability_score REAL,
+    gdrive_folder_url TEXT,
+    remote_status TEXT DEFAULT 'Unknown',
+    ai_notes TEXT,
+    comp_estimate TEXT DEFAULT '',
+    known_contacts TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    dupe_of TEXT DEFAULT ''
+);
+
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    field_changed TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_at TEXT DEFAULT (datetime('now')),
+    changed_by TEXT DEFAULT 'system'
+);
+
+CREATE TABLE feedback_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    relevance_score INTEGER,
+    reject_reason TEXT NOT NULL,
+    jd_excerpt TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+"""
+
+
+@pytest.fixture()
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _patch_base_and_log(tmp_path, monkeypatch):
+    """Redirect BASE and the event log so tests don't touch the real repo."""
+    monkeypatch.setattr(actions, "BASE", str(tmp_path))
+    monkeypatch.setattr(utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
+    os.makedirs(tmp_path / "companies" / "_applied", exist_ok=True)
+    os.makedirs(tmp_path / "companies" / "_rejected", exist_ok=True)
+    os.makedirs(tmp_path / "companies" / "_waitlisted", exist_ok=True)
+
+
+def insert_job(
+    conn,
+    *,
+    stage="scored",
+    company="Acme Corp",
+    title="Operations Manager",
+    score=7,
+    folder=None,
+    raw_jd_text=None,
+    score_status="scored",
+    apply_flag=0,
+    gdrive_url=None,
+):
+    """Insert a job with sane defaults; returns the row as sqlite3.Row."""
+    job_id = str(uuid.uuid4())[:8]
+    fp = f"fp_{job_id}"
+    conn.execute(
+        """INSERT INTO jobs (id, fingerprint, url, title, company, relevance_score,
+                             stage, prep_folder_path, raw_jd_text, score_status,
+                             apply_flag, gdrive_folder_url)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            job_id,
+            fp,
+            f"https://example.com/{job_id}",
+            title,
+            company,
+            score,
+            stage,
+            folder,
+            raw_jd_text,
+            score_status,
+            apply_flag,
+            gdrive_url,
+        ),
+    )
+    conn.commit()
+    return conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+
+
+# ── handle_rejection ────────────────────────────────────────────────────────
+
+
+class TestHandleRejection:
+    def test_with_folder_moves_and_writes_marker(self, db, tmp_path):
+        folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_120000"
+        folder.mkdir(parents=True)
+        (folder / "resume.pdf").touch()
+
+        job = insert_job(db, stage="materials_drafted", folder=str(folder), score=8)
+        result = actions.handle_rejection(db, job, "Low Fit Score")
+
+        assert result is True
+        row = db.execute("SELECT stage, reject_reason, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "rejected"
+        assert row["reject_reason"] == "Low Fit Score"
+        assert "_rejected" in row["prep_folder_path"]
+        assert os.path.isdir(row["prep_folder_path"])
+
+        markers = [f for f in os.listdir(row["prep_folder_path"]) if f.startswith("REJECTED_")]
+        assert len(markers) == 1
+        assert "Low_Fit_Score" in markers[0]
+
+    def test_without_folder_returns_false(self, db):
+        job = insert_job(db, stage="scored", folder=None, score=6)
+        assert actions.handle_rejection(db, job, "Wrong Level") is False
+
+        row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "rejected"
+        assert row["reject_reason"] == "Wrong Level"
+
+    def test_writes_feedback_log_with_jd_excerpt(self, db):
+        job = insert_job(db, stage="scored", raw_jd_text="A" * 1000)
+        actions.handle_rejection(db, job, "Not Relevant")
+
+        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
+        assert fb is not None
+        assert fb["reject_reason"] == "Not Relevant"
+        assert fb["title"] == "Operations Manager"
+        assert len(fb["jd_excerpt"]) == 500
+
+    def test_empty_jd_gives_empty_excerpt(self, db):
+        job = insert_job(db, stage="scored", raw_jd_text=None)
+        actions.handle_rejection(db, job, "Not Relevant")
+
+        fb = db.execute("SELECT jd_excerpt FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
+        assert fb["jd_excerpt"] == ""
+
+    def test_writes_audit_rows(self, db):
+        job = insert_job(db, stage="scored")
+        actions.handle_rejection(db, job, "Wrong Level")
+
+        audits = db.execute(
+            "SELECT field_changed, old_value, new_value FROM audit_log WHERE job_id=? ORDER BY id",
+            (job["id"],),
+        ).fetchall()
+        fields = [a["field_changed"] for a in audits]
+        assert "stage" in fields
+        assert "reject_reason" in fields
+        stage_audit = next(a for a in audits if a["field_changed"] == "stage")
+        assert stage_audit["old_value"] == "scored"
+        assert stage_audit["new_value"] == "rejected"
+
+    def test_marker_sanitizes_unsafe_characters(self, db, tmp_path):
+        folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_120000"
+        folder.mkdir(parents=True)
+        job = insert_job(db, stage="materials_drafted", folder=str(folder))
+
+        actions.handle_rejection(db, job, "Comp/Role\\Mismatch!")
+
+        dest = db.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()[0]
+        markers = [f for f in os.listdir(dest) if f.startswith("REJECTED_")]
+        assert len(markers) == 1
+        # Slashes and exclamation stripped; spaces → underscores
+        assert "/" not in markers[0]
+        assert "\\" not in markers[0]
+        assert "!" not in markers[0]
+
+
+# ── handle_not_selected ─────────────────────────────────────────────────────
+
+
+class TestHandleNotSelected:
+    def test_keeps_folder_in_applied_drops_marker(self, db, tmp_path):
+        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_2026-04-13_120000"
+        folder.mkdir(parents=True)
+        job = insert_job(db, stage="applied", folder=str(folder), score=8)
+
+        result = actions.handle_not_selected(db, job, "Too Senior")
+
+        assert result is False
+        row = db.execute("SELECT stage, reject_reason, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "not_selected"
+        assert row["reject_reason"] == "Too Senior"
+        assert row["prep_folder_path"] == str(folder)
+
+        markers = [f for f in os.listdir(row["prep_folder_path"]) if f.startswith("NOT_SELECTED_")]
+        assert len(markers) == 1
+        assert "Too_Senior" in markers[0]
+
+    def test_does_not_write_feedback_log(self, db, tmp_path):
+        """Company rejections must not contaminate the scorer feedback loop."""
+        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_2026-04-13_120000"
+        folder.mkdir(parents=True)
+        job = insert_job(db, stage="applied", folder=str(folder))
+
+        actions.handle_not_selected(db, job, "Skills Mismatch")
+
+        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
+        assert fb is None
+
+    def test_without_folder(self, db):
+        job = insert_job(db, stage="applied", folder=None)
+        assert actions.handle_not_selected(db, job, "Company Passed") is False
+
+        row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "not_selected"
+        assert row["reject_reason"] == "Company Passed"
+
+    def test_writes_audit_rows(self, db):
+        job = insert_job(db, stage="applied")
+        actions.handle_not_selected(db, job, "Company Passed")
+
+        audits = db.execute(
+            "SELECT field_changed, new_value FROM audit_log WHERE job_id=? ORDER BY id",
+            (job["id"],),
+        ).fetchall()
+        fields = [a["field_changed"] for a in audits]
+        assert "stage" in fields
+        assert "reject_reason" in fields
+        stage_audit = next(a for a in audits if a["field_changed"] == "stage")
+        assert stage_audit["new_value"] == "not_selected"
+
+
+# ── handle_waitlist ─────────────────────────────────────────────────────────
+
+
+class TestHandleWaitlist:
+    def test_with_folder_moves_to_waitlisted(self, db, tmp_path):
+        folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_140000"
+        folder.mkdir(parents=True)
+        (folder / "cover_letter.docx").touch()
+        job = insert_job(db, stage="materials_drafted", folder=str(folder))
+
+        assert actions.handle_waitlist(db, job) is True
+
+        row = db.execute("SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "waitlisted"
+        assert "_waitlisted" in row["prep_folder_path"]
+        assert os.path.isdir(row["prep_folder_path"])
+        assert os.path.isfile(os.path.join(row["prep_folder_path"], "cover_letter.docx"))
+
+    def test_without_folder(self, db):
+        job = insert_job(db, stage="scored", folder=None)
+        assert actions.handle_waitlist(db, job) is False
+
+        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "waitlisted"
+
+    def test_does_not_write_feedback_log(self, db):
+        """Waitlisting is deferral, not rejection — no scorer feedback."""
+        job = insert_job(db, stage="scored")
+        actions.handle_waitlist(db, job)
+
+        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
+        assert fb is None
+
+    def test_writes_stage_audit(self, db):
+        job = insert_job(db, stage="scored")
+        actions.handle_waitlist(db, job)
+
+        audit = db.execute(
+            "SELECT old_value, new_value FROM audit_log WHERE job_id=? AND field_changed='stage'",
+            (job["id"],),
+        ).fetchone()
+        assert audit["old_value"] == "scored"
+        assert audit["new_value"] == "waitlisted"
+
+
+# ── handle_reactivate ───────────────────────────────────────────────────────
+
+
+class TestHandleReactivate:
+    def test_with_folder_restores_materials_drafted(self, db, tmp_path):
+        folder = tmp_path / "companies" / "_waitlisted" / "Acme_Ops_2026-04-13_150000"
+        folder.mkdir(parents=True)
+        (folder / "resume.pdf").touch()
+        job = insert_job(db, stage="waitlisted", folder=str(folder))
+
+        assert actions.handle_reactivate(db, job) is True
+
+        row = db.execute("SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "materials_drafted"
+        assert "_waitlisted" not in row["prep_folder_path"]
+        assert os.path.isdir(row["prep_folder_path"])
+        assert os.path.isfile(os.path.join(row["prep_folder_path"], "resume.pdf"))
+
+    def test_without_folder_falls_back_to_scored(self, db):
+        job = insert_job(db, stage="waitlisted", folder=None)
+        assert actions.handle_reactivate(db, job) is False
+
+        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "scored"
+
+    def test_missing_folder_path_falls_back_to_scored(self, db):
+        """Folder path in DB but directory doesn't exist → scored."""
+        job = insert_job(db, stage="waitlisted", folder="/nonexistent/Acme_Ops")
+        assert actions.handle_reactivate(db, job) is False
+
+        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "scored"
+
+    def test_writes_stage_audit(self, db):
+        job = insert_job(db, stage="waitlisted", folder=None)
+        actions.handle_reactivate(db, job)
+
+        audit = db.execute(
+            "SELECT old_value, new_value FROM audit_log WHERE job_id=? AND field_changed='stage'",
+            (job["id"],),
+        ).fetchone()
+        assert audit["old_value"] == "waitlisted"
+        assert audit["new_value"] == "scored"
+
+
+# ── notify_waitlist_resurface ───────────────────────────────────────────────
+
+
+class TestNotifyWaitlistResurface:
+    def test_fires_popen_when_waitlisted_exist(self, db, monkeypatch):
+        insert_job(db, stage="waitlisted", company="Acme Corp", title="Site Lead")
+
+        popen_calls: list[list[str]] = []
+        monkeypatch.setattr(actions.subprocess, "Popen", lambda args, **kw: popen_calls.append(args))
+
+        actions.notify_waitlist_resurface(db, "Acme Corp")
+
+        assert len(popen_calls) == 1
+        assert "send-raw" in popen_calls[0]
+
+    def test_no_notification_when_nothing_waitlisted(self, db, monkeypatch):
+        insert_job(db, stage="scored", company="Acme Corp")
+
+        popen_calls: list[list[str]] = []
+        monkeypatch.setattr(actions.subprocess, "Popen", lambda args, **kw: popen_calls.append(args))
+
+        actions.notify_waitlist_resurface(db, "Acme Corp")
+
+        assert popen_calls == []
+
+    def test_notification_lists_waitlisted_titles(self, db, monkeypatch):
+        insert_job(db, stage="waitlisted", company="Acme Corp", title="Site Lead")
+        insert_job(db, stage="waitlisted", company="Acme Corp", title="Ops Manager")
+
+        popen_calls: list[list[str]] = []
+        monkeypatch.setattr(actions.subprocess, "Popen", lambda args, **kw: popen_calls.append(args))
+
+        actions.notify_waitlist_resurface(db, "Acme Corp")
+
+        body = popen_calls[0][-1]  # last arg is the body
+        assert "Site Lead" in body
+        assert "Ops Manager" in body
+
+
+# ── reset_prep_to_scored ────────────────────────────────────────────────────
+
+
+class TestResetPrepToScored:
+    def test_resets_stage_and_clears_folder(self, db):
+        job = insert_job(db, stage="prep_in_progress", folder="/tmp/some/path")
+
+        assert actions.reset_prep_to_scored(db, job["id"], reason="test_reason") is True
+
+        row = db.execute(
+            "SELECT stage, prep_folder_path, stage_updated FROM jobs WHERE id=?", (job["id"],)
+        ).fetchone()
+        assert row["stage"] == "scored"
+        assert row["prep_folder_path"] is None
+        assert row["stage_updated"] is not None
+
+    def test_writes_audit(self, db):
+        job = insert_job(db, stage="prep_in_progress")
+        actions.reset_prep_to_scored(db, job["id"], reason="unit_test")
+
+        audit = db.execute(
+            "SELECT field_changed, old_value, new_value FROM audit_log WHERE job_id=?",
+            (job["id"],),
+        ).fetchall()
+        assert len(audit) == 1
+        assert audit[0]["field_changed"] == "stage"
+        assert audit[0]["old_value"] == "prep_in_progress"
+        assert audit[0]["new_value"] == "scored"
+
+    def test_emits_prep_failed_reset_event(self, db, tmp_path):
+        job = insert_job(db, stage="prep_in_progress")
+        actions.reset_prep_to_scored(db, job["id"], reason="validation_failed")
+
+        entries = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text().splitlines()]
+        resets = [e for e in entries if e["event"] == "prep_failed_reset"]
+        assert len(resets) == 1
+        assert resets[0]["job_id"] == job["id"]
+        assert resets[0]["reason"] == "validation_failed"
+
+    def test_guards_materials_drafted(self, db):
+        job = insert_job(db, stage="materials_drafted", folder="/keep/me")
+        assert actions.reset_prep_to_scored(db, job["id"], reason="unused") is False
+
+        row = db.execute("SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "materials_drafted"
+        assert row["prep_folder_path"] == "/keep/me"
+        audit = db.execute("SELECT 1 FROM audit_log WHERE job_id=?", (job["id"],)).fetchall()
+        assert audit == []
+
+    def test_guards_applied(self, db):
+        job = insert_job(db, stage="applied")
+        assert actions.reset_prep_to_scored(db, job["id"], reason="unused") is False
+
+        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "applied"
+
+
+# ── promote_to_scored ───────────────────────────────────────────────────────
+
+
+class TestPromoteToScored:
+    def test_sets_score_7_and_stage_scored(self, db):
+        job = insert_job(db, stage="manual_review", score=5, score_status="manual_review")
+        actions.promote_to_scored(db, job, reason="Promoted from Review tab")
+
+        row = db.execute(
+            "SELECT relevance_score, stage, score_status, score_flag_reason FROM jobs WHERE id=?",
+            (job["id"],),
+        ).fetchone()
+        assert row["relevance_score"] == 7
+        assert row["stage"] == "scored"
+        assert row["score_status"] == "scored"
+        assert row["score_flag_reason"] == "Promoted from Review tab"
+
+    def test_default_reason_when_not_provided(self, db):
+        job = insert_job(db, stage="manual_review", score=5, score_status="manual_review")
+        actions.promote_to_scored(db, job)
+
+        row = db.execute("SELECT score_flag_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["score_flag_reason"] == "Promoted from web UI"
+
+    def test_writes_stage_audit(self, db):
+        job = insert_job(db, stage="manual_review", score=5, score_status="manual_review")
+        actions.promote_to_scored(db, job)
+
+        audit = db.execute(
+            "SELECT old_value, new_value FROM audit_log WHERE job_id=? AND field_changed='stage'",
+            (job["id"],),
+        ).fetchone()
+        assert audit["old_value"] == "manual_review"
+        assert audit["new_value"] == "scored"
+
+    def test_emits_review_promoted_event(self, db, tmp_path):
+        job = insert_job(db, stage="manual_review", score=5, score_status="manual_review")
+        actions.promote_to_scored(db, job)
+
+        entries = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text().splitlines()]
+        promoted = [e for e in entries if e["event"] == "review_promoted"]
+        assert len(promoted) == 1
+        assert promoted[0]["job_id"] == job["id"]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -403,9 +403,7 @@ class TestResetPrepToScored:
 
         assert actions.reset_prep_to_scored(db, job["id"], reason="test_reason") is True
 
-        row = db.execute(
-            "SELECT stage, prep_folder_path, stage_updated FROM jobs WHERE id=?", (job["id"],)
-        ).fetchone()
+        row = db.execute("SELECT stage, prep_folder_path, stage_updated FROM jobs WHERE id=?", (job["id"],)).fetchone()
         assert row["stage"] == "scored"
         assert row["prep_folder_path"] is None
         assert row["stage_updated"] is not None

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -249,6 +249,7 @@ def test_router_registered_on_app(client: TestClient):
         "promote",
         "reject",
         "not-selected",
+        "regenerate",
     ):
         assert f"/board/jobs/{{fingerprint}}/{endpoint}" in paths
 
@@ -471,6 +472,145 @@ class TestNotSelected:
             data={"reason": "Other"},
         )
         assert response.status_code == 404
+
+
+# ── /regenerate handler ───────────────────────────────────────────────────
+
+
+class TestRegenerate:
+    def _seed_prep_folder(self, client: TestClient, fingerprint: str) -> Path:
+        folder = client._tmp_path / "companies" / f"Acme_regen_{fingerprint}"
+        folder.mkdir(parents=True)
+        (folder / "resume.pdf").touch()
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "UPDATE jobs SET prep_folder_path=?, gdrive_folder_url='https://drive/abc' WHERE fingerprint=?",
+            (str(folder), fingerprint),
+        )
+        conn.commit()
+        conn.close()
+        return folder
+
+    def test_happy_path_deletes_folder_and_dispatches(self, client: TestClient, popen_calls):
+        folder = self._seed_prep_folder(client, "fp_drafted")
+
+        response = client.post("/board/jobs/fp_drafted/regenerate")
+
+        assert response.status_code == 200
+        assert not folder.exists()
+
+        conn = sqlite3.connect(client._db_path)
+        row = conn.execute(
+            "SELECT stage, prep_folder_path, gdrive_folder_url, apply_flag "
+            "FROM jobs WHERE fingerprint='fp_drafted'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "prep_in_progress"
+        assert row[1] is None
+        assert row[2] is None
+        assert row[3] == 1
+
+        assert len(popen_calls) == 1
+        assert "prep_application.py" in popen_calls[0][1]
+
+    def test_no_op_on_prep_in_progress(self, client: TestClient, popen_calls):
+        """Double-click during regen: second POST returns current row, no new subprocess."""
+        response = client.post("/board/jobs/fp_prep/regenerate")
+
+        assert response.status_code == 200
+        assert response.text.strip().startswith("<tr")
+        assert _fetch_stage(client, "fp_prep") == "prep_in_progress"
+        assert popen_calls == []
+        assert _fetch_audit(client, "fp_prep") == []
+
+    def test_without_folder_still_dispatches(self, client: TestClient, popen_calls):
+        """Regenerate is valid even if no prep_folder_path is recorded."""
+        response = client.post("/board/jobs/fp_drafted/regenerate")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_drafted") == "prep_in_progress"
+        assert len(popen_calls) == 1
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient, popen_calls):
+        response = client.post("/board/jobs/fp_nonexistent/regenerate")
+        assert response.status_code == 404
+        assert popen_calls == []
+
+
+# ── Concurrency cap ──────────────────────────────────────────────────────
+
+
+class TestPrepConcurrencyCap:
+    def _set_three_in_flight(self, client: TestClient) -> None:
+        """Three jobs already in prep_in_progress (fp_prep + 2 new)."""
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, stage) "
+            "VALUES ('inflight1','fp_inflight1','u','T','C','prep_in_progress')"
+        )
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, stage) "
+            "VALUES ('inflight2','fp_inflight2','u','T','C','prep_in_progress')"
+        )
+        # fp_prep is already prep_in_progress → 3 in flight total
+        conn.commit()
+        conn.close()
+
+    def test_prep_returns_429_when_cap_reached(self, client: TestClient, popen_calls):
+        self._set_three_in_flight(client)
+
+        response = client.post("/board/jobs/fp_scored/prep")
+
+        assert response.status_code == 429
+        assert "queue full" in response.text.lower()
+        # DB unchanged
+        assert _fetch_stage(client, "fp_scored") == "scored"
+        assert _fetch_audit(client, "fp_scored") == []
+        # No new subprocess
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert prep_calls == []
+
+    def test_regenerate_returns_429_when_cap_reached(self, client: TestClient, popen_calls):
+        self._set_three_in_flight(client)
+
+        # fp_drafted is at materials_drafted — regen would push to 4 in flight
+        response = client.post("/board/jobs/fp_drafted/regenerate")
+
+        assert response.status_code == 429
+        # Stage unchanged
+        assert _fetch_stage(client, "fp_drafted") == "materials_drafted"
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert prep_calls == []
+
+    def test_prep_allowed_at_cap_minus_one(self, client: TestClient, popen_calls):
+        """With 2 in flight, a 3rd prep is allowed."""
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, stage) "
+            "VALUES ('inflight1','fp_inflight1','u','T','C','prep_in_progress')"
+        )
+        # fp_prep is the 2nd in flight
+        conn.commit()
+        conn.close()
+
+        response = client.post("/board/jobs/fp_scored/prep")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_scored") == "prep_in_progress"
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert len(prep_calls) == 1
+
+    def test_idempotent_prep_bypasses_cap(self, client: TestClient, popen_calls):
+        """A re-click on an in-flight or drafted job returns the row even if cap is reached."""
+        self._set_three_in_flight(client)
+
+        # fp_drafted is at materials_drafted, so /prep returns idempotent row before cap check
+        response = client.post("/board/jobs/fp_drafted/prep")
+
+        assert response.status_code == 200
+        assert response.text.strip().startswith("<tr")
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert prep_calls == []
 
 
 # ── /waitlist handler ─────────────────────────────────────────────────────

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -1,0 +1,209 @@
+"""Tests for web POST handlers in src/findajob/web/routes/board_actions.py.
+
+Each handler is exercised against a real TestClient-backed FastAPI app and an
+on-disk SQLite DB so the audit_log JOIN behavior matches production. The
+subprocess.Popen call that dispatches prep is monkeypatched on the
+board_actions module so tests don't actually fork prep_application.py.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob import utils
+from findajob.web import routes as _web_routes
+from findajob.web.app import create_app
+
+SCHEMA = """
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    location TEXT DEFAULT '',
+    remote_status TEXT DEFAULT 'Unknown',
+    known_contacts TEXT DEFAULT '',
+    comp_estimate TEXT DEFAULT '',
+    ai_notes TEXT,
+    relevance_score INTEGER,
+    interview_likelihood INTEGER,
+    stage TEXT,
+    stage_updated TEXT,
+    apply_flag INTEGER DEFAULT 0,
+    prep_folder_path TEXT,
+    reject_reason TEXT DEFAULT '',
+    user_notes TEXT DEFAULT '',
+    gdrive_folder_url TEXT,
+    source TEXT DEFAULT 'test',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    field_changed TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_at TEXT DEFAULT (datetime('now')),
+    changed_by TEXT DEFAULT 'system'
+);
+"""
+
+
+def _insert_job(
+    conn: sqlite3.Connection,
+    *,
+    fingerprint: str,
+    stage: str,
+    job_id: str | None = None,
+    company: str = "Acme Corp",
+    title: str = "Senior Ops",
+    url: str = "https://example.com/job",
+    score: int = 8,
+) -> str:
+    job_id = job_id or fingerprint.replace("fp", "id")
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, url, title, company, stage, relevance_score) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (job_id, fingerprint, url, title, company, stage, score),
+    )
+    conn.commit()
+    return job_id
+
+
+@pytest.fixture()
+def popen_calls(monkeypatch) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, args, **_kw):
+            calls.append(args)
+
+    from findajob.web.routes import board_actions
+
+    monkeypatch.setattr(board_actions.subprocess, "Popen", _FakePopen)
+    return calls
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch, popen_calls) -> TestClient:
+    monkeypatch.setattr(utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
+
+    db_path = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA)
+    _insert_job(conn, fingerprint="fp_scored", stage="scored")
+    _insert_job(conn, fingerprint="fp_manual", stage="manual_review")
+    _insert_job(conn, fingerprint="fp_prep", stage="prep_in_progress")
+    _insert_job(conn, fingerprint="fp_drafted", stage="materials_drafted")
+    _insert_job(conn, fingerprint="fp_applied", stage="applied")
+    conn.close()
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    app = create_app(companies_root=companies, db_path=db_path)
+    client = TestClient(app)
+    client._db_path = db_path  # expose for assertions
+    return client
+
+
+def _fetch_stage(client: TestClient, fingerprint: str) -> str | None:
+    conn = sqlite3.connect(client._db_path)
+    row = conn.execute("SELECT stage FROM jobs WHERE fingerprint=?", (fingerprint,)).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def _fetch_audit(client: TestClient, fingerprint: str) -> list[tuple[str, str | None, str | None]]:
+    conn = sqlite3.connect(client._db_path)
+    rows = conn.execute(
+        "SELECT al.field_changed, al.old_value, al.new_value "
+        "FROM audit_log al JOIN jobs j ON j.id = al.job_id "
+        "WHERE j.fingerprint=? ORDER BY al.id",
+        (fingerprint,),
+    ).fetchall()
+    conn.close()
+    return [tuple(r) for r in rows]
+
+
+# ── /prep handler ──────────────────────────────────────────────────────────
+
+
+class TestPrep:
+    def test_happy_path_flags_scored_job(self, client: TestClient, popen_calls):
+        response = client.post("/board/jobs/fp_scored/prep")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_scored") == "prep_in_progress"
+
+        audit = _fetch_audit(client, "fp_scored")
+        assert any(a == ("stage", "scored", "prep_in_progress") for a in audit)
+
+        assert len(popen_calls) == 1
+        args = popen_calls[0]
+        assert "prep_application.py" in args[1]
+        assert args[-1] == "--no-sync"
+
+    def test_happy_path_flags_manual_review_job(self, client: TestClient, popen_calls):
+        response = client.post("/board/jobs/fp_manual/prep")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_manual") == "prep_in_progress"
+        assert len(popen_calls) == 1
+
+    def test_returns_updated_row_html(self, client: TestClient, popen_calls):
+        response = client.post("/board/jobs/fp_scored/prep")
+
+        assert response.status_code == 200
+        # HTMX swaps a <tr> — the response should be a table row, not the full page
+        assert response.text.strip().startswith("<tr")
+        assert 'data-fingerprint="fp_scored"' in response.text
+        # After the transition the row shows the Prep in progress indicator
+        assert "Prep in progress" in response.text
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient, popen_calls):
+        response = client.post("/board/jobs/fp_nonexistent/prep")
+
+        assert response.status_code == 404
+        assert popen_calls == []
+
+    def test_idempotent_on_prep_in_progress(self, client: TestClient, popen_calls):
+        """Double-click during prep: second POST is a no-op, returns current row."""
+        response = client.post("/board/jobs/fp_prep/prep")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_prep") == "prep_in_progress"
+        # No second subprocess launched, no audit row written
+        assert popen_calls == []
+        assert _fetch_audit(client, "fp_prep") == []
+
+    def test_idempotent_on_materials_drafted(self, client: TestClient, popen_calls):
+        """Clicking Flag for Prep on an already-drafted job is a no-op."""
+        response = client.post("/board/jobs/fp_drafted/prep")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_drafted") == "materials_drafted"
+        assert popen_calls == []
+
+    def test_double_post_launches_prep_once(self, client: TestClient, popen_calls):
+        """Two rapid POSTs: first dispatches, second hits the idempotency guard."""
+        first = client.post("/board/jobs/fp_scored/prep")
+        second = client.post("/board/jobs/fp_scored/prep")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert len(popen_calls) == 1
+        assert _fetch_stage(client, "fp_scored") == "prep_in_progress"
+
+
+def test_router_registered_on_app(client: TestClient):
+    """The new board_actions router must be included in the aggregated router."""
+    # Smoke-check the aggregated router has the new path registered.
+    paths = {route.path for route in _web_routes.router.routes}
+    assert "/board/jobs/{fingerprint}/prep" in paths

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -32,6 +32,8 @@ CREATE TABLE jobs (
     ai_notes TEXT,
     relevance_score INTEGER,
     interview_likelihood INTEGER,
+    score_status TEXT,
+    score_flag_reason TEXT,
     stage TEXT,
     stage_updated TEXT,
     apply_flag INTEGER DEFAULT 0,
@@ -97,12 +99,15 @@ def popen_calls(monkeypatch) -> list[list[str]]:
 
 @pytest.fixture()
 def client(tmp_path: Path, monkeypatch, popen_calls) -> TestClient:
+    from findajob import actions
     from findajob.web.routes import board_actions
 
     monkeypatch.setattr(utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
-    # /apply resolves its destination folder via board_actions.BASE; point at the
-    # test's tmp_path so folder moves don't reach into the real repo.
+    # /apply resolves its destination folder via board_actions.BASE; actions.BASE
+    # drives handle_waitlist / handle_reactivate folder moves. Point both at the
+    # test's tmp_path so folder ops don't reach into the real repo.
     monkeypatch.setattr(board_actions, "BASE", str(tmp_path))
+    monkeypatch.setattr(actions, "BASE", str(tmp_path))
 
     db_path = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db_path)
@@ -114,6 +119,8 @@ def client(tmp_path: Path, monkeypatch, popen_calls) -> TestClient:
     _insert_job(conn, fingerprint="fp_applied", stage="applied")
     _insert_job(conn, fingerprint="fp_interview", stage="interview")
     _insert_job(conn, fingerprint="fp_offer", stage="offer")
+    # Different company so waitlist-resurface tests don't see fp_applied as a sibling
+    _insert_job(conn, fingerprint="fp_waitlisted", stage="waitlisted", company="Waitlist Co")
     conn.close()
 
     companies = tmp_path / "companies"
@@ -219,8 +226,137 @@ def test_router_registered_on_app(client: TestClient):
     # Smoke-check the aggregated router has the new path registered.
     paths = {route.path for route in _web_routes.router.routes}
     assert "/board/jobs/{fingerprint}/prep" in paths
-    for endpoint in ("apply", "interview", "offer", "withdraw"):
+    for endpoint in ("apply", "interview", "offer", "withdraw", "waitlist", "reactivate", "promote"):
         assert f"/board/jobs/{{fingerprint}}/{endpoint}" in paths
+
+
+# ── /waitlist handler ─────────────────────────────────────────────────────
+
+
+class TestWaitlist:
+    def test_happy_path_from_dashboard_stage(self, client: TestClient):
+        response = client.post("/board/jobs/fp_drafted/waitlist")
+
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_drafted") == "waitlisted"
+
+        audit = _fetch_audit(client, "fp_drafted")
+        assert any(a == ("stage", "materials_drafted", "waitlisted") for a in audit)
+
+    def test_happy_path_moves_folder(self, client: TestClient):
+        folder = client._tmp_path / "companies" / "Acme_Ops_waitlist_test"
+        folder.mkdir(parents=True)
+        (folder / "resume.pdf").touch()
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE fingerprint='fp_drafted'", (str(folder),))
+        conn.commit()
+        conn.close()
+
+        client.post("/board/jobs/fp_drafted/waitlist")
+
+        assert not folder.exists()
+        conn = sqlite3.connect(client._db_path)
+        new_path = conn.execute(
+            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'"
+        ).fetchone()[0]
+        conn.close()
+        assert "_waitlisted" in new_path
+        assert Path(new_path).is_dir()
+
+    def test_idempotent_on_already_waitlisted(self, client: TestClient):
+        response = client.post("/board/jobs/fp_waitlisted/waitlist")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_waitlisted") == "waitlisted"
+        assert _fetch_audit(client, "fp_waitlisted") == []
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/waitlist")
+        assert response.status_code == 404
+
+
+# ── /reactivate handler ───────────────────────────────────────────────────
+
+
+class TestReactivate:
+    def test_happy_path_without_folder(self, client: TestClient):
+        response = client.post("/board/jobs/fp_waitlisted/reactivate")
+
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_waitlisted") == "scored"
+
+        audit = _fetch_audit(client, "fp_waitlisted")
+        assert any(a == ("stage", "waitlisted", "scored") for a in audit)
+
+    def test_happy_path_restores_folder(self, client: TestClient):
+        """With a folder in _waitlisted/, reactivate moves it back and sets stage=materials_drafted."""
+        folder = client._tmp_path / "companies" / "_waitlisted" / "Acme_Ops_reactivate"
+        folder.mkdir(parents=True)
+        (folder / "resume.pdf").touch()
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "UPDATE jobs SET prep_folder_path=? WHERE fingerprint='fp_waitlisted'",
+            (str(folder),),
+        )
+        conn.commit()
+        conn.close()
+
+        client.post("/board/jobs/fp_waitlisted/reactivate")
+
+        assert _fetch_stage(client, "fp_waitlisted") == "materials_drafted"
+        conn = sqlite3.connect(client._db_path)
+        new_path = conn.execute(
+            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_waitlisted'"
+        ).fetchone()[0]
+        conn.close()
+        assert "_waitlisted" not in new_path
+        assert Path(new_path).is_dir()
+        assert not folder.exists()
+
+    def test_409_on_non_waitlisted_job(self, client: TestClient):
+        response = client.post("/board/jobs/fp_scored/reactivate")
+
+        assert response.status_code == 409
+        # Stage unchanged
+        assert _fetch_stage(client, "fp_scored") == "scored"
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/reactivate")
+        assert response.status_code == 404
+
+
+# ── /promote handler ──────────────────────────────────────────────────────
+
+
+class TestPromote:
+    def test_happy_path_from_manual_review(self, client: TestClient):
+        response = client.post("/board/jobs/fp_manual/promote")
+
+        assert response.status_code == 200
+        assert response.text == ""
+
+        conn = sqlite3.connect(client._db_path)
+        row = conn.execute(
+            "SELECT stage, relevance_score FROM jobs WHERE fingerprint='fp_manual'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "scored"
+        assert row[1] == 7
+
+        audit = _fetch_audit(client, "fp_manual")
+        assert any(a == ("stage", "manual_review", "scored") for a in audit)
+
+    def test_409_on_non_manual_review_job(self, client: TestClient):
+        response = client.post("/board/jobs/fp_scored/promote")
+
+        assert response.status_code == 409
+        assert _fetch_stage(client, "fp_scored") == "scored"
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/promote")
+        assert response.status_code == 404
 
 
 # ── /apply handler ─────────────────────────────────────────────────────────

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -84,8 +84,7 @@ def _insert_job(
 ) -> str:
     job_id = job_id or fingerprint.replace("fp", "id")
     conn.execute(
-        "INSERT INTO jobs (id, fingerprint, url, title, company, stage, relevance_score) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (id, fingerprint, url, title, company, stage, relevance_score) VALUES (?, ?, ?, ?, ?, ?, ?)",
         (job_id, fingerprint, url, title, company, stage, score),
     )
     conn.commit()
@@ -258,8 +257,7 @@ def test_router_registered_on_app(client: TestClient):
 def _fetch_feedback(client: TestClient, fingerprint: str) -> list[tuple[str, str]]:
     conn = sqlite3.connect(client._db_path)
     rows = conn.execute(
-        "SELECT fb.reject_reason, fb.title FROM feedback_log fb "
-        "JOIN jobs j ON j.id = fb.job_id WHERE j.fingerprint=?",
+        "SELECT fb.reject_reason, fb.title FROM feedback_log fb JOIN jobs j ON j.id = fb.job_id WHERE j.fingerprint=?",
         (fingerprint,),
     ).fetchall()
     conn.close()
@@ -297,9 +295,7 @@ class TestReject:
 
         # Folder moved to _rejected/ with a REJECTED_ marker
         conn = sqlite3.connect(client._db_path)
-        new_path = conn.execute(
-            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'"
-        ).fetchone()[0]
+        new_path = conn.execute("SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'").fetchone()[0]
         conn.close()
         assert "_rejected" in new_path
         assert not folder.exists()
@@ -433,9 +429,7 @@ class TestNotSelected:
         client.post("/board/jobs/fp_applied/not-selected", data={"reason": ""})
 
         conn = sqlite3.connect(client._db_path)
-        reject_reason = conn.execute(
-            "SELECT reject_reason FROM jobs WHERE fingerprint='fp_applied'"
-        ).fetchone()[0]
+        reject_reason = conn.execute("SELECT reject_reason FROM jobs WHERE fingerprint='fp_applied'").fetchone()[0]
         conn.close()
         assert reject_reason == "Company passed"
 
@@ -502,8 +496,7 @@ class TestRegenerate:
 
         conn = sqlite3.connect(client._db_path)
         row = conn.execute(
-            "SELECT stage, prep_folder_path, gdrive_folder_url, apply_flag "
-            "FROM jobs WHERE fingerprint='fp_drafted'"
+            "SELECT stage, prep_folder_path, gdrive_folder_url, apply_flag FROM jobs WHERE fingerprint='fp_drafted'"
         ).fetchone()
         conn.close()
         assert row[0] == "prep_in_progress"
@@ -619,9 +612,7 @@ class TestPrepConcurrencyCap:
 
 def _fetch_user_notes(client: TestClient, fingerprint: str) -> str | None:
     conn = sqlite3.connect(client._db_path)
-    row = conn.execute(
-        "SELECT user_notes FROM jobs WHERE fingerprint=?", (fingerprint,)
-    ).fetchone()
+    row = conn.execute("SELECT user_notes FROM jobs WHERE fingerprint=?", (fingerprint,)).fetchone()
     conn.close()
     return row[0] if row else None
 
@@ -702,9 +693,7 @@ class TestWaitlist:
 
         assert not folder.exists()
         conn = sqlite3.connect(client._db_path)
-        new_path = conn.execute(
-            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'"
-        ).fetchone()[0]
+        new_path = conn.execute("SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'").fetchone()[0]
         conn.close()
         assert "_waitlisted" in new_path
         assert Path(new_path).is_dir()
@@ -752,9 +741,7 @@ class TestReactivate:
 
         assert _fetch_stage(client, "fp_waitlisted") == "materials_drafted"
         conn = sqlite3.connect(client._db_path)
-        new_path = conn.execute(
-            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_waitlisted'"
-        ).fetchone()[0]
+        new_path = conn.execute("SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_waitlisted'").fetchone()[0]
         conn.close()
         assert "_waitlisted" not in new_path
         assert Path(new_path).is_dir()
@@ -783,9 +770,7 @@ class TestPromote:
         assert response.text == ""
 
         conn = sqlite3.connect(client._db_path)
-        row = conn.execute(
-            "SELECT stage, relevance_score FROM jobs WHERE fingerprint='fp_manual'"
-        ).fetchone()
+        row = conn.execute("SELECT stage, relevance_score FROM jobs WHERE fingerprint='fp_manual'").fetchone()
         conn.close()
         assert row[0] == "scored"
         assert row[1] == 7
@@ -828,9 +813,7 @@ class TestApply:
         assert _fetch_stage(client, "fp_drafted") == "applied"
         # Folder moved into _applied/
         conn = sqlite3.connect(client._db_path)
-        new_path = conn.execute(
-            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'"
-        ).fetchone()[0]
+        new_path = conn.execute("SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'").fetchone()[0]
         conn.close()
         assert "_applied" in new_path
         assert not folder.exists()

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -250,6 +250,7 @@ def test_router_registered_on_app(client: TestClient):
         "reject",
         "not-selected",
         "regenerate",
+        "notes",
     ):
         assert f"/board/jobs/{{fingerprint}}/{endpoint}" in paths
 
@@ -611,6 +612,67 @@ class TestPrepConcurrencyCap:
         assert response.text.strip().startswith("<tr")
         prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
         assert prep_calls == []
+
+
+# ── /notes handler ───────────────────────────────────────────────────────
+
+
+def _fetch_user_notes(client: TestClient, fingerprint: str) -> str | None:
+    conn = sqlite3.connect(client._db_path)
+    row = conn.execute(
+        "SELECT user_notes FROM jobs WHERE fingerprint=?", (fingerprint,)
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+class TestNotes:
+    def test_happy_path_saves_note(self, client: TestClient):
+        response = client.post(
+            "/board/jobs/fp_applied/notes",
+            data={"notes": "Follow up in two weeks"},
+        )
+
+        assert response.status_code == 200
+        assert _fetch_user_notes(client, "fp_applied") == "Follow up in two weeks"
+
+    def test_response_is_rerendered_td_with_input(self, client: TestClient):
+        response = client.post(
+            "/board/jobs/fp_applied/notes",
+            data={"notes": "Recruiter call Wed"},
+        )
+        # Response is a <td> containing the input with the saved value
+        assert response.text.strip().startswith("<td")
+        assert 'value="Recruiter call Wed"' in response.text
+        assert 'name="notes"' in response.text
+        assert 'hx-post="/board/jobs/fp_applied/notes"' in response.text
+
+    def test_empty_note_clears_db_column(self, client: TestClient):
+        # First set some text
+        client.post("/board/jobs/fp_applied/notes", data={"notes": "original"})
+        assert _fetch_user_notes(client, "fp_applied") == "original"
+
+        # Then clear it
+        response = client.post("/board/jobs/fp_applied/notes", data={"notes": ""})
+
+        assert response.status_code == 200
+        assert _fetch_user_notes(client, "fp_applied") == ""
+
+    def test_no_audit_log_entry(self, client: TestClient):
+        """Notes are free-text, rewritten on every keystroke debounce — no audit noise."""
+        client.post("/board/jobs/fp_applied/notes", data={"notes": "anything"})
+        assert _fetch_audit(client, "fp_applied") == []
+
+    def test_does_not_affect_stage(self, client: TestClient):
+        client.post("/board/jobs/fp_applied/notes", data={"notes": "leave stage alone"})
+        assert _fetch_stage(client, "fp_applied") == "applied"
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post(
+            "/board/jobs/fp_nonexistent/notes",
+            data={"notes": "anything"},
+        )
+        assert response.status_code == 404
 
 
 # ── /waitlist handler ─────────────────────────────────────────────────────

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -79,21 +79,30 @@ def _insert_job(
 
 @pytest.fixture()
 def popen_calls(monkeypatch) -> list[list[str]]:
+    """Capture subprocess.Popen invocations from both the web layer and
+    findajob.actions (notify_waitlist_resurface launches notify.py via Popen)."""
     calls: list[list[str]] = []
 
     class _FakePopen:
         def __init__(self, args, **_kw):
             calls.append(args)
 
+    from findajob import actions
     from findajob.web.routes import board_actions
 
     monkeypatch.setattr(board_actions.subprocess, "Popen", _FakePopen)
+    monkeypatch.setattr(actions.subprocess, "Popen", _FakePopen)
     return calls
 
 
 @pytest.fixture()
 def client(tmp_path: Path, monkeypatch, popen_calls) -> TestClient:
+    from findajob.web.routes import board_actions
+
     monkeypatch.setattr(utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
+    # /apply resolves its destination folder via board_actions.BASE; point at the
+    # test's tmp_path so folder moves don't reach into the real repo.
+    monkeypatch.setattr(board_actions, "BASE", str(tmp_path))
 
     db_path = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db_path)
@@ -103,6 +112,8 @@ def client(tmp_path: Path, monkeypatch, popen_calls) -> TestClient:
     _insert_job(conn, fingerprint="fp_prep", stage="prep_in_progress")
     _insert_job(conn, fingerprint="fp_drafted", stage="materials_drafted")
     _insert_job(conn, fingerprint="fp_applied", stage="applied")
+    _insert_job(conn, fingerprint="fp_interview", stage="interview")
+    _insert_job(conn, fingerprint="fp_offer", stage="offer")
     conn.close()
 
     companies = tmp_path / "companies"
@@ -110,6 +121,7 @@ def client(tmp_path: Path, monkeypatch, popen_calls) -> TestClient:
     app = create_app(companies_root=companies, db_path=db_path)
     client = TestClient(app)
     client._db_path = db_path  # expose for assertions
+    client._tmp_path = tmp_path
     return client
 
 
@@ -207,3 +219,182 @@ def test_router_registered_on_app(client: TestClient):
     # Smoke-check the aggregated router has the new path registered.
     paths = {route.path for route in _web_routes.router.routes}
     assert "/board/jobs/{fingerprint}/prep" in paths
+    for endpoint in ("apply", "interview", "offer", "withdraw"):
+        assert f"/board/jobs/{{fingerprint}}/{endpoint}" in paths
+
+
+# ── /apply handler ─────────────────────────────────────────────────────────
+
+
+class TestApply:
+    def _seed_prep_folder(self, client: TestClient, fingerprint: str) -> Path:
+        folder = client._tmp_path / "companies" / f"Acme_Ops_{fingerprint}"
+        folder.mkdir(parents=True)
+        (folder / "resume.pdf").touch()
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE fingerprint=?", (str(folder), fingerprint))
+        conn.commit()
+        conn.close()
+        return folder
+
+    def test_happy_path_from_materials_drafted(self, client: TestClient):
+        folder = self._seed_prep_folder(client, "fp_drafted")
+
+        response = client.post("/board/jobs/fp_drafted/apply")
+
+        assert response.status_code == 200
+        assert response.text == ""  # empty body = HTMX removes the row
+        assert _fetch_stage(client, "fp_drafted") == "applied"
+        # Folder moved into _applied/
+        conn = sqlite3.connect(client._db_path)
+        new_path = conn.execute(
+            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'"
+        ).fetchone()[0]
+        conn.close()
+        assert "_applied" in new_path
+        assert not folder.exists()
+        assert Path(new_path).is_dir()
+
+        audit = _fetch_audit(client, "fp_drafted")
+        assert any(a == ("stage", "materials_drafted", "applied") for a in audit)
+
+    def test_happy_path_without_folder(self, client: TestClient):
+        """Apply without a prep folder still transitions DB state."""
+        response = client.post("/board/jobs/fp_drafted/apply")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_drafted") == "applied"
+
+    def test_idempotent_on_already_applied(self, client: TestClient):
+        response = client.post("/board/jobs/fp_applied/apply")
+
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_applied") == "applied"
+        # No audit written — idempotency short-circuit
+        assert _fetch_audit(client, "fp_applied") == []
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/apply")
+        assert response.status_code == 404
+
+
+# ── /interview handler ────────────────────────────────────────────────────
+
+
+class TestInterview:
+    def test_happy_path_from_applied(self, client: TestClient):
+        response = client.post("/board/jobs/fp_applied/interview")
+
+        assert response.status_code == 200
+        assert response.text.strip().startswith("<tr")
+        assert 'data-fingerprint="fp_applied"' in response.text
+        assert _fetch_stage(client, "fp_applied") == "interview"
+
+        audit = _fetch_audit(client, "fp_applied")
+        assert any(a == ("stage", "applied", "interview") for a in audit)
+
+    def test_idempotent_on_already_interview(self, client: TestClient):
+        response = client.post("/board/jobs/fp_interview/interview")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_interview") == "interview"
+        assert _fetch_audit(client, "fp_interview") == []
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/interview")
+        assert response.status_code == 404
+
+
+# ── /offer handler ────────────────────────────────────────────────────────
+
+
+class TestOffer:
+    def test_happy_path_from_interview(self, client: TestClient):
+        response = client.post("/board/jobs/fp_interview/offer")
+
+        assert response.status_code == 200
+        assert response.text.strip().startswith("<tr")
+        assert _fetch_stage(client, "fp_interview") == "offer"
+
+        audit = _fetch_audit(client, "fp_interview")
+        assert any(a == ("stage", "interview", "offer") for a in audit)
+
+    def test_happy_path_from_applied(self, client: TestClient):
+        """Recruiter-straight-to-offer flow."""
+        response = client.post("/board/jobs/fp_applied/offer")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_applied") == "offer"
+
+    def test_idempotent_on_already_offer(self, client: TestClient):
+        response = client.post("/board/jobs/fp_offer/offer")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_offer") == "offer"
+        assert _fetch_audit(client, "fp_offer") == []
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/offer")
+        assert response.status_code == 404
+
+
+# ── /withdraw handler ─────────────────────────────────────────────────────
+
+
+class TestWithdraw:
+    def _seed_waitlisted_sibling(self, client: TestClient, company: str) -> None:
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, stage) "
+            "VALUES ('sib', 'fp_sibling', 'u', 'Other role', ?, 'waitlisted')",
+            (company,),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_happy_path_empties_response(self, client: TestClient):
+        response = client.post("/board/jobs/fp_applied/withdraw")
+
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_applied") == "withdrawn"
+
+        audit = _fetch_audit(client, "fp_applied")
+        assert any(a == ("stage", "applied", "withdrawn") for a in audit)
+
+    def test_fires_waitlist_resurface_notification(self, client: TestClient, popen_calls):
+        """A waitlisted sibling at the same company triggers a notification."""
+        self._seed_waitlisted_sibling(client, "Acme Corp")
+
+        client.post("/board/jobs/fp_applied/withdraw")
+
+        notify_calls = [c for c in popen_calls if any("notify.py" in arg for arg in c)]
+        assert len(notify_calls) == 1
+        assert "send-raw" in notify_calls[0]
+
+    def test_no_resurface_when_no_waitlisted(self, client: TestClient, popen_calls):
+        """No waitlisted jobs at that company → no notification fires."""
+        client.post("/board/jobs/fp_applied/withdraw")
+
+        notify_calls = [c for c in popen_calls if any("notify.py" in arg for arg in c)]
+        assert notify_calls == []
+
+    def test_idempotent_on_already_withdrawn(self, client: TestClient, popen_calls):
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET stage='withdrawn' WHERE fingerprint='fp_applied'")
+        conn.commit()
+        conn.close()
+
+        self._seed_waitlisted_sibling(client, "Acme Corp")
+        response = client.post("/board/jobs/fp_applied/withdraw")
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_applied") == "withdrawn"
+        # No notify fires on a no-op withdrawal
+        notify_calls = [c for c in popen_calls if any("notify.py" in arg for arg in c)]
+        assert notify_calls == []
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/withdraw")
+        assert response.status_code == 404

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -8,6 +8,7 @@ board_actions module so tests don't actually fork prep_application.py.
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from pathlib import Path
 
@@ -38,6 +39,7 @@ CREATE TABLE jobs (
     stage_updated TEXT,
     apply_flag INTEGER DEFAULT 0,
     prep_folder_path TEXT,
+    raw_jd_text TEXT,
     reject_reason TEXT DEFAULT '',
     user_notes TEXT DEFAULT '',
     gdrive_folder_url TEXT,
@@ -54,6 +56,17 @@ CREATE TABLE audit_log (
     new_value TEXT,
     changed_at TEXT DEFAULT (datetime('now')),
     changed_by TEXT DEFAULT 'system'
+);
+
+CREATE TABLE feedback_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    relevance_score INTEGER,
+    reject_reason TEXT NOT NULL,
+    jd_excerpt TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now'))
 );
 """
 
@@ -226,8 +239,238 @@ def test_router_registered_on_app(client: TestClient):
     # Smoke-check the aggregated router has the new path registered.
     paths = {route.path for route in _web_routes.router.routes}
     assert "/board/jobs/{fingerprint}/prep" in paths
-    for endpoint in ("apply", "interview", "offer", "withdraw", "waitlist", "reactivate", "promote"):
+    for endpoint in (
+        "apply",
+        "interview",
+        "offer",
+        "withdraw",
+        "waitlist",
+        "reactivate",
+        "promote",
+        "reject",
+        "not-selected",
+    ):
         assert f"/board/jobs/{{fingerprint}}/{endpoint}" in paths
+
+
+def _fetch_feedback(client: TestClient, fingerprint: str) -> list[tuple[str, str]]:
+    conn = sqlite3.connect(client._db_path)
+    rows = conn.execute(
+        "SELECT fb.reject_reason, fb.title FROM feedback_log fb "
+        "JOIN jobs j ON j.id = fb.job_id WHERE j.fingerprint=?",
+        (fingerprint,),
+    ).fetchall()
+    conn.close()
+    return [tuple(r) for r in rows]
+
+
+# ── /reject handler ───────────────────────────────────────────────────────
+
+
+class TestReject:
+    def _seed_prep_folder(self, client: TestClient, fingerprint: str, parent: str = "") -> Path:
+        parent_path = client._tmp_path / "companies" / parent if parent else client._tmp_path / "companies"
+        parent_path.mkdir(parents=True, exist_ok=True)
+        folder = parent_path / f"Acme_Ops_reject_{fingerprint}"
+        folder.mkdir()
+        (folder / "resume.pdf").touch()
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE fingerprint=?", (str(folder), fingerprint))
+        conn.commit()
+        conn.close()
+        return folder
+
+    def test_happy_path_from_dashboard(self, client: TestClient):
+        folder = self._seed_prep_folder(client, "fp_drafted")
+
+        response = client.post("/board/jobs/fp_drafted/reject", data={"reason": "Low Fit Score"})
+
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_drafted") == "rejected"
+
+        # feedback_log written with the reason + title
+        fb = _fetch_feedback(client, "fp_drafted")
+        assert fb == [("Low Fit Score", "Senior Ops")]
+
+        # Folder moved to _rejected/ with a REJECTED_ marker
+        conn = sqlite3.connect(client._db_path)
+        new_path = conn.execute(
+            "SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_drafted'"
+        ).fetchone()[0]
+        conn.close()
+        assert "_rejected" in new_path
+        assert not folder.exists()
+        markers = [f for f in os.listdir(new_path) if f.startswith("REJECTED_")]
+        assert len(markers) == 1
+        assert "Low_Fit_Score" in markers[0]
+
+    def test_happy_path_without_folder(self, client: TestClient):
+        response = client.post("/board/jobs/fp_scored/reject", data={"reason": "Wrong Level"})
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_scored") == "rejected"
+        fb = _fetch_feedback(client, "fp_scored")
+        assert fb == [("Wrong Level", "Senior Ops")]
+
+    def test_empty_reason_defaults_to_other(self, client: TestClient):
+        response = client.post("/board/jobs/fp_scored/reject", data={"reason": ""})
+
+        assert response.status_code == 200
+        fb = _fetch_feedback(client, "fp_scored")
+        assert fb == [("Other", "Senior Ops")]
+
+    def test_fires_waitlist_resurface(self, client: TestClient, popen_calls):
+        """A waitlisted sibling at the same company triggers a notification."""
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, stage) "
+            "VALUES ('sib','fp_sib','u','Other','Acme Corp','waitlisted')"
+        )
+        conn.commit()
+        conn.close()
+
+        client.post("/board/jobs/fp_scored/reject", data={"reason": "Low Fit Score"})
+
+        notify_calls = [c for c in popen_calls if any("notify.py" in arg for arg in c)]
+        assert len(notify_calls) == 1
+
+    def test_idempotent_on_already_rejected(self, client: TestClient):
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET stage='rejected' WHERE fingerprint='fp_scored'")
+        conn.commit()
+        conn.close()
+
+        response = client.post("/board/jobs/fp_scored/reject", data={"reason": "Other"})
+
+        assert response.status_code == 200
+        assert _fetch_feedback(client, "fp_scored") == []
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/reject", data={"reason": "Other"})
+        assert response.status_code == 404
+
+
+# ── /not-selected handler ────────────────────────────────────────────────
+
+
+class TestNotSelected:
+    def _seed_applied_folder(self, client: TestClient, fingerprint: str) -> Path:
+        applied_dir = client._tmp_path / "companies" / "_applied"
+        applied_dir.mkdir(parents=True, exist_ok=True)
+        folder = applied_dir / f"Acme_Ops_notsel_{fingerprint}"
+        folder.mkdir()
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE fingerprint=?", (str(folder), fingerprint))
+        conn.commit()
+        conn.close()
+        return folder
+
+    def test_happy_path_from_applied(self, client: TestClient):
+        folder = self._seed_applied_folder(client, "fp_applied")
+
+        response = client.post(
+            "/board/jobs/fp_applied/not-selected",
+            data={"reason": "Too Senior"},
+        )
+
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_applied") == "not_selected"
+
+        # Folder stays in _applied/ with a NOT_SELECTED_ marker
+        assert folder.exists()
+        markers = [f for f in os.listdir(folder) if f.startswith("NOT_SELECTED_")]
+        assert len(markers) == 1
+        assert "Too_Senior" in markers[0]
+
+    def test_does_not_write_feedback_log(self, client: TestClient):
+        """Company rejections must not contaminate the scorer feedback loop."""
+        self._seed_applied_folder(client, "fp_applied")
+        client.post("/board/jobs/fp_applied/not-selected", data={"reason": "Too Senior"})
+
+        assert _fetch_feedback(client, "fp_applied") == []
+
+    def test_happy_path_from_interview(self, client: TestClient):
+        response = client.post(
+            "/board/jobs/fp_interview/not-selected",
+            data={"reason": "Skills Mismatch"},
+        )
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_interview") == "not_selected"
+
+    def test_happy_path_from_offer(self, client: TestClient):
+        response = client.post(
+            "/board/jobs/fp_offer/not-selected",
+            data={"reason": "Company Not a Fit"},
+        )
+
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_offer") == "not_selected"
+
+    def test_409_on_pre_application_stage(self, client: TestClient):
+        """Not Selected only valid for applied/interview/offer."""
+        response = client.post(
+            "/board/jobs/fp_scored/not-selected",
+            data={"reason": "Too Senior"},
+        )
+
+        assert response.status_code == 409
+        assert _fetch_stage(client, "fp_scored") == "scored"
+
+    def test_409_on_waitlisted(self, client: TestClient):
+        response = client.post(
+            "/board/jobs/fp_waitlisted/not-selected",
+            data={"reason": "Too Senior"},
+        )
+        assert response.status_code == 409
+
+    def test_empty_reason_defaults_to_company_passed(self, client: TestClient):
+        self._seed_applied_folder(client, "fp_applied")
+        client.post("/board/jobs/fp_applied/not-selected", data={"reason": ""})
+
+        conn = sqlite3.connect(client._db_path)
+        reject_reason = conn.execute(
+            "SELECT reject_reason FROM jobs WHERE fingerprint='fp_applied'"
+        ).fetchone()[0]
+        conn.close()
+        assert reject_reason == "Company passed"
+
+    def test_fires_waitlist_resurface(self, client: TestClient, popen_calls):
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, stage) "
+            "VALUES ('sib','fp_sib','u','Other','Acme Corp','waitlisted')"
+        )
+        conn.commit()
+        conn.close()
+
+        client.post(
+            "/board/jobs/fp_applied/not-selected",
+            data={"reason": "Too Senior"},
+        )
+
+        notify_calls = [c for c in popen_calls if any("notify.py" in arg for arg in c)]
+        assert len(notify_calls) == 1
+
+    def test_idempotent_on_already_not_selected(self, client: TestClient):
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET stage='not_selected' WHERE fingerprint='fp_applied'")
+        conn.commit()
+        conn.close()
+
+        response = client.post("/board/jobs/fp_applied/not-selected", data={"reason": "Other"})
+
+        assert response.status_code == 200
+        assert _fetch_feedback(client, "fp_applied") == []
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post(
+            "/board/jobs/fp_nonexistent/not-selected",
+            data={"reason": "Other"},
+        )
+        assert response.status_code == 404
 
 
 # ── /waitlist handler ─────────────────────────────────────────────────────

--- a/tests/test_poll_flags.py
+++ b/tests/test_poll_flags.py
@@ -516,5 +516,3 @@ class TestWaitlistTab:
 
         row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
         assert row["stage"] == "rejected"
-
-

--- a/tests/test_poll_flags.py
+++ b/tests/test_poll_flags.py
@@ -174,8 +174,15 @@ def companies_dir(tmp_path):
 @pytest.fixture(autouse=True)
 def _patch_poll_flags(poll_flags_mod, tmp_path, monkeypatch):
     """Patch poll_flags module globals for every test."""
+    from findajob import actions
+
     monkeypatch.setattr(poll_flags_mod, "BASE", str(tmp_path))
     monkeypatch.setattr(poll_flags_mod, "log_event", lambda *a, **kw: None)
+    # Action helpers were extracted to findajob.actions in 14c PR-A (#61);
+    # tests that invoke handle_rejection/handle_reactivate via poll_flags_mod
+    # now reach into that module, so BASE + log_event need silencing there too.
+    monkeypatch.setattr(actions, "BASE", str(tmp_path))
+    monkeypatch.setattr(actions, "log_event", lambda *a, **kw: None)
     # Ensure companies subdirectories exist under tmp_path
     os.makedirs(os.path.join(str(tmp_path), "companies", "_applied"), exist_ok=True)
     os.makedirs(os.path.join(str(tmp_path), "companies", "_rejected"), exist_ok=True)
@@ -220,235 +227,6 @@ def insert_job(
     )
     conn.commit()
     return conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
-
-
-# ── handle_rejection ────────────────────────────────────────────────────────
-
-
-class TestHandleRejection:
-    def test_rejection_with_folder(self, poll_flags_mod, db, tmp_path):
-        """Rejection moves folder to _rejected, updates DB, writes feedback_log + marker."""
-        folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_120000"
-        folder.mkdir(parents=True, exist_ok=True)
-        (folder / "resume.pdf").touch()
-
-        job = insert_job(db, stage="materials_drafted", folder=str(folder), score=8)
-        result = poll_flags_mod.handle_rejection(db, job, "Low Fit Score")
-
-        assert result is True
-
-        row = db.execute("SELECT stage, reject_reason, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "rejected"
-        assert row["reject_reason"] == "Low Fit Score"
-        # Folder moved to _rejected
-        assert "_rejected" in row["prep_folder_path"]
-        assert os.path.isdir(row["prep_folder_path"])
-
-        # Marker file created
-        marker_files = [f for f in os.listdir(row["prep_folder_path"]) if f.startswith("REJECTED_")]
-        assert len(marker_files) == 1
-        assert "Low_Fit_Score" in marker_files[0]
-
-        # feedback_log entry
-        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
-        assert fb is not None
-        assert fb["reject_reason"] == "Low Fit Score"
-        assert fb["title"] == "Operations Manager"
-
-        # audit_log entries
-        audits = db.execute("SELECT * FROM audit_log WHERE job_id=? ORDER BY id", (job["id"],)).fetchall()
-        fields = [a["field_changed"] for a in audits]
-        assert "stage" in fields
-        assert "reject_reason" in fields
-
-    def test_rejection_without_folder(self, poll_flags_mod, db):
-        """Rejection without folder: DB updated, no folder operations."""
-        job = insert_job(db, stage="scored", folder=None, score=6)
-        result = poll_flags_mod.handle_rejection(db, job, "Wrong Level")
-
-        assert result is False
-
-        row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "rejected"
-        assert row["reject_reason"] == "Wrong Level"
-
-        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
-        assert fb is not None
-
-    def test_rejection_writes_jd_excerpt(self, poll_flags_mod, db):
-        """If job has raw_jd_text, feedback_log gets first 500 chars."""
-        long_jd = "A" * 1000
-        job = insert_job(db, stage="scored", raw_jd_text=long_jd)
-        poll_flags_mod.handle_rejection(db, job, "Not Relevant")
-
-        fb = db.execute("SELECT jd_excerpt FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
-        assert len(fb["jd_excerpt"]) == 500
-
-    def test_rejection_no_jd_gives_empty_excerpt(self, poll_flags_mod, db):
-        """No raw_jd_text means empty jd_excerpt."""
-        job = insert_job(db, stage="scored", raw_jd_text=None)
-        poll_flags_mod.handle_rejection(db, job, "Not Relevant")
-
-        fb = db.execute("SELECT jd_excerpt FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
-        assert fb["jd_excerpt"] == ""
-
-
-# ── handle_not_selected ────────────────────────────────────────────────────
-
-
-class TestHandleNotSelected:
-    def test_not_selected_with_folder(self, poll_flags_mod, db, tmp_path):
-        """Not Selected: stage=not_selected, folder stays in _applied/, marker file added, NO feedback_log."""
-        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_2026-04-13_120000"
-        folder.mkdir(parents=True, exist_ok=True)
-        (folder / "resume.pdf").touch()
-
-        job = insert_job(db, stage="applied", folder=str(folder), score=8)
-        result = poll_flags_mod.handle_not_selected(db, job, "Too Senior")
-
-        assert result is False  # no folder moved
-
-        row = db.execute("SELECT stage, reject_reason, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "not_selected"
-        assert row["reject_reason"] == "Too Senior"
-        # Folder stays in _applied/ (not moved)
-        assert "_applied" in row["prep_folder_path"]
-        assert os.path.isdir(row["prep_folder_path"])
-
-        # Marker file created
-        marker_files = [f for f in os.listdir(row["prep_folder_path"]) if f.startswith("NOT_SELECTED_")]
-        assert len(marker_files) == 1
-        assert "Too_Senior" in marker_files[0]
-
-        # NO feedback_log entry (critical: company rejections don't contaminate scorer)
-        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
-        assert fb is None
-
-        # audit_log entries written
-        audits = db.execute("SELECT * FROM audit_log WHERE job_id=? ORDER BY id", (job["id"],)).fetchall()
-        fields = [a["field_changed"] for a in audits]
-        assert "stage" in fields
-        assert "reject_reason" in fields
-        stage_audit = [a for a in audits if a["field_changed"] == "stage"][0]
-        assert stage_audit["new_value"] == "not_selected"
-
-    def test_not_selected_without_folder(self, poll_flags_mod, db):
-        """Not Selected without folder: DB updated, no marker file, no feedback_log."""
-        job = insert_job(db, stage="applied", folder=None, score=7)
-        result = poll_flags_mod.handle_not_selected(db, job, "Skills Mismatch")
-
-        assert result is False
-
-        row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "not_selected"
-        assert row["reject_reason"] == "Skills Mismatch"
-
-        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
-        assert fb is None
-
-    def test_not_selected_only_valid_for_post_apply_stages(self, db):
-        """Not Selected on scored job should be guarded — stage stays unchanged."""
-        job = insert_job(db, stage="scored")
-
-        # The guard in main() checks: job["stage"] in ("applied", "interview", "offer")
-        assert job["stage"] not in ("applied", "interview", "offer")
-
-    def test_not_selected_routes_before_rejection(self, poll_flags_mod, db):
-        """When STATUS='Not Selected' + REJECT_REASON set, handle_not_selected is used, not handle_rejection."""
-        job = insert_job(db, stage="applied", score=8)
-        poll_flags_mod.handle_not_selected(db, job, "Company Not a Fit")
-
-        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "not_selected"  # not "rejected"
-
-        fb = db.execute("SELECT * FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()
-        assert fb is None  # not written
-
-
-# ── handle_waitlist ─────────────────────────────────────────────────────────
-
-
-class TestHandleWaitlist:
-    def test_waitlist_with_folder(self, poll_flags_mod, db, tmp_path):
-        """Folder moves to _waitlisted/, stage updated."""
-        folder = tmp_path / "companies" / "Acme_Ops_2026-04-13_140000"
-        folder.mkdir(parents=True, exist_ok=True)
-        (folder / "cover_letter.docx").touch()
-
-        job = insert_job(db, stage="materials_drafted", folder=str(folder))
-        result = poll_flags_mod.handle_waitlist(db, job)
-
-        assert result is True
-
-        row = db.execute("SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "waitlisted"
-        assert "_waitlisted" in row["prep_folder_path"]
-        assert os.path.isdir(row["prep_folder_path"])
-
-    def test_waitlist_without_folder(self, poll_flags_mod, db):
-        """No folder: stage updated, no folder operations, returns False."""
-        job = insert_job(db, stage="scored", folder=None)
-        result = poll_flags_mod.handle_waitlist(db, job)
-
-        assert result is False
-
-        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "waitlisted"
-
-    def test_waitlist_writes_audit_log(self, poll_flags_mod, db):
-        """Audit log entry for stage change."""
-        job = insert_job(db, stage="scored")
-        poll_flags_mod.handle_waitlist(db, job)
-
-        audit = db.execute("SELECT * FROM audit_log WHERE job_id=? AND field_changed='stage'", (job["id"],)).fetchone()
-        assert audit is not None
-        assert audit["old_value"] == "scored"
-        assert audit["new_value"] == "waitlisted"
-
-
-# ── handle_reactivate ──────────────────────────────────────────────────────
-
-
-class TestHandleReactivate:
-    def test_reactivate_with_folder(self, poll_flags_mod, db, tmp_path):
-        """Folder moves back from _waitlisted/, stage→materials_drafted."""
-        folder = tmp_path / "companies" / "_waitlisted" / "Acme_Ops_2026-04-13_150000"
-        folder.mkdir(parents=True, exist_ok=True)
-        (folder / "resume.pdf").touch()
-
-        job = insert_job(db, stage="waitlisted", folder=str(folder))
-        result = poll_flags_mod.handle_reactivate(db, job)
-
-        assert result is True
-
-        row = db.execute("SELECT stage, prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "materials_drafted"
-        assert "_waitlisted" not in row["prep_folder_path"]
-        assert os.path.isdir(row["prep_folder_path"])
-        assert os.path.isfile(os.path.join(row["prep_folder_path"], "resume.pdf"))
-
-    def test_reactivate_without_folder(self, poll_flags_mod, db):
-        """No folder: stage→scored."""
-        job = insert_job(db, stage="waitlisted", folder=None)
-        result = poll_flags_mod.handle_reactivate(db, job)
-
-        assert result is False
-
-        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "scored"
-
-    def test_reactivate_missing_folder_path_falls_back_to_scored(self, poll_flags_mod, db):
-        """Folder path in DB but dir doesn't exist → scored."""
-        job = insert_job(db, stage="waitlisted", folder="/nonexistent/Acme_Ops")
-        result = poll_flags_mod.handle_reactivate(db, job)
-
-        assert result is False
-
-        row = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
-        assert row["stage"] == "scored"
-
-        audit = db.execute("SELECT * FROM audit_log WHERE job_id=? AND field_changed='stage'", (job["id"],)).fetchone()
-        assert audit["new_value"] == "scored"
 
 
 # ── Dashboard flag processing (main() logic patterns) ──────────────────────
@@ -698,36 +476,6 @@ class TestDashboardRejectionPriority:
 
 
 class TestReviewTab:
-    def test_promote_sets_score_and_stage(self, poll_flags_mod, db):
-        """Promote: score=7, stage=scored, score_status=scored."""
-        from datetime import UTC, datetime
-
-        job = insert_job(db, stage="manual_review", score=5, score_status="manual_review")
-
-        # Replicate Review promote logic
-        now = datetime.now(UTC).isoformat()
-        db.execute(
-            """UPDATE jobs SET relevance_score=7, stage='scored',
-                   score_status='scored', score_flag_reason='Promoted from Review tab',
-                   stage_updated=?, updated_at=?
-               WHERE id=?""",
-            (now, now, job["id"]),
-        )
-        db.commit()
-        poll_flags_mod.write_audit(db, job["id"], "stage", "manual_review", "scored")
-
-        row = db.execute(
-            "SELECT relevance_score, stage, score_status, score_flag_reason FROM jobs WHERE id=?", (job["id"],)
-        ).fetchone()
-        assert row["relevance_score"] == 7
-        assert row["stage"] == "scored"
-        assert row["score_status"] == "scored"
-        assert row["score_flag_reason"] == "Promoted from Review tab"
-
-        audit = db.execute("SELECT * FROM audit_log WHERE job_id=? AND field_changed='stage'", (job["id"],)).fetchone()
-        assert audit["old_value"] == "manual_review"
-        assert audit["new_value"] == "scored"
-
     def test_review_reject(self, poll_flags_mod, db):
         """Reject from Review tab → handle_rejection called."""
         job = insert_job(db, stage="manual_review", score=4)
@@ -770,33 +518,3 @@ class TestWaitlistTab:
         assert row["stage"] == "rejected"
 
 
-# ── notify_waitlist_resurface ───────────────────────────────────────────────
-
-
-class TestNotifyWaitlistResurface:
-    def test_resurface_sends_notification(self, poll_flags_mod, db, monkeypatch):
-        """When waitlisted jobs exist at company, Popen is called."""
-        import subprocess as sp
-
-        insert_job(db, stage="waitlisted", company="Acme Corp", title="Site Lead")
-
-        popen_calls = []
-        monkeypatch.setattr(sp, "Popen", lambda args, **kw: popen_calls.append(args))
-        # Also patch subprocess in poll_flags module namespace
-        monkeypatch.setattr(poll_flags_mod.subprocess, "Popen", lambda args, **kw: popen_calls.append(args))
-
-        poll_flags_mod.notify_waitlist_resurface(db, "Acme Corp")
-        assert len(popen_calls) >= 1
-
-    def test_resurface_no_waitlisted_no_notification(self, poll_flags_mod, db, monkeypatch):
-        """No waitlisted jobs → no notification sent."""
-        import subprocess as sp
-
-        insert_job(db, stage="scored", company="Acme Corp")
-
-        popen_calls = []
-        monkeypatch.setattr(sp, "Popen", lambda args, **kw: popen_calls.append(args))
-        monkeypatch.setattr(poll_flags_mod.subprocess, "Popen", lambda args, **kw: popen_calls.append(args))
-
-        poll_flags_mod.notify_waitlist_resurface(db, "Acme Corp")
-        assert len(popen_calls) == 0

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -426,7 +426,7 @@ class TestResetPrepToScored:
         monkeypatch.setattr(utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
 
     def test_resets_stage_and_clears_folder(self, db, tmp_path, monkeypatch):
-        from findajob.utils import reset_prep_to_scored
+        from findajob.actions import reset_prep_to_scored
 
         self._redirect_log(monkeypatch, tmp_path)
         job_id = insert_job(db, stage="prep_in_progress", folder="/tmp/some/path")
@@ -444,7 +444,7 @@ class TestResetPrepToScored:
 
     def test_writes_audit_entry(self, db, tmp_path, monkeypatch):
         """CORE invariant of #172: every stage transition auditable."""
-        from findajob.utils import reset_prep_to_scored
+        from findajob.actions import reset_prep_to_scored
 
         self._redirect_log(monkeypatch, tmp_path)
         job_id = insert_job(db, stage="prep_in_progress")
@@ -464,7 +464,7 @@ class TestResetPrepToScored:
         """Operator monitoring: failure resets must be visible in pipeline.jsonl."""
         import json
 
-        from findajob.utils import reset_prep_to_scored
+        from findajob.actions import reset_prep_to_scored
 
         log_path = tmp_path / "events.jsonl"
         self._redirect_log(monkeypatch, tmp_path)
@@ -480,7 +480,7 @@ class TestResetPrepToScored:
 
     def test_guards_materials_drafted(self, db, tmp_path, monkeypatch):
         """Don't clobber a successful prep that raced in before the error path."""
-        from findajob.utils import reset_prep_to_scored
+        from findajob.actions import reset_prep_to_scored
 
         self._redirect_log(monkeypatch, tmp_path)
         job_id = insert_job(db, stage="materials_drafted", folder="/keep/me")
@@ -496,7 +496,7 @@ class TestResetPrepToScored:
 
     def test_guards_applied(self, db, tmp_path, monkeypatch):
         """Don't roll back a job the user already submitted."""
-        from findajob.utils import reset_prep_to_scored
+        from findajob.actions import reset_prep_to_scored
 
         self._redirect_log(monkeypatch, tmp_path)
         job_id = insert_job(db, stage="applied")

--- a/tests/test_web_board_dashboard.py
+++ b/tests/test_web_board_dashboard.py
@@ -43,4 +43,7 @@ def test_dashboard_shows_in_scope_jobs(client: TestClient) -> None:
     assert r.status_code == 200
     assert "Senior DC Ops" in r.text
     assert "NPI PM" in r.text
-    assert "Junior" not in r.text  # filtered out by score<7
+    # fp3 (score=3) is filtered out by score<7. Check by fingerprint — the
+    # reject-reason dropdown now contains substrings like "Too Junior" for
+    # every rendered row, so bare-word "Junior" is a false-positive signal.
+    assert 'data-fingerprint="fp3"' not in r.text

--- a/tests/test_web_board_review.py
+++ b/tests/test_web_board_review.py
@@ -33,5 +33,8 @@ def test_review_shows_manual_review_only(client: TestClient) -> None:
     r = client.get("/board/review")
     assert r.status_code == 200
     assert "Ambiguous Title" in r.text
-    assert "Other" not in r.text
+    # fp-scored isn't in manual_review, so its row should not render.
+    # Match the fingerprint attribute — "Other" as a bare word now appears in
+    # the reject-reason dropdown for every rendered row.
+    assert 'data-fingerprint="fp-scored"' not in r.text
     assert "target company bump" in r.text


### PR DESCRIPTION
## Summary

First of two PRs for #61 (web frontend 14c). Adds 11 POST handlers so the
operator can drive every STATUS + REJECT_REASON transition from the `/board/*`
pages instead of editing the Google Sheet. `scripts/poll_flags.py` is
unchanged — Sheets edits still work in parallel as a safety net. PR-B (to
follow) deletes `poll_flags.py`, stops `sync_sheet.py` from reading user
edits, drops `Ghosted`, and adds Playwright E2E coverage.

Refactor: extracted seven stage-transition helpers out of `poll_flags.py`
into `src/findajob/actions.py` so both PR-A handlers and PR-B's
`scripts/watchdog.py` can reuse them. Behavior unchanged.

## Endpoints added

| Tab            | Endpoints                                              |
|----------------|--------------------------------------------------------|
| Dashboard      | `/prep`, `/regenerate`, `/waitlist`, `/apply`, `/reject` |
| Applied        | `/interview`, `/offer`, `/withdraw`, `/not-selected`, `/reject`, `/notes` |
| Review         | `/promote`, `/reject`                                  |
| Waitlist       | `/reactivate`, `/reject`                               |

Each handler is idempotent (stage re-read before write), 404s on unknown
fingerprint, and 409s on wrong-stage where applicable (`/promote` on
non-`manual_review`, `/reactivate` on non-`waitlisted`, `/not-selected` on
pre-application stages). `/prep` and `/regenerate` share a 3-job
concurrency cap with 429 response matching `poll_flags.py`'s
`MAX_CONCURRENT_PREPS`.

## UI changes

- New `_status_cell.html` and `_reject_cell.html` partials — per-tab
  dropdowns (and buttons for single-action tabs).
- Applied-tab `user_notes` cell uses `_notes_cell.html` — HTMX debounced
  (blur + 800ms) inline edit writing directly to `jobs.user_notes`.
- `Not Selected` on the Applied STATUS dropdown sets
  `tr.dataset.pendingAction = 'not-selected'`; the Reject dropdown then
  routes to `/not-selected` instead of `/reject` — cross-cell state
  without an Alpine dependency.

## Tests

7 test classes, 65 tests in `tests/test_board_actions.py` covering:
- Happy path per endpoint (DB transitions, folder moves, marker files,
  feedback_log write-or-not invariants)
- Idempotency per endpoint
- 404 / 409 / 429 responses
- `notify_waitlist_resurface` firing on reject, not-selected, withdraw
- Concurrency cap enforcement + bypass on idempotent re-clicks

Full suite: 624/624 green. `uv run ruff check .` + `uv run mypy
src/findajob/` clean.

## Safety net

- `scripts/poll_flags.py` keeps reading the Sheet via its 10-min cron entry.
  If a handler has a bug, the operator can still drive the workflow from
  the Sheet. PR-B removes this redundancy once we've run on `:latest` for
  a day.
- `poll_flags.py` imports the moved helpers from `findajob.actions`, so the
  Sheets write path and the web write path share the same code.

## Not in this PR

- Deleting `poll_flags.py`, adding `scripts/watchdog.py`, stripping
  Sheets-read paths from `sync_sheet.py`, dropping `Ghosted`, Playwright E2E,
  and the documentation sweep — all in PR-B (labeled `migration-required`).
- Authentication / CSRF — deferred per spec §D7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)