### PR TITLE
feat(web): 14c PR-C — dashboard UX polish (#61)

### DIFF
--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -28,6 +28,8 @@ def _filter_clause(q: str) -> tuple[str, list[str]]:
 
 _DASHBOARD_COLS = [
     ("Rel", "relevance_score"),
+    ("Fit", "fit_score"),
+    ("Prob", "probability_score"),
     ("Likelihood", "interview_likelihood"),
     ("Title", "title"),
     ("Company", "company"),
@@ -50,9 +52,19 @@ def _normalize_density(raw: str) -> str:
     return raw if raw in _VALID_DENSITIES else _DEFAULT_DENSITY
 
 
+# Exclude rows whose (company, title) already has a sibling in a post-application
+# stage — dedup failures (see #13/#16/#17) otherwise surface already-applied jobs.
+# LOWER+TRIM guards against whitespace/casing differences in title ingestion.
 _DASHBOARD_WHERE = (
-    "(relevance_score >= 7 AND stage IN ('scored','manual_review'))"
-    " OR stage IN ('prep_in_progress','materials_drafted')"
+    "((relevance_score >= 7 AND stage IN ('scored','manual_review'))"
+    " OR stage IN ('prep_in_progress','materials_drafted'))"
+    " AND NOT EXISTS ("
+    "  SELECT 1 FROM jobs sib"
+    "  WHERE sib.id != jobs.id"
+    "    AND LOWER(TRIM(sib.company)) = LOWER(TRIM(jobs.company))"
+    "    AND LOWER(TRIM(sib.title)) = LOWER(TRIM(jobs.title))"
+    "    AND sib.stage IN ('applied','interview','offer','not_selected')"
+    " )"
 )
 
 
@@ -68,8 +80,9 @@ def dashboard(
     order = "DESC" if desc else "ASC"
     rows = db.execute(
         f"SELECT fingerprint, title, company, location, remote_status, known_contacts, "
-        f"comp_estimate, ai_notes, relevance_score, interview_likelihood, "
-        f"stage, created_at, stage_updated, url FROM jobs WHERE {_DASHBOARD_WHERE} "
+        f"comp_estimate, ai_notes, relevance_score, fit_score, probability_score, "
+        f"interview_likelihood, stage, created_at, stage_updated, url, prep_folder_path "
+        f"FROM jobs WHERE {_DASHBOARD_WHERE} "
         f"ORDER BY {sort_col} {order}"
     ).fetchall()
     materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
@@ -354,8 +367,9 @@ def dashboard_rows(
     filter_sql, params = _filter_clause(q)
     rows = db.execute(
         f"SELECT fingerprint, title, company, location, remote_status, known_contacts, "
-        f"comp_estimate, ai_notes, relevance_score, interview_likelihood, "
-        f"stage, created_at, stage_updated, url FROM jobs WHERE ({_DASHBOARD_WHERE}) {filter_sql} "
+        f"comp_estimate, ai_notes, relevance_score, fit_score, probability_score, "
+        f"interview_likelihood, stage, created_at, stage_updated, url, prep_folder_path "
+        f"FROM jobs WHERE ({_DASHBOARD_WHERE}) {filter_sql} "
         f"ORDER BY {sort_col} {order}",
         params,
     ).fetchall()

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -72,8 +72,9 @@ def _launch_prep_subprocess(job: sqlite3.Row) -> None:
 
 _DASHBOARD_ROW_SQL = (
     "SELECT fingerprint, title, company, location, remote_status, known_contacts, "
-    "comp_estimate, ai_notes, relevance_score, interview_likelihood, "
-    "stage, created_at, stage_updated, url FROM jobs WHERE fingerprint=?"
+    "comp_estimate, ai_notes, relevance_score, fit_score, probability_score, "
+    "interview_likelihood, stage, created_at, stage_updated, url, prep_folder_path "
+    "FROM jobs WHERE fingerprint=?"
 )
 
 

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -15,6 +15,10 @@
   {% if stage_class %}{% set _ = row_classes.append(stage_class) %}{% endif %}
 {% endif %}
 <tr class="{{ row_classes | join(' ') }}" data-fingerprint="{{ row.fingerprint }}">
+  {% if tab in ('dashboard', 'applied', 'review', 'waitlist') %}
+    {% include "board/_status_cell.html" %}
+    {% include "board/_reject_cell.html" %}
+  {% endif %}
   {% for display, field in columns %}
     {% if tab == 'applied' and field == 'user_notes' %}
       {% include "board/_notes_cell.html" %}
@@ -25,8 +29,10 @@
       <div class="cell-text-wrap" title="{{ row[field] if row[field] is not none else '' }}">
       {% if field == 'title' and row.url %}
         <a class="underline" href="{{ row.url }}" target="_blank" rel="noopener noreferrer">{{ row[field] }}</a>
-      {% elif field == 'company' and tab == 'applied' and row.fingerprint and row.stage in folder_stages and materials_base_url %}
+      {% elif field == 'company' and row.fingerprint and row.stage in folder_stages and materials_base_url %}
         <a class="underline" href="{{ materials_base_url }}/materials/{{ row.fingerprint }}">{{ row[field] }}</a>
+      {% elif field in ('fit_score', 'probability_score') and row[field] is not none %}
+        {{ row[field] | round | int }}
       {% else %}
         {{ row[field] }}
       {% endif %}
@@ -34,8 +40,4 @@
     </td>
     {% endif %}
   {% endfor %}
-  {% if tab in ('dashboard', 'applied', 'review', 'waitlist') %}
-    {% include "board/_status_cell.html" %}
-    {% include "board/_reject_cell.html" %}
-  {% endif %}
 </tr>

--- a/src/findajob/web/templates/base.html
+++ b/src/findajob/web/templates/base.html
@@ -10,7 +10,7 @@
 </head>
 <body class="bg-slate-50 text-slate-900" hx-boost="true">
   {% block nav %}{% include "_nav.html" %}{% endblock %}
-  <main class="max-w-6xl mx-auto px-4 py-6">
+  <main class="{% block main_classes %}max-w-6xl mx-auto px-4 py-6{% endblock %}">
     {% if _rendered_md is defined and _rendered_md %}<div class="prose prose-slate max-w-none">{{ _rendered_md | safe }}</div>{% endif %}
     {% block content %}{% endblock %}
     {% block body %}{% endblock %}

--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -9,27 +9,29 @@
 {% set stage = row.stage %}
 <td class="px-3 py-1 align-top text-sm whitespace-nowrap">
   {% if tab == 'dashboard' %}
-    {% if stage == 'prep_in_progress' %}
-      <div class="mb-1 text-xs text-slate-500">Prep in progress…</div>
-    {% elif stage == 'materials_drafted' %}
-      <div class="mb-1 text-xs font-medium text-emerald-700">Ready to Apply</div>
-    {% endif %}
-    <select
-      class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
-      data-fp="{{ fp }}"
-      onchange="if(this.value){htmx.ajax('POST', `/board/jobs/{{ fp }}/${this.value}`, {target: this.closest('tr'), swap: 'outerHTML'});this.value='';}">
-      <option value="">— Change status —</option>
-      {% if stage in ('scored', 'manual_review') %}
-        <option value="prep">Flag for Prep</option>
+    <div class="flex items-center gap-2">
+      {% if stage == 'prep_in_progress' %}
+        <span class="text-xs text-slate-500" title="Prep subprocess running">Prep…</span>
+      {% elif stage == 'materials_drafted' %}
+        <span class="text-xs font-medium text-emerald-700" title="Materials drafted — ready to apply">Ready</span>
       {% endif %}
-      {% if stage in ('prep_in_progress', 'materials_drafted') %}
-        <option value="regenerate">Regenerate</option>
-      {% endif %}
-      <option value="waitlist">Waitlist</option>
-      {% if stage == 'materials_drafted' %}
-        <option value="apply">Applied</option>
-      {% endif %}
-    </select>
+      <select
+        class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+        data-fp="{{ fp }}"
+        onchange="if(this.value){htmx.ajax('POST', `/board/jobs/{{ fp }}/${this.value}`, {target: this.closest('tr'), swap: 'outerHTML'});this.value='';}">
+        <option value="">— Change status —</option>
+        {% if stage in ('scored', 'manual_review') %}
+          <option value="prep">Flag for Prep</option>
+        {% endif %}
+        {% if stage in ('prep_in_progress', 'materials_drafted') %}
+          <option value="regenerate">Regenerate</option>
+        {% endif %}
+        <option value="waitlist">Waitlist</option>
+        {% if stage == 'materials_drafted' %}
+          <option value="apply">Applied</option>
+        {% endif %}
+      </select>
+    </div>
   {% elif tab == 'applied' %}
     {% if stage == 'not_selected' %}
       <span class="text-xs text-slate-500">Not Selected</span>

--- a/src/findajob/web/templates/board/applied.html
+++ b/src/findajob/web/templates/board/applied.html
@@ -1,11 +1,14 @@
 {% extends "base.html" %}
 {% block title %}Applied — findajob{% endblock %}
+{% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Applied</h1>
 {% include "_filters.html" ignore missing %}
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
     <tr>
+      <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
       {% for display, field in columns %}
       <th class="px-3 py-2">
         <a href="?sort={{ field }}&desc={% if sort == field and desc %}0{% else %}1{% endif %}">
@@ -13,8 +16,6 @@
         </a>
       </th>
       {% endfor %}
-      <th class="px-3 py-2">Status</th>
-      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">

--- a/src/findajob/web/templates/board/dashboard.html
+++ b/src/findajob/web/templates/board/dashboard.html
@@ -1,11 +1,14 @@
 {% extends "base.html" %}
 {% block title %}Dashboard — findajob{% endblock %}
+{% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
 {% include "_filters.html" ignore missing %}
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
     <tr>
+      <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
       {% for display, field in columns %}
       <th class="px-3 py-2">
         <a href="?sort={{ field }}&desc={% if sort == field and desc %}0{% else %}1{% endif %}">
@@ -13,8 +16,6 @@
         </a>
       </th>
       {% endfor %}
-      <th class="px-3 py-2">Status</th>
-      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">

--- a/src/findajob/web/templates/board/review.html
+++ b/src/findajob/web/templates/board/review.html
@@ -1,11 +1,14 @@
 {% extends "base.html" %}
 {% block title %}Review — findajob{% endblock %}
+{% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Review</h1>
 {% include "_filters.html" ignore missing %}
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
     <tr>
+      <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
       {% for display, field in columns %}
       <th class="px-3 py-2">
         <a href="?sort={{ field }}&desc={% if sort == field and desc %}0{% else %}1{% endif %}">
@@ -13,8 +16,6 @@
         </a>
       </th>
       {% endfor %}
-      <th class="px-3 py-2">Status</th>
-      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">

--- a/src/findajob/web/templates/board/waitlist.html
+++ b/src/findajob/web/templates/board/waitlist.html
@@ -1,11 +1,14 @@
 {% extends "base.html" %}
 {% block title %}Waitlist — findajob{% endblock %}
+{% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Waitlist</h1>
 {% include "_filters.html" ignore missing %}
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
     <tr>
+      <th class="px-3 py-2">Status</th>
+      <th class="px-3 py-2">Reject</th>
       {% for display, field in columns %}
       <th class="px-3 py-2">
         <a href="?sort={{ field }}&desc={% if sort == field and desc %}0{% else %}1{% endif %}">
@@ -13,8 +16,6 @@
         </a>
       </th>
       {% endfor %}
-      <th class="px-3 py-2">Status</th>
-      <th class="px-3 py-2">Reject</th>
     </tr>
   </thead>
   <tbody id="rows">

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -32,6 +32,8 @@ CREATE TABLE jobs (
     comp_estimate TEXT DEFAULT '',
     ai_notes TEXT,
     relevance_score INTEGER,
+    fit_score REAL,
+    probability_score REAL,
     interview_likelihood INTEGER,
     score_status TEXT,
     score_flag_reason TEXT,
@@ -195,8 +197,8 @@ class TestPrep:
         # HTMX swaps a <tr> — the response should be a table row, not the full page
         assert response.text.strip().startswith("<tr")
         assert 'data-fingerprint="fp_scored"' in response.text
-        # After the transition the row shows the Prep in progress indicator
-        assert "Prep in progress" in response.text
+        # After the transition the row shows the Prep indicator badge
+        assert 'title="Prep subprocess running"' in response.text
 
     def test_404_on_unknown_fingerprint(self, client: TestClient, popen_calls):
         response = client.post("/board/jobs/fp_nonexistent/prep")

--- a/tests/test_web_board_dashboard.py
+++ b/tests/test_web_board_dashboard.py
@@ -14,10 +14,10 @@ def client(tmp_path: Path) -> TestClient:
     db = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db)
     conn.execute(
-        "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "relevance_score INTEGER, interview_likelihood INTEGER, "
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, interview_likelihood INTEGER, "
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
-        "ai_notes TEXT, created_at TEXT, stage_updated TEXT, url TEXT)"
+        "ai_notes TEXT, created_at TEXT, stage_updated TEXT, url TEXT, prep_folder_path TEXT)"
     )
     conn.execute(
         "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score, url) "

--- a/tests/test_web_board_filter.py
+++ b/tests/test_web_board_filter.py
@@ -14,9 +14,10 @@ def client(tmp_path: Path) -> TestClient:
     db = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db)
     conn.execute(
-        "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "relevance_score INTEGER, interview_likelihood INTEGER, location TEXT, remote_status TEXT, "
-        "known_contacts TEXT, comp_estimate TEXT, ai_notes TEXT, url TEXT, created_at TEXT, stage_updated TEXT)"
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, interview_likelihood INTEGER, "
+        "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
+        "ai_notes TEXT, url TEXT, created_at TEXT, stage_updated TEXT, prep_folder_path TEXT)"
     )
     for fp, title, company in [
         ("fp1", "NPI PM", "Meta"),

--- a/tests/test_web_board_sort.py
+++ b/tests/test_web_board_sort.py
@@ -14,11 +14,11 @@ def client(tmp_path: Path) -> TestClient:
     db = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db)
     conn.execute(
-        "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "relevance_score INTEGER, interview_likelihood INTEGER, "
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, interview_likelihood INTEGER, "
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
         "ai_notes TEXT, user_notes TEXT, score_flag_reason TEXT, source TEXT, url TEXT, "
-        "created_at TEXT, stage_updated TEXT)"
+        "created_at TEXT, stage_updated TEXT, prep_folder_path TEXT)"
     )
     conn.execute(
         "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "

--- a/tests/test_web_nav.py
+++ b/tests/test_web_nav.py
@@ -14,11 +14,11 @@ def client(tmp_path: Path) -> TestClient:
     db = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db)
     conn.execute(
-        "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
         "fit_score REAL, probability_score REAL, relevance_score INTEGER, interview_likelihood INTEGER, "
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
         "ai_notes TEXT, user_notes TEXT, score_flag_reason TEXT, source TEXT, url TEXT, "
-        "created_at TEXT, stage_updated TEXT)"
+        "created_at TEXT, stage_updated TEXT, prep_folder_path TEXT)"
     )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary

Six dashboard/board UX polish items on top of PR-B. All surfaced during the PR-B post-merge smoke test (see screenshots attached to PR #179 review thread).

## What changed

1. **STATUS + REJECT as cols 1–2 on every tab.** Matches Sheet layout (col A/B) — preserves muscle memory after the Sheets-to-web pivot. Task #21.
2. **Dashboard gains Fit + Prob columns.** The 1-100 post-prep scores from fit_analyst render next to the Rel/Likelihood scorer outputs. Blank until prep completes. Task #18.
3. **Dashboard excludes sibling-applied jobs.** \`NOT EXISTS\` subquery on \`LOWER(TRIM(company))\` + \`LOWER(TRIM(title))\` tuple guards against dedup bugs (#13/#16/#17 in task list) surfacing already-applied roles. Task #15.
4. **"Ready to Apply" / "Prep…" labels inline with dropdown.** Was stacked above, making those rows taller than neighbors. Flex container; labels shortened to \`Ready\` / \`Prep…\` with tooltips. Task #14.
5. **Company cell hyperlinks to \`/materials/{fp}\` on every tab** (was Applied-only) when a prep folder exists and \`FINDAJOB_MATERIALS_BASE_URL\` is set. Task #20.
6. **Board pages go full-bleed.** \`base.html\` gains a \`main_classes\` block; board tabs override to \`w-full\` so tables use the full viewport instead of the max-w-6xl centered column. Task #22.

## Test plan

- [x] \`uv run pytest tests/ -v\` — 613 passed
- [x] \`uv run ruff check .\` + \`ruff format --check\` — clean
- [x] \`uv run mypy src/findajob/\` — clean
- [ ] CI green
- [ ] Post-merge smoke: take screenshots of Dashboard + Applied + Review + Waitlist, confirm STATUS/REJECT at left, Fit+Prob render on Dashboard, Nscale Director of Lab Services (already-applied sibling) stays hidden

## Not in this PR

Known data bugs that need their own investigation (tracked in local task list — will file as GitHub issues if the user wants):
- #13/#16/#17 — fingerprint collision + cross-source dedup + clean_title whitespace
- #19 — .docx download blocking (Chrome insecure origin + Content-Disposition)

These are all dedup/ingest issues, not display issues. Current PR masks their symptoms on Dashboard via the sibling-applied filter; root cause fixes come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)