### PR TITLE
feat(web): sub-tab nav + /board/rejected view (#191)

### DIFF
--- a/scripts/sync_sheet.py
+++ b/scripts/sync_sheet.py
@@ -604,7 +604,11 @@ REJECTED_APPS_HEADERS = [
 
 
 def sync_rejected_apps(svc, conn):
-    """Sync jobs that were rejected or not selected after being in 'applied' stage."""
+    """Sync jobs that were rejected or not selected after being in 'applied' stage.
+
+    Retirable: superseded by the web `/board/rejected` view (#191). Remove alongside
+    the Sheet1-write retirement tracked in #136.
+    """
     rows = conn.execute("""
         SELECT j.*, a.changed_at AS rejected_date
         FROM jobs j

--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -1,4 +1,4 @@
-"""Board tabs: /board/dashboard, /applied, /review, /waitlist, /archive."""
+"""Board tabs: /board/dashboard, /applied, /review, /waitlist, /rejected, /archive."""
 
 from __future__ import annotations
 
@@ -260,6 +260,97 @@ def waitlist(
             "desc": desc,
             "density": _normalize_density(density),
             "tab": "waitlist",
+            "materials_base_url": materials_base_url,
+        },
+    )
+
+
+_REJECTED_COLS = [
+    ("Title", "title"),
+    ("Company", "company"),
+    ("Reason", "reject_reason"),
+    ("Rejected", "rejected_date"),
+    ("Source", "rejection_source"),
+]
+_REJECTED_SORTABLE = {c for _, c in _REJECTED_COLS}
+_REJECTED_DEFAULT_SORT = "rejected_date"
+
+
+# Latest stage-transition into rejected/not_selected per job. audit_log.job_id
+# stores jobs.id (UUID) — match jobs.id, not fingerprint. MAX(changed_at) picks
+# the most recent transition in case a job was rejected, reactivated, and
+# rejected again. See CLAUDE.md §"audit_log timestamp format".
+_REJECTED_SQL = """
+SELECT j.fingerprint, j.title, j.company, j.url, j.stage, j.reject_reason,
+       CASE j.stage WHEN 'not_selected' THEN 'company' ELSE 'user' END AS rejection_source,
+       al.rejected_date
+FROM jobs j
+LEFT JOIN (
+  SELECT job_id, MAX(changed_at) AS rejected_date
+  FROM audit_log
+  WHERE field_changed = 'stage' AND new_value IN ('rejected','not_selected')
+  GROUP BY job_id
+) al ON al.job_id = j.id
+WHERE j.stage IN ('rejected','not_selected')
+ORDER BY {sort_col} {order}
+"""
+
+
+@router.get("/board/rejected", response_class=HTMLResponse)
+def rejected(
+    request: Request,
+    sort: str = Query(default=""),
+    desc: int = Query(default=1),
+    density: str = Query(default=_DEFAULT_DENSITY),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    sort_col = sort if sort in _REJECTED_SORTABLE else _REJECTED_DEFAULT_SORT
+    order = "DESC" if desc else "ASC"
+    rows = db.execute(_REJECTED_SQL.format(sort_col=sort_col, order=order)).fetchall()
+    materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="board/rejected.html",
+        context={
+            "columns": _REJECTED_COLS,
+            "rows": rows,
+            "sort": sort_col,
+            "desc": desc,
+            "density": _normalize_density(density),
+            "tab": "rejected",
+            "materials_base_url": materials_base_url,
+        },
+    )
+
+
+@router.get("/board/rejected/rows", response_class=HTMLResponse)
+def rejected_rows(
+    request: Request,
+    q: str = Query(default=""),
+    sort: str = Query(default=""),
+    desc: int = Query(default=1),
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    sort_col = sort if sort in _REJECTED_SORTABLE else _REJECTED_DEFAULT_SORT
+    order = "DESC" if desc else "ASC"
+    filter_sql, params = _filter_clause(q)
+    qualified_filter = filter_sql.replace("title", "j.title").replace("company", "j.company")
+    base = _REJECTED_SQL.format(sort_col=sort_col, order=order)
+    sql = base.replace(
+        "WHERE j.stage IN ('rejected','not_selected')",
+        f"WHERE j.stage IN ('rejected','not_selected'){qualified_filter}",
+    )
+    rows = db.execute(sql, params).fetchall()
+    materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="_job_rows_fragment.html",
+        context={
+            "columns": _REJECTED_COLS,
+            "rows": rows,
+            "tab": "rejected",
             "materials_base_url": materials_base_url,
         },
     )

--- a/src/findajob/web/templates/board/_tabs.html
+++ b/src/findajob/web/templates/board/_tabs.html
@@ -1,0 +1,25 @@
+{# Secondary tab bar shared by every /board/* view. Active tab is visually
+   distinct via aria-current + background color. #}
+{% set board_tabs = [
+  ("/board/dashboard", "Dashboard"),
+  ("/board/applied", "Applied"),
+  ("/board/waitlist", "Waitlist"),
+  ("/board/review", "Review"),
+  ("/board/rejected", "Rejected"),
+  ("/board/archive", "Archive"),
+] %}
+<nav class="mb-4 border-b border-slate-200" aria-label="Board views">
+  <ul class="flex flex-wrap gap-1 text-sm">
+    {% for href, label in board_tabs %}
+      {% set active = request.url.path == href %}
+      <li>
+        <a href="{{ href }}"
+           {% if active %}aria-current="page"{% endif %}
+           class="inline-block px-3 py-2 rounded-t
+                  {% if active %}bg-white border-x border-t border-slate-200 -mb-px font-semibold text-slate-900{% else %}text-slate-600 hover:bg-slate-100{% endif %}">
+          {{ label }}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</nav>

--- a/src/findajob/web/templates/board/applied.html
+++ b/src/findajob/web/templates/board/applied.html
@@ -3,6 +3,7 @@
 {% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Applied</h1>
+{% include "board/_tabs.html" %}
 {% include "_filters.html" ignore missing %}
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">

--- a/src/findajob/web/templates/board/archive.html
+++ b/src/findajob/web/templates/board/archive.html
@@ -2,6 +2,7 @@
 {% block title %}Archive — findajob{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Archive ({{ rows|length }}{% if next_offset %}+{% endif %})</h1>
+{% include "board/_tabs.html" %}
 <div class="mb-3 text-xs text-slate-600 flex items-center gap-1">
   <span>Rows:</span>
   <a href="?sort={{ sort }}&desc={{ desc }}&density=compact"

--- a/src/findajob/web/templates/board/rejected.html
+++ b/src/findajob/web/templates/board/rejected.html
@@ -1,15 +1,19 @@
 {% extends "base.html" %}
-{% block title %}Dashboard — findajob{% endblock %}
+{% block title %}Rejected — findajob{% endblock %}
 {% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
+<h1 class="text-2xl font-semibold mb-4">Rejected ({{ rows|length }})</h1>
 {% include "board/_tabs.html" %}
 {% include "_filters.html" ignore missing %}
+<p class="mb-3 text-xs text-slate-600">
+  Source: <span class="font-medium">user</span> = you rejected before applying
+  (stage <code>rejected</code>; folder under <code>_rejected/</code>).
+  <span class="font-medium">company</span> = company rejected after you applied
+  (stage <code>not_selected</code>; folder stays under <code>_applied/</code> with a marker file).
+</p>
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
     <tr>
-      <th class="px-3 py-2">Status</th>
-      <th class="px-3 py-2">Reject</th>
       {% for display, field in columns %}
       <th class="px-3 py-2">
         <a href="?sort={{ field }}&desc={% if sort == field and desc %}0{% else %}1{% endif %}">
@@ -23,7 +27,7 @@
     {% for row in rows %}
       {% include "_job_row.html" %}
     {% else %}
-      <tr><td colspan="{{ columns|length + 2 }}" class="px-3 py-4 text-slate-500">No jobs in this view right now.</td></tr>
+      <tr><td colspan="{{ columns|length }}" class="px-3 py-4 text-slate-500">No rejected jobs yet.</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/findajob/web/templates/board/review.html
+++ b/src/findajob/web/templates/board/review.html
@@ -3,6 +3,7 @@
 {% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Review</h1>
+{% include "board/_tabs.html" %}
 {% include "_filters.html" ignore missing %}
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">

--- a/src/findajob/web/templates/board/waitlist.html
+++ b/src/findajob/web/templates/board/waitlist.html
@@ -3,6 +3,7 @@
 {% block main_classes %}w-full px-4 py-6{% endblock %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Waitlist</h1>
+{% include "board/_tabs.html" %}
 {% include "_filters.html" ignore missing %}
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">

--- a/tests/test_web_board_rejected.py
+++ b/tests/test_web_board_rejected.py
@@ -1,0 +1,103 @@
+"""Board Rejected tab — lists stage IN (rejected, not_selected), joins audit_log.
+
+Schema note: audit_log.job_id stores jobs.id (UUID), not jobs.fingerprint. See
+test_web_board_applied.py for the broader convention.
+"""
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FINDAJOB_MATERIALS_BASE_URL", "http://test:8090")
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, company TEXT, "
+        "stage TEXT, reject_reason TEXT, url TEXT, created_at TEXT, stage_updated TEXT, "
+        "prep_folder_path TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
+    three_days_ago = (datetime.now(UTC) - timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S")
+    one_day_ago = (datetime.now(UTC) - timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+
+    # User rejection: scored → rejected
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, reject_reason, url) "
+        "VALUES ('id-rej','fp-rej','Wrong Stack','Acme','rejected','Tech Stack Mismatch','https://example.com/j1')"
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+        "VALUES ('id-rej','stage','scored','rejected',?,'user')",
+        (three_days_ago,),
+    )
+
+    # Company rejection: applied → not_selected
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, reject_reason, url) "
+        "VALUES ('id-ns','fp-ns','Principal Eng','Meta','not_selected','No Response','https://example.com/j2')"
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+        "VALUES ('id-ns','stage','applied','not_selected',?,'user')",
+        (one_day_ago,),
+    )
+
+    # Active application — must NOT appear on /board/rejected
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) "
+        "VALUES ('id-app','fp-app','Staff Eng','Google','applied')"
+    )
+
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    return TestClient(create_app(companies_root=companies, db_path=db))
+
+
+def test_rejected_lists_both_user_and_company_rejections(client: TestClient) -> None:
+    r = client.get("/board/rejected")
+    assert r.status_code == 200
+    assert "Wrong Stack" in r.text
+    assert "Principal Eng" in r.text
+    # Rejection source flag
+    assert ">user<" in r.text
+    assert ">company<" in r.text
+    # Reject reasons from jobs table
+    assert "Tech Stack Mismatch" in r.text
+    assert "No Response" in r.text
+
+
+def test_rejected_excludes_active_applications(client: TestClient) -> None:
+    r = client.get("/board/rejected")
+    assert r.status_code == 200
+    assert 'data-fingerprint="fp-app"' not in r.text
+    assert "Staff Eng" not in r.text
+
+
+def test_rejected_company_hyperlinks_to_materials(client: TestClient) -> None:
+    r = client.get("/board/rejected")
+    assert r.status_code == 200
+    # Both rejected and not_selected are in FOLDER_STAGES, so company cells
+    # hyperlink to /materials/{fingerprint}. The materials viewer then resolves
+    # the folder on disk (_rejected/ for user, _applied/+marker for company).
+    assert 'href="http://test:8090/materials/fp-rej"' in r.text
+    assert 'href="http://test:8090/materials/fp-ns"' in r.text
+
+
+def test_rejected_rows_filter_endpoint(client: TestClient) -> None:
+    r = client.get("/board/rejected/rows?q=Principal")
+    assert r.status_code == 200
+    assert "Principal Eng" in r.text
+    assert "Wrong Stack" not in r.text

--- a/tests/test_web_board_tabs.py
+++ b/tests/test_web_board_tabs.py
@@ -1,0 +1,66 @@
+"""Secondary tab bar on every /board/* view (issue #191).
+
+Each board page includes board/_tabs.html which renders six tabs
+(Dashboard, Applied, Waitlist, Review, Rejected, Archive). The active tab
+is visually distinct via aria-current="page".
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+TAB_LINKS = [
+    "/board/dashboard",
+    "/board/applied",
+    "/board/waitlist",
+    "/board/review",
+    "/board/rejected",
+    "/board/archive",
+]
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, company TEXT, "
+        "stage TEXT, fit_score REAL, probability_score REAL, relevance_score INTEGER, "
+        "interview_likelihood INTEGER, location TEXT, remote_status TEXT, known_contacts TEXT, "
+        "comp_estimate TEXT, ai_notes TEXT, user_notes TEXT, score_flag_reason TEXT, "
+        "source TEXT, reject_reason TEXT, url TEXT, created_at TEXT, stage_updated TEXT, "
+        "prep_folder_path TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    return TestClient(create_app(companies_root=companies, db_path=db))
+
+
+@pytest.mark.parametrize("path", TAB_LINKS)
+def test_every_board_page_renders_full_tab_bar(client: TestClient, path: str) -> None:
+    r = client.get(path)
+    assert r.status_code == 200, f"{path} returned {r.status_code}"
+    for href in TAB_LINKS:
+        assert f'href="{href}"' in r.text, f"{path} missing tab link to {href}"
+
+
+@pytest.mark.parametrize("path", TAB_LINKS)
+def test_active_tab_marked_aria_current(client: TestClient, path: str) -> None:
+    r = client.get(path)
+    assert r.status_code == 200
+    # The active tab renders href="<path>" followed shortly by aria-current="page".
+    # Pull out the substring starting at the active href and verify the marker
+    # appears before the next </a> tag.
+    idx = r.text.index(f'href="{path}"')
+    snippet = r.text[idx : idx + 400]
+    assert 'aria-current="page"' in snippet, f"{path} did not mark itself active"


### PR DESCRIPTION
Closes #191.

## Summary
- **Sub-tab bar on every `/board/*` page.** New `board/_tabs.html` partial renders six tabs (Dashboard, Applied, Waitlist, Review, Rejected, Archive). Active tab is marked with `aria-current="page"` and a background highlight. Fixes the dead-end when the Dashboard queue empties — the operator can now cross-navigate without typing URLs.
- **`GET /board/rejected`** read-only view listing jobs with `stage IN (rejected, not_selected)`. Columns: Title (hyperlinked to the posting), Company (hyperlinked to materials viewer), Reason (from `jobs.reject_reason`), Rejected date (from `audit_log` most-recent stage transition), Source flag (`user` vs `company`).
- **Folder links** reuse the existing materials-viewer hyperlink. Because both `rejected` and `not_selected` are already in `FOLDER_STAGES`, the company cell auto-renders the link, and the viewer resolves the on-disk path via `jobs.prep_folder_path` — so user rejections resolve under `companies/_rejected/` and company rejections under `companies/_applied/` with the `NOT_SELECTED_` marker, per CLAUDE.md §"Stage `not_selected`".
- **`/board/rejected/rows`** HTMX endpoint so the shared `_filters.html` title/company filter works on the new tab.
- **`scripts/sync_sheet.py::sync_rejected_apps`** flagged as retirable in its docstring. Actual removal deferred to the Sheet1-write retirement (#136), per AC #4.

## Test plan
- [x] `uv run pytest` — 686 passed (16 new: 12 parametrized tab-bar tests × 6 paths, 4 rejected-view tests)
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 90 files already formatted
- [x] `uv run mypy src/findajob/web/routes/board.py` — no issues
- [x] Smoke-rendered `/board/rejected` with user + company rejection fixtures — tab bar + active marker + row layout verified
- [ ] Visual check on docker.lan after merge + deploy (tab bar renders, cross-navigation works, `/board/rejected` populates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)