### PR TITLE
feat(14d): web form replaces Google Form for manual JD ingest (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,19 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 ### Added
 
 - **Web UI is now the primary write surface for the board.** Every STATUS and REJECT_REASON action that previously required editing the Google Sheet — Flag for Prep, Applied, Interviewing, Offer, Withdrew, Not Selected, Waitlist, Reactivate, Promote, Regenerate, Reject — now has a POST handler at `/board/jobs/{fingerprint}/{action}`, wired up to Alpine-flavored HTMX dropdowns on each board tab. The Applied tab's `user_notes` column edits through `POST /board/jobs/{fingerprint}/notes` with an 800ms debounce (#61 PR-A).
+- **Manual JD ingest moved from Google Form to web UI.** The new `/ingest/` page replaces the Google Form + `scripts/ingest_form.py` polling loop — paste company / title / URL / full JD text and the row lands on the Dashboard at `stage=scored`, `relevance_score=8`, `source='web_manual'`. The full-JD-text field is required, which covers JS-rendered SPAs and auth-walled postings that scrape poorly (absorbs #79); `prep_application.py` uses the pasted JD directly and skips URL refetch. A "Generate prep folder immediately" checkbox dispatches `prep_application.py` subject to the same 3-job concurrency cap as the Dashboard's Flag-for-Prep button. The form template includes a disabled Speculative-mode tab linking to #131 for the follow-up cold-outreach flow (#62).
 
 ### Changed
 
 - **Google Sheet is now one-way (DB → Sheet).** `sync_sheet.py` no longer reads user edits back from any tab; the four `values().get()` calls (Dashboard, Applied, Review, Waitlist) are deleted, along with the `pending_statuses` / `pending_rejects` / `pending_notes` preservation logic. The Sheet remains available as a read-only synced view; operators drive the pipeline from `/board/*` in the web UI (#61 PR-B).
 - **`poll_flags.py` removed; replaced by `scripts/watchdog.py`.** The 10-minute cron's only remaining responsibility is to roll stuck `prep_in_progress` jobs back to `scored` after 60 min. Every transition handler (handle_rejection, handle_not_selected, handle_waitlist, handle_reactivate, promote_to_scored, notify_waitlist_resurface, reset_prep_to_scored) now lives in `src/findajob/actions.py` and is called from `findajob.web.routes.board_actions` (#61 PR-B).
 - **Applied tab drops the `Ghosted` status option.** With the Sheet no longer preserving user-only flags across syncs, the existing 21-day row-age gray-coloring rule replaces it. Operators who want to act on a quiet row flip to `Not Selected` (#61 PR-B).
+- **`scripts/ingest_form.py` timer retired.** The `*/30` crontab entry is commented out; the script is kept in place as a manual-run fallback for draining any leftover Google Form responses until the Form itself is decommissioned. New submissions should use the `/ingest/` web form (#62).
 
 ### Migration required
 
 - Crontab entry changes from `scripts/poll_flags.py` to `scripts/watchdog.py`. Operators pulling `:latest` pick up the swap automatically at container restart — no manual action needed. Sheet edits made during the pull window (if any) are ignored; operators should use the web UI for any queued transitions.
+- `*/30 ingest_form.py` entry in `ops/crontab` is commented out; operators pulling `:latest` stop seeing the 30-min Google Form poll at container restart. The `/ingest/` web form replaces it. No state migration required — existing `manual_form`-source rows keep their semantics, new rows land as `web_manual` (#62).
 - `jobs` gains a nullable `loose_fingerprint TEXT` column and `idx_jobs_loose_fingerprint` index for Tier 2 dedup (#182). Fresh deploys get the column from `scripts/init_db.py` on first container start. Existing stacks must run `python3 scripts/migrate_add_loose_fingerprint.py` once after pulling `:latest` — the script is idempotent, backfills existing rows by recomputing `loose_fingerprint(title, company)`, and preserves all other state.
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,10 +130,12 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 <repo>/src/findajob/paths.py                # central path resolver — from findajob.paths import BASE, AICHAT, PANDOC
 <repo>/src/findajob/utils.py                # shared utilities: log_event(), write_audit(), load_env()
 <repo>/src/findajob/cleaning.py             # normalize, fingerprint, clean_title, clean_company
+<repo>/src/findajob/ingest.py               # ingest_manual_job() — shared entry point for the /ingest/ web form (#62)
 <repo>/src/findajob/fetchers.py             # Greenhouse, RapidAPI, Gmail job fetching
 <repo>/src/findajob/scoring.py              # score_job(), _build_feedback_block()
 <repo>/src/findajob/scorer_prefilter.py     # deterministic pre-filter (Stage 1 + 2)
 <repo>/src/findajob/web/app.py               # FastAPI app factory (create_app)
+<repo>/src/findajob/web/routes/ingest.py     # GET /ingest/ form + POST /ingest/manual handler
 <repo>/src/findajob/web/routes.py            # /healthz, /folders/<stage>/<name>/*, /files/* routes
 <repo>/src/findajob/web/folder_resolver.py   # resolves stage→filesystem path, path-traversal guards
 <repo>/src/findajob/web/templates/           # Jinja2 templates (index.html, folder.html, viewer.html)
@@ -145,7 +147,7 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 <repo>/scripts/setup_sheets.py             # one-time sheet formatting (idempotent)
 <repo>/scripts/prep_application.py          # on-demand LLM material generation
 <repo>/scripts/find_contacts.py             # LinkedIn contact matching + outreach drafts
-<repo>/scripts/ingest_form.py               # Google Form → DB ingestion
+<repo>/scripts/ingest_form.py               # Google Form → DB ingestion (retired: timer disabled in #62; kept for manual runs)
 <repo>/scripts/notify.py                    # ntfy push notifications (8 subcommands incl. send-raw, scoreboard)
 <repo>/scripts/rename_folders.py            # rename company folders to new format (idempotent)
 
@@ -268,9 +270,11 @@ return zero LinkedIn results. Validate each query manually before committing.
 
 > **Web UI is the write surface.** As of #61 PR-B, `sync_sheet.py` writes DB
 > state to the Sheet one-way and never reads from it. Operators drive every
-> STATUS + REJECT_REASON transition through `/board/*`. The Sheet remains as
-> a read-only synced view for mobile/glance use; `sync_sheet.py` retires in
-> 14d (#14). Sheet1 is already superseded by `/board/archive` (#60).
+> STATUS + REJECT_REASON transition through `/board/*`. As of #62 (14d), the
+> `/ingest/` web form replaces the Google Form + `ingest_form.py` poll loop.
+> The Sheet remains a read-only synced view for mobile/glance use until
+> `sync_sheet.py` itself is retired — the remaining step under the parent
+> #14. Sheet1 is already superseded by `/board/archive` (#60).
 
 **Sheet1** — filtered archive (A–N), archival filter:
 Jobs appear if: `score>=5` OR `stage in lifecycle stages` OR `age < 14 days` OR `target company`.

--- a/docs/scripts-reference.md
+++ b/docs/scripts-reference.md
@@ -121,17 +121,13 @@ Reads `data/connections.csv`, finds LinkedIn connections at the target company, 
 
 ---
 
-### `ingest_form.py`
-**Run by:** scheduler (every 30 min)
+### `ingest_form.py` (retired)
+**Run by:** manually, only. Scheduled timer removed in #62.
 **No arguments.**
 
-Polls the Google Form responses sheet for new rows. For each unprocessed row:
-1. Creates a fingerprint from `url|company|title`
-2. Deduplicates against existing DB jobs
-3. Inserts as `source='manual_form'`, `stage='scored'`, `relevance_score=8`
-4. Writes 'Processed: {timestamp}' to col J in the responses sheet
-5. If "Generate folder" column = yes/y/true → calls `prep_application.py`
-6. Calls `sync_sheet.py` after all ingestions
+Superseded by the `/ingest/` web form (`src/findajob/web/routes/ingest.py`), which is now the operator write surface for manual job submissions. New submissions use `source='web_manual'`.
+
+The script is kept in place as a manual-run fallback in case any Google Form responses need to be drained after the web form ships; it still polls the Form responses sheet and writes rows with `source='manual_form'`. It can be removed once the Google Form is fully decommissioned.
 
 ---
 

--- a/docs/setup/state-migration.md
+++ b/docs/setup/state-migration.md
@@ -173,7 +173,7 @@ Once the validation triage passes:
 # Enable all systemd timers
 systemctl --user enable --now findajob-triage.timer
 systemctl --user enable --now findajob-poller.timer
-systemctl --user enable --now findajob-form-ingest.timer
+# findajob-form-ingest.timer retired in #62 — the /ingest/ web UI replaces it.
 systemctl --user enable --now findajob-notify-stats.timer
 systemctl --user enable --now findajob-notify-health.timer
 systemctl --user enable --now findajob-notify-issues.timer

--- a/ops/crontab
+++ b/ops/crontab
@@ -11,7 +11,10 @@ PYTHONUNBUFFERED=1
 # ── Ingest + scoring ─────────────────────────────────────────────────────────
 0    0   *  *  *   timeout ${FINDAJOB_TRIAGE_TIMEOUT:-7200} python3 /app/scripts/triage.py
 */10 *   *  *  *   timeout 900 python3 /app/scripts/watchdog.py
-*/30 *   *  *  *   python3 /app/scripts/ingest_form.py
+# Google Form ingest retired in #62 — the /ingest/ web form is the operator
+# write surface now. Script kept for ad-hoc manual runs until the Google
+# Form is fully decommissioned.
+# */30 *   *  *  *   python3 /app/scripts/ingest_form.py
 
 # ── Notifications ────────────────────────────────────────────────────────────
 0    6   *  *  *        python3 /app/scripts/notify.py apply-reminder

--- a/src/findajob/ingest.py
+++ b/src/findajob/ingest.py
@@ -1,0 +1,187 @@
+"""Shared manual-ingest helper — the one place that turns a (company, title,
+url, jd, ...) tuple from an operator into a row in ``jobs``.
+
+Used by ``src/findajob/web/routes/ingest.py`` — the `/ingest/manual` web
+form (#62). The legacy ``scripts/ingest_form.py`` Google-Form polling
+loop still carries its own inline ingest logic; its timer was disabled
+in #62 and the script is kept around only as a frozen manual-run fallback
+until the Google Form is fully retired.
+
+Behavior:
+
+- Cleans title/company via ``findajob.cleaning``.
+- Computes strict + loose fingerprints and runs the same two-tier dedup
+  ``scripts/triage.py`` uses: strict ``fingerprint`` → URL fallback →
+  ``loose_fingerprint`` when either side has a coarse location (#182).
+- Inserts with ``stage='scored'``, ``relevance_score=8``, ``apply_flag=0``.
+  Writes ``raw_jd_text`` when provided, so ``prep_application.py`` uses
+  the pasted JD directly and never re-curls the URL (#79 absorption).
+- When ``generate_folder=True``, launches ``prep_application.py`` via
+  ``subprocess.Popen(start_new_session=True)`` so the caller returns
+  immediately.
+
+The caller decides the ``source`` label — ``'web_manual'`` for the web
+form, distinct from the legacy script's ``'manual_form'`` so the two
+paths stay distinguishable in ``jobs.source`` post-retirement.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from findajob.cleaning import (
+    clean_company,
+    clean_title,
+    fingerprint,
+    is_coarse_location,
+    loose_fingerprint,
+)
+from findajob.paths import BASE
+from findajob.utils import log_event
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Outcome of a single ``ingest_manual_job`` call.
+
+    - ``status="ingested"``: new row inserted; ``job_id`` is the new id.
+    - ``status="duplicate"``: existing row matched; ``job_id`` is the
+      pre-existing id, ``existing_match`` names the tier that matched
+      ("strict" / "url" / "loose").
+    """
+
+    status: Literal["ingested", "duplicate"]
+    job_id: str
+    company: str
+    title: str
+    existing_match: str | None = None
+    prep_launched: bool = False
+
+
+def ingest_manual_job(
+    conn: sqlite3.Connection,
+    *,
+    company: str,
+    title: str,
+    url: str,
+    location: str = "",
+    remote_status: str = "Unknown",
+    notes: str = "",
+    known_contacts: str = "",
+    raw_jd_text: str = "",
+    generate_folder: bool = False,
+    source: str,
+) -> IngestResult:
+    """Insert one manually-submitted job into ``jobs`` (or report a dup).
+
+    ``conn`` is committed on insert; no commit on duplicate.
+
+    Inputs are trimmed; ``title`` and ``company`` pass through
+    ``clean_title`` / ``clean_company`` so fingerprints line up with
+    automated-ingest rows for the same posting.
+    """
+    company = clean_company(company.strip())
+    title = clean_title(title.strip())
+    url = url.strip()
+    location = location.strip()
+    remote_status = remote_status.strip() or "Unknown"
+    notes = notes.strip()
+    known_contacts = known_contacts.strip()
+    raw_jd_text = raw_jd_text.strip()
+
+    fp = fingerprint(title, company, location)
+    lfp = loose_fingerprint(title, company)
+
+    existing = conn.execute("SELECT id FROM jobs WHERE fingerprint=?", (fp,)).fetchone()
+    matched_tier: str | None = "strict" if existing else None
+
+    if not existing and url:
+        existing = conn.execute("SELECT id FROM jobs WHERE url=?", (url,)).fetchone()
+        if existing:
+            matched_tier = "url"
+
+    if not existing:
+        incoming_coarse = is_coarse_location(location)
+        for row in conn.execute("SELECT id, location FROM jobs WHERE loose_fingerprint=?", (lfp,)).fetchall():
+            if incoming_coarse or is_coarse_location(row["location"] or ""):
+                existing = row
+                matched_tier = "loose"
+                break
+
+    if existing:
+        return IngestResult(
+            status="duplicate",
+            job_id=existing["id"],
+            company=company,
+            title=title,
+            existing_match=matched_tier,
+        )
+
+    now = datetime.now(UTC).isoformat()
+    job_id = f"{source}-{fp}"
+
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            id, fingerprint, loose_fingerprint, url, title, company, location,
+            source, raw_jd_text, remote_status, known_contacts, ai_notes,
+            relevance_score, stage, apply_flag,
+            created_at, updated_at, dupe_of
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 8, 'scored', 0, ?, ?, '')
+        """,
+        (
+            job_id,
+            fp,
+            lfp,
+            url,
+            title,
+            company,
+            location,
+            source,
+            raw_jd_text or None,
+            remote_status,
+            known_contacts,
+            notes,
+            now,
+            now,
+        ),
+    )
+    conn.commit()
+
+    log_event(
+        "manual_job_ingested",
+        job_id=job_id,
+        source=source,
+        company=company,
+        title=title,
+        url=url,
+        has_jd=bool(raw_jd_text),
+    )
+
+    prep_launched = False
+    if generate_folder:
+        subprocess.Popen(
+            [
+                sys.executable,
+                f"{BASE}/scripts/prep_application.py",
+                company,
+                title,
+                url,
+                job_id,
+            ],
+            start_new_session=True,
+        )
+        prep_launched = True
+
+    return IngestResult(
+        status="ingested",
+        job_id=job_id,
+        company=company,
+        title=title,
+        prep_launched=prep_launched,
+    )

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter
 
-from findajob.web.routes import board, board_actions, healthz, landing, materials
+from findajob.web.routes import board, board_actions, healthz, ingest, landing, materials
 
 router = APIRouter()
 router.include_router(materials.router)
@@ -10,3 +10,4 @@ router.include_router(healthz.router)
 router.include_router(landing.router)
 router.include_router(board.router)
 router.include_router(board_actions.router)
+router.include_router(ingest.router)

--- a/src/findajob/web/routes/ingest.py
+++ b/src/findajob/web/routes/ingest.py
@@ -1,0 +1,136 @@
+"""Manual JD ingest form — the web write surface that retires the Google
+Form polling loop (#62).
+
+``GET /ingest/`` renders the form; ``POST /ingest/manual`` writes straight
+into ``jobs`` via :func:`findajob.ingest.ingest_manual_job` and returns an
+HTMX partial for the result panel.
+
+The form mode toggle at the top of the page scaffolds #131's Speculative
+flow: the "Real posting" tab is active, the "Speculative" tab is disabled
+with a link to #131 so the eventual POST sibling drops in without a
+template rewrite.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse
+
+from findajob.ingest import IngestResult, ingest_manual_job
+from findajob.web.routes.materials import get_db
+
+router = APIRouter()
+
+_MAX_CONCURRENT_PREPS = 3
+"""Mirrors ``board_actions.MAX_CONCURRENT_PREPS`` — a manual-form submission
+with "generate folder" checked obeys the same cap as a Dashboard Flag-for-Prep
+click, so the operator can't bypass the LLM-cost backstop by ingesting
+twenty postings in a row with the checkbox on.
+"""
+
+
+@router.get("/ingest/", response_class=HTMLResponse)
+def ingest_page(request: Request) -> HTMLResponse:
+    """Render the manual-JD form."""
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="ingest/form.html",
+        context={},
+    )
+
+
+@router.post("/ingest/manual", response_class=HTMLResponse)
+def submit_manual(
+    request: Request,
+    company: str = Form(...),
+    title: str = Form(...),
+    url: str = Form(...),
+    raw_jd_text: str = Form(...),
+    location: str = Form(""),
+    remote_status: str = Form("Unknown"),
+    notes: str = Form(""),
+    known_contacts: str = Form(""),
+    generate_folder: bool = Form(False),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Ingest a manually-pasted JD. Returns an HTMX result partial."""
+    missing = [
+        name
+        for name, value in (
+            ("company", company),
+            ("title", title),
+            ("url", url),
+            ("full JD text", raw_jd_text),
+        )
+        if not value.strip()
+    ]
+    if missing:
+        return _render_result(
+            request,
+            outcome="error",
+            message=f"Missing required field(s): {', '.join(missing)}.",
+        )
+
+    prep_deferred = False
+    if generate_folder:
+        in_flight = db.execute("SELECT COUNT(*) FROM jobs WHERE stage='prep_in_progress'").fetchone()[0]
+        if in_flight >= _MAX_CONCURRENT_PREPS:
+            generate_folder = False
+            prep_deferred = True
+
+    result: IngestResult = ingest_manual_job(
+        db,
+        company=company,
+        title=title,
+        url=url,
+        location=location,
+        remote_status=remote_status,
+        notes=notes,
+        known_contacts=known_contacts,
+        raw_jd_text=raw_jd_text,
+        generate_folder=generate_folder,
+        source="web_manual",
+    )
+
+    if result.status == "duplicate":
+        return _render_result(
+            request,
+            outcome="duplicate",
+            message=(
+                f"Already in DB: {result.company} / {result.title} "
+                f"(matched by {result.existing_match}). No new row created."
+            ),
+            result=result,
+        )
+
+    message_parts = [f"Ingested: {result.company} / {result.title}."]
+    if result.prep_launched:
+        message_parts.append("Prep folder generation started.")
+    if prep_deferred:
+        message_parts.append(
+            f"Prep queue is full ({_MAX_CONCURRENT_PREPS} in flight); flag from the dashboard once one completes."
+        )
+    return _render_result(
+        request,
+        outcome="success",
+        message=" ".join(message_parts),
+        result=result,
+    )
+
+
+def _render_result(
+    request: Request,
+    *,
+    outcome: str,
+    message: str,
+    result: IngestResult | None = None,
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="ingest/_result.html",
+        context={"outcome": outcome, "message": message, "result": result},
+    )

--- a/src/findajob/web/routes/landing.py
+++ b/src/findajob/web/routes/landing.py
@@ -43,7 +43,7 @@ def landing(
 
 
 _PLACEHOLDERS = [
-    ("/ingest/", "Ingest", "Manual job form and synthetic JD submission.", "#79"),
+    # /ingest/ promoted to a real route in src/findajob/web/routes/ingest.py (#62).
     ("/tools/", "Tools", "Doctor, stats, scoreboard.", ""),
     ("/config/", "Config", "Roles, prefilter rules, feedback tuning.", ""),
     ("/docs/", "Docs", "User-facing documentation.", ""),

--- a/src/findajob/web/templates/ingest/_result.html
+++ b/src/findajob/web/templates/ingest/_result.html
@@ -1,0 +1,15 @@
+{# Ingest submit result partial — swapped into #ingest-result by HTMX. #}
+{% set styles = {
+  "success": "border-emerald-300 bg-emerald-50 text-emerald-900",
+  "duplicate": "border-amber-300 bg-amber-50 text-amber-900",
+  "error": "border-red-300 bg-red-50 text-red-900",
+} %}
+<div data-outcome="{{ outcome }}"
+     class="border rounded p-3 text-sm {{ styles.get(outcome, 'border-slate-300 bg-slate-50 text-slate-900') }}">
+  <p>{{ message }}</p>
+  {% if outcome == "success" %}
+    <p class="mt-2">
+      <a href="/board/dashboard" class="underline font-medium">View on Dashboard</a>
+    </p>
+  {% endif %}
+</div>

--- a/src/findajob/web/templates/ingest/form.html
+++ b/src/findajob/web/templates/ingest/form.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+{% block title %}findajob — ingest{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-1">Ingest a job</h1>
+<p class="text-sm text-slate-600 mb-4">
+  Paste a job description directly into the pipeline. Rows land on the
+  Dashboard at <code class="bg-slate-100 px-1 rounded">stage=scored</code>
+  with <code class="bg-slate-100 px-1 rounded">relevance_score=8</code>,
+  the same as the old Google Form.
+</p>
+
+{# Mode toggle. Speculative (#131) slots in here later. #}
+<div class="flex gap-2 mb-6 border-b border-slate-200">
+  <button type="button"
+          class="px-3 py-2 text-sm font-medium border-b-2 border-slate-800 text-slate-900"
+          aria-current="page">
+    Real posting
+  </button>
+  <button type="button"
+          class="px-3 py-2 text-sm font-medium border-b-2 border-transparent text-slate-400 cursor-not-allowed"
+          disabled
+          title="Speculative company briefing — coming in #131">
+    Speculative &middot; <span class="text-xs">#131</span>
+  </button>
+</div>
+
+<form id="manual-ingest-form"
+      hx-post="/ingest/manual"
+      hx-target="#ingest-result"
+      hx-swap="innerHTML"
+      hx-on::after-request="if (event.detail.successful && event.detail.xhr.responseText.includes('data-outcome=&quot;success&quot;')) this.reset()"
+      class="space-y-4 max-w-3xl">
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <label class="block">
+      <span class="text-sm font-medium text-slate-700">Company <span class="text-red-600">*</span></span>
+      <input type="text" name="company" required autocomplete="off"
+             class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+    </label>
+    <label class="block">
+      <span class="text-sm font-medium text-slate-700">Title <span class="text-red-600">*</span></span>
+      <input type="text" name="title" required autocomplete="off"
+             class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+    </label>
+  </div>
+
+  <label class="block">
+    <span class="text-sm font-medium text-slate-700">URL <span class="text-red-600">*</span></span>
+    <input type="url" name="url" required placeholder="https://…" autocomplete="off"
+           class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+    <span class="text-xs text-slate-500 mt-1 block">Even for auth-walled listings, paste the URL you saw the posting at — it shows up in the Dashboard cell and outreach drafts.</span>
+  </label>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <label class="block">
+      <span class="text-sm font-medium text-slate-700">Location</span>
+      <input type="text" name="location" placeholder="Remote / Menlo Park, CA / Los Angeles, CA"
+             class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+    </label>
+    <label class="block">
+      <span class="text-sm font-medium text-slate-700">Remote status</span>
+      <select name="remote_status"
+              class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+        <option value="Unknown">Unknown</option>
+        <option value="Remote">Remote</option>
+        <option value="Hybrid">Hybrid</option>
+        <option value="On-site">On-site</option>
+      </select>
+    </label>
+  </div>
+
+  <label class="block">
+    <span class="text-sm font-medium text-slate-700">Full JD text <span class="text-red-600">*</span></span>
+    <textarea name="raw_jd_text" required rows="12"
+              placeholder="Paste the full job description here. Supports JS-rendered SPAs and auth-walled postings — prep_application.py will use this directly instead of re-fetching the URL."
+              class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 font-mono text-xs"></textarea>
+  </label>
+
+  <label class="block">
+    <span class="text-sm font-medium text-slate-700">Notes / why interested</span>
+    <textarea name="notes" rows="2"
+              class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm"></textarea>
+  </label>
+
+  <label class="block">
+    <span class="text-sm font-medium text-slate-700">Known contacts</span>
+    <input type="text" name="known_contacts" placeholder="First Last · First Last …"
+           class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+  </label>
+
+  <label class="flex items-center gap-2 pt-2">
+    <input type="checkbox" name="generate_folder" value="true"
+           class="rounded border-slate-300 text-slate-800 focus:ring-slate-500">
+    <span class="text-sm text-slate-700">
+      Generate prep folder immediately
+      <span class="text-slate-500">(runs resume/cover/outreach drafts now; otherwise flag from the Dashboard later)</span>
+    </span>
+  </label>
+
+  <div class="flex items-center gap-3 pt-2">
+    <button type="submit"
+            class="bg-slate-800 text-white text-sm font-medium rounded px-4 py-2 hover:bg-slate-700">
+      Ingest
+    </button>
+    <span class="text-xs text-slate-500 htmx-indicator">Submitting…</span>
+  </div>
+</form>
+
+<div id="ingest-result" class="mt-6 max-w-3xl"></div>
+{% endblock %}

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,189 @@
+"""Unit tests for :func:`findajob.ingest.ingest_manual_job`.
+
+The helper is the shared entry point for manual ingest (web form #62 + the
+legacy Google-Form script). Tests cover fresh inserts, all three dedup
+tiers (strict / url / loose), raw_jd_text storage, and the optional
+generate_folder subprocess launch.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from findajob import ingest as ingest_mod
+from findajob import utils as findajob_utils
+
+SCHEMA = """
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    loose_fingerprint TEXT,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    location TEXT DEFAULT '',
+    source TEXT NOT NULL,
+    raw_jd_text TEXT,
+    remote_status TEXT DEFAULT 'Unknown',
+    known_contacts TEXT DEFAULT '',
+    ai_notes TEXT,
+    relevance_score INTEGER,
+    stage TEXT DEFAULT 'discovered',
+    apply_flag INTEGER DEFAULT 0,
+    reject_reason TEXT DEFAULT '',
+    prep_folder_path TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    dupe_of TEXT DEFAULT ''
+);
+"""
+
+
+@pytest.fixture()
+def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    # Redirect pipeline.jsonl to tmp so log_event() calls during ingest
+    # don't write to the real logs/ directory.
+    monkeypatch.setattr(findajob_utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
+    db_path = tmp_path / "pipeline.db"
+    c = sqlite3.connect(db_path)
+    c.row_factory = sqlite3.Row
+    c.executescript(SCHEMA)
+    return c
+
+
+@pytest.fixture()
+def popen_calls(monkeypatch) -> list[list[str]]:
+    """Capture the Popen call that generate_folder=True makes — tests must
+    not actually launch prep_application.py."""
+    calls: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, args, **_kw):
+            calls.append(args)
+
+    monkeypatch.setattr(ingest_mod.subprocess, "Popen", _FakePopen)
+    return calls
+
+
+def _submit(conn: sqlite3.Connection, **kwargs):
+    defaults: dict = {
+        "company": "Acme Data Centers",
+        "title": "Senior Operations Engineer",
+        "url": "https://boards.greenhouse.io/acme/jobs/42",
+        "raw_jd_text": "Lead a team of ops engineers…",
+        "location": "Menlo Park, CA",
+        "source": "web_manual",
+    }
+    defaults.update(kwargs)
+    return ingest_mod.ingest_manual_job(conn, **defaults)
+
+
+def test_fresh_submission_inserts_row(conn: sqlite3.Connection, popen_calls):
+    result = _submit(conn)
+    assert result.status == "ingested"
+    assert result.prep_launched is False
+    assert popen_calls == []
+
+    row = conn.execute("SELECT * FROM jobs WHERE id=?", (result.job_id,)).fetchone()
+    assert row is not None
+    assert row["company"] == "Acme Data Centers"
+    assert row["title"] == "Senior Operations Engineer"
+    assert row["source"] == "web_manual"
+    assert row["stage"] == "scored"
+    assert row["relevance_score"] == 8
+    assert row["apply_flag"] == 0
+    assert row["raw_jd_text"] == "Lead a team of ops engineers…"
+    assert row["id"].startswith("web_manual-")
+    assert row["loose_fingerprint"] is not None
+
+
+def test_raw_jd_text_blank_stored_as_null(conn: sqlite3.Connection, popen_calls):
+    result = _submit(conn, raw_jd_text="   ")
+    row = conn.execute("SELECT raw_jd_text FROM jobs WHERE id=?", (result.job_id,)).fetchone()
+    assert row["raw_jd_text"] is None
+
+
+def test_clean_title_strips_nbsp_and_whitespace(conn: sqlite3.Connection, popen_calls):
+    # NBSP (U+00A0) sneaks in via pasted job board titles; clean_title must strip it
+    # so the web form produces the same fingerprint as an automated ingest would.
+    result = _submit(conn, title="  Senior Operations  Engineer  ")
+    row = conn.execute("SELECT title FROM jobs WHERE id=?", (result.job_id,)).fetchone()
+    assert row["title"] == "Senior Operations Engineer"
+
+
+def test_strict_fingerprint_duplicate(conn: sqlite3.Connection, popen_calls):
+    first = _submit(conn)
+    assert first.status == "ingested"
+
+    second = _submit(conn)  # identical submission
+    assert second.status == "duplicate"
+    assert second.existing_match == "strict"
+    assert second.job_id == first.job_id
+
+    count = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+    assert count == 1
+
+
+def test_url_duplicate(conn: sqlite3.Connection, popen_calls):
+    first = _submit(conn)
+    # Same URL, different title/location → strict fingerprint misses, URL matches
+    second = _submit(
+        conn,
+        title="Operations Manager",
+        location="Remote",
+    )
+    assert second.status == "duplicate"
+    assert second.existing_match == "url"
+    assert second.job_id == first.job_id
+
+
+def test_tier2_loose_dedup_when_existing_has_coarse_location(conn: sqlite3.Connection, popen_calls):
+    # Existing row has coarse location ("" / "US"); new row comes in with a
+    # specific city for the same (company, title). Tier 2 should match —
+    # this is the cross-source syndication case from #182 Bug C.
+    first = _submit(conn, location="United States", url="https://greenhouse.io/a/1")
+    second = _submit(conn, location="Barstow, TX", url="https://linkedin.com/jobs/999")
+    assert second.status == "duplicate"
+    assert second.existing_match == "loose"
+    assert second.job_id == first.job_id
+
+
+def test_tier2_loose_dedup_when_incoming_has_coarse_location(conn: sqlite3.Connection, popen_calls):
+    _submit(conn, location="Barstow, TX", url="https://greenhouse.io/a/1")
+    second = _submit(conn, location="", url="https://linkedin.com/jobs/999")
+    assert second.status == "duplicate"
+    assert second.existing_match == "loose"
+
+
+def test_distinct_cities_do_not_collapse(conn: sqlite3.Connection, popen_calls):
+    # Both rows have specific (non-coarse) locations — they are genuinely
+    # distinct reqs (site manager in Barstow vs Prineville). Must NOT match
+    # on Tier 2.
+    first = _submit(conn, location="Barstow, TX", url="https://greenhouse.io/a/1")
+    second = _submit(conn, location="Prineville, OR", url="https://greenhouse.io/a/2")
+    assert first.status == "ingested"
+    assert second.status == "ingested"
+    count = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+    assert count == 2
+
+
+def test_generate_folder_launches_prep(conn: sqlite3.Connection, popen_calls):
+    result = _submit(conn, generate_folder=True)
+    assert result.prep_launched is True
+    assert len(popen_calls) == 1
+    args = popen_calls[0]
+    # [python, prep_application.py, company, title, url, job_id]
+    assert args[1].endswith("/scripts/prep_application.py")
+    assert args[2] == "Acme Data Centers"
+    assert args[3] == "Senior Operations Engineer"
+    assert args[5] == result.job_id
+
+
+def test_source_label_threaded_through(conn: sqlite3.Connection, popen_calls):
+    result = _submit(conn, source="manual_form")  # legacy script identifier
+    row = conn.execute("SELECT source FROM jobs WHERE id=?", (result.job_id,)).fetchone()
+    assert row["source"] == "manual_form"
+    assert result.job_id.startswith("manual_form-")

--- a/tests/test_web_ingest.py
+++ b/tests/test_web_ingest.py
@@ -1,0 +1,189 @@
+"""Integration tests for the manual-ingest web route (#62).
+
+Exercises ``GET /ingest/`` and ``POST /ingest/manual`` against a real
+TestClient-backed FastAPI app + on-disk SQLite. ``subprocess.Popen`` is
+monkeypatched on the ``findajob.ingest`` module so no prep_application.py
+fork happens during tests.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob import utils
+from findajob.web.app import create_app
+
+SCHEMA = """
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    loose_fingerprint TEXT,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    location TEXT DEFAULT '',
+    source TEXT NOT NULL,
+    raw_jd_text TEXT,
+    remote_status TEXT DEFAULT 'Unknown',
+    known_contacts TEXT DEFAULT '',
+    ai_notes TEXT,
+    relevance_score INTEGER,
+    stage TEXT DEFAULT 'discovered',
+    apply_flag INTEGER DEFAULT 0,
+    reject_reason TEXT DEFAULT '',
+    prep_folder_path TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    dupe_of TEXT DEFAULT ''
+);
+"""
+
+_VALID_FORM: dict[str, str] = {
+    "company": "Acme Data Centers",
+    "title": "Senior Operations Engineer",
+    "url": "https://boards.greenhouse.io/acme/jobs/42",
+    "raw_jd_text": "Lead a team of ops engineers…",
+    "location": "Menlo Park, CA",
+    "remote_status": "On-site",
+    "notes": "",
+    "known_contacts": "",
+}
+
+
+@pytest.fixture()
+def popen_calls(monkeypatch) -> list[list[str]]:
+    calls: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, args, **_kw):
+            calls.append(args)
+
+    from findajob import ingest as ingest_mod
+
+    monkeypatch.setattr(ingest_mod.subprocess, "Popen", _FakePopen)
+    return calls
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch, popen_calls) -> TestClient:
+    monkeypatch.setattr(utils, "LOG_PATH", str(tmp_path / "events.jsonl"))
+
+    db_path = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(SCHEMA)
+    conn.close()
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    app = create_app(companies_root=companies, db_path=db_path)
+    client = TestClient(app)
+    client._db_path = db_path  # type: ignore[attr-defined]
+    return client
+
+
+def _job_count(client: TestClient) -> int:
+    conn = sqlite3.connect(client._db_path)  # type: ignore[attr-defined]
+    n = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+    conn.close()
+    return int(n)
+
+
+def _fetch_one(client: TestClient) -> sqlite3.Row:
+    conn = sqlite3.connect(client._db_path)  # type: ignore[attr-defined]
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM jobs").fetchone()
+    conn.close()
+    assert row is not None
+    return row
+
+
+def test_get_renders_form(client: TestClient) -> None:
+    resp = client.get("/ingest/")
+    assert resp.status_code == 200
+    html = resp.text
+    assert 'id="manual-ingest-form"' in html
+    assert 'hx-post="/ingest/manual"' in html
+    # Speculative mode stub must be present so #131 slots in cleanly.
+    assert "#131" in html
+
+
+def test_post_success_inserts_row(client: TestClient, popen_calls) -> None:
+    resp = client.post("/ingest/manual", data=_VALID_FORM)
+    assert resp.status_code == 200
+    assert 'data-outcome="success"' in resp.text
+    assert "Ingested" in resp.text
+
+    assert _job_count(client) == 1
+    row = _fetch_one(client)
+    assert row["source"] == "web_manual"
+    assert row["stage"] == "scored"
+    assert row["relevance_score"] == 8
+    assert row["raw_jd_text"] == "Lead a team of ops engineers…"
+    assert popen_calls == []  # no generate_folder checkbox
+
+
+def test_post_missing_required_returns_error_partial(client: TestClient) -> None:
+    data = dict(_VALID_FORM)
+    data["raw_jd_text"] = "   "  # whitespace-only fails the non-empty check
+    resp = client.post("/ingest/manual", data=data)
+    assert resp.status_code == 200
+    assert 'data-outcome="error"' in resp.text
+    assert "Missing required field" in resp.text
+    assert _job_count(client) == 0
+
+
+def test_post_missing_required_formkey_returns_422(client: TestClient) -> None:
+    # FastAPI's Form(...) rejects absent fields before our handler runs.
+    data = {k: v for k, v in _VALID_FORM.items() if k != "company"}
+    resp = client.post("/ingest/manual", data=data)
+    assert resp.status_code == 422
+
+
+def test_post_duplicate_returns_duplicate_partial(client: TestClient) -> None:
+    first = client.post("/ingest/manual", data=_VALID_FORM)
+    assert 'data-outcome="success"' in first.text
+
+    second = client.post("/ingest/manual", data=_VALID_FORM)
+    assert second.status_code == 200
+    assert 'data-outcome="duplicate"' in second.text
+    assert "strict" in second.text  # reports the match tier
+    assert _job_count(client) == 1
+
+
+def test_generate_folder_launches_prep(client: TestClient, popen_calls) -> None:
+    data = dict(_VALID_FORM)
+    data["generate_folder"] = "true"
+    resp = client.post("/ingest/manual", data=data)
+    assert resp.status_code == 200
+    assert 'data-outcome="success"' in resp.text
+    assert "Prep folder generation started" in resp.text
+    assert len(popen_calls) == 1
+    assert popen_calls[0][1].endswith("/scripts/prep_application.py")
+
+
+def test_generate_folder_deferred_when_prep_queue_full(client: TestClient, popen_calls) -> None:
+    # Fill the prep-in-flight cap with 3 jobs stuck in prep_in_progress.
+    conn = sqlite3.connect(client._db_path)  # type: ignore[attr-defined]
+    for i in range(3):
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, source, stage)"
+            " VALUES (?, ?, ?, ?, ?, 'test', 'prep_in_progress')",
+            (f"id_{i}", f"fp_{i}", f"https://x/{i}", f"T{i}", f"C{i}"),
+        )
+    conn.commit()
+    conn.close()
+
+    data = dict(_VALID_FORM)
+    data["generate_folder"] = "true"
+    resp = client.post("/ingest/manual", data=data)
+    assert resp.status_code == 200
+    assert 'data-outcome="success"' in resp.text
+    # Row inserted, but prep NOT launched — cap enforced.
+    assert "Prep queue is full" in resp.text
+    assert popen_calls == []
+    # Row created (4 total now: 3 seed + 1 new).
+    assert _job_count(client) == 4

--- a/tests/test_web_landing.py
+++ b/tests/test_web_landing.py
@@ -49,7 +49,7 @@ def test_landing_nav_home_active(client: TestClient) -> None:
 @pytest.mark.parametrize(
     "path,label,issue",
     [
-        ("/ingest/", "Ingest", "#79"),
+        # /ingest/ promoted from placeholder to a real route in #62 — covered by tests/test_web_ingest.py.
         ("/tools/", "Tools", ""),
         ("/config/", "Config", ""),
         ("/docs/", "Docs", ""),


### PR DESCRIPTION
Closes #62. Absorbs #79 (full-JD-text field covers JS-rendered SPAs and auth-walled listings).

## Summary

- New `/ingest/` page in the web UI with `POST /ingest/manual` handler; writes straight into `jobs` via a new shared `findajob.ingest.ingest_manual_job()` helper.
- Full JD text is a required form field — when provided, `prep_application.py` uses it directly and skips URL refetch (absorbs #79).
- New rows land at `source='web_manual'`, `stage='scored'`, `relevance_score=8`. Distinct from legacy `'manual_form'` rows so post-retirement audit stays clean.
- `ops/crontab`'s `*/30 ingest_form.py` timer is commented out; the script is kept for ad-hoc drains of the old Google Form until the Form itself is decommissioned.
- Form template includes a disabled **Speculative** mode tab linking to #131 so the follow-up candidate-led briefing flow slots in without a rewrite.

## Acceptance criteria (from #62)

1. ✅ Paste JD + metadata via form → row in DB with `source='web_manual'`, `stage='scored'`, `relevance_score=8`.
2. ✅ When full JD text is provided, pipeline uses it directly (no URL fetch). Stored in `jobs.raw_jd_text`; `prep_application.py` already reads this column and only falls back to curl for blank rows.
3. ✅ Generate-folder toggle fires `prep_application.py` via `subprocess.Popen(start_new_session=True)`, subject to the same 3-job concurrency cap as the Dashboard's Flag-for-Prep button.
4. ✅ `ingest_form.py` timer disabled; Google Form retirement path in motion.

## Documentation Impact

- `CHANGELOG.md` — Added/Changed/Migration required entries for the new form + retired timer.
- `CLAUDE.md` — Key File Locations: added `src/findajob/ingest.py` and `src/findajob/web/routes/ingest.py`; updated the `ingest_form.py` line to note retirement. Google Sheet Architecture callout rewritten to credit #62 for the ingest move and clarify that `sync_sheet.py` retirement is the remaining step under parent #14.
- `CLAUDE.local.md` (gitignored) — Scheduler table's `form-ingest` row struck through with a retirement note.
- `docs/scripts-reference.md` — `ingest_form.py` section rewritten as "retired; kept for manual runs."
- `docs/setup/state-migration.md` — Struck the `findajob-form-ingest.timer` systemd enable with a retirement note.

## Migration required

- `*/30 ingest_form.py` line in `ops/crontab` is commented out. Operators pulling `:latest` stop seeing the 30-min Google Form poll at container restart. No state migration needed; existing `manual_form`-source rows keep their semantics.

## Verification

- Unit: `tests/test_ingest.py` (10 tests) — fresh insert, strict/URL/loose dedup tiers, `raw_jd_text` storage, `clean_title` NBSP handling, prep Popen, source label threading.
- Integration: `tests/test_web_ingest.py` (7 tests) — GET renders, POST success, POST missing required (both whitespace-only and absent form key), POST duplicate, generate-folder launches prep, generate-folder deferred at 3-job cap.
- Full suite: `669 passed` with ruff + `ruff format --check` + mypy all clean.
- Browser smoke (Playwright against scratch DB): fill + submit success path resets form and shows green partial with Dashboard link; duplicate path shows amber partial and preserves form fields; Speculative tab renders disabled; nav highlights `/ingest/` as active. Screenshots attached below if useful — redacted from the final PR.

## Pre-existing fragility worth calling out (not fixed here)

`findajob.utils.log_event()` 500s on fresh dev envs if `<repo>/logs/` doesn't exist — `open(..., "a")` creates the file but not the parent directory. Production has the dir baked in, but a fresh-install dogfooder on a laptop will trip on this the first time any write handler runs. Out of 14d scope; worth a follow-up issue.

## Test plan

- [ ] Pull this branch into a scratch container, confirm `/ingest/` renders and the form submits a real DB row.
- [ ] Verify the crontab change lands cleanly at restart (`docker compose logs scheduler | grep -i cron`) and the old 30-min form-ingest entry no longer fires.
- [ ] Fill the form with a JD-containing submission, flag for prep from the Dashboard, verify `prep_application.py` uses the pasted JD and does NOT curl the URL.
- [ ] Confirm #131 issue link renders as a clickable/hoverable tooltip on the disabled Speculative tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)