### PR TITLE
fix(watchdog): compare stage_updated as ISO string (#205)

### DIFF
--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -16,7 +16,7 @@ import time
 import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from findajob.cleaning import fingerprint, is_coarse_location, loose_fingerprint, normalize
 from findajob.cost_tracking import log_call
@@ -95,17 +95,23 @@ def score_null_manual_review_rows(
 
     Only considers rows updated within NULL_SCORE_RETRY_DAYS to avoid retrying
     genuinely unparseable JDs forever. Returns the count of successfully rescored rows.
+
+    stage_updated is stored as Python ISO format ("2026-04-23T17:19:57+00:00");
+    compute the cutoff in Python so both sides of the comparison use the same format.
+    SQLite's datetime('now', ...) returns space-separated form which misorders against
+    ISO-T on same-day rows (T > space at pos 10).
     """
+    cutoff = (datetime.now(UTC) - timedelta(days=NULL_SCORE_RETRY_DAYS)).isoformat()
     rows = conn.execute(
         """
         SELECT id, title, company, location, raw_jd_text FROM jobs
         WHERE stage = 'manual_review'
           AND relevance_score IS NULL
-          AND stage_updated > datetime('now', ?)
+          AND stage_updated > ?
           AND (dupe_of = '' OR dupe_of IS NULL)
         LIMIT ?
         """,
-        (f"-{NULL_SCORE_RETRY_DAYS} days", limit),
+        (cutoff, limit),
     ).fetchall()
 
     rescored = 0

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -11,6 +11,7 @@ POST handlers (findajob.web.routes.board_actions) calling findajob.actions.
 """
 
 import sqlite3
+from datetime import UTC, datetime, timedelta
 
 from findajob.actions import reset_prep_to_scored
 from findajob.paths import BASE
@@ -21,12 +22,20 @@ STALE_PREP_MINUTES = 60
 
 
 def run_watchdog(conn: sqlite3.Connection) -> int:
-    """Reset any job stuck in prep_in_progress > STALE_PREP_MINUTES. Returns reset count."""
+    """Reset any job stuck in prep_in_progress > STALE_PREP_MINUTES. Returns reset count.
+
+    stage_updated is written by web handlers as Python's datetime.isoformat()
+    (e.g. "2026-04-23T17:19:57.663641+00:00"). SQLite's datetime('now', ...) returns
+    the naïve space-separated form ("2026-04-23 16:19:57"); lexical `<` against
+    an ISO-T value is unreliable on same-day rows because `T` > space at pos 10.
+    Compute the cutoff in Python as an ISO string so both sides share the format.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(minutes=STALE_PREP_MINUTES)).isoformat()
     stale = conn.execute(
         """SELECT id FROM jobs
            WHERE stage = 'prep_in_progress'
-             AND stage_updated < datetime('now', ?)""",
-        (f"-{STALE_PREP_MINUTES} minutes",),
+             AND stage_updated < ?""",
+        (cutoff,),
     ).fetchall()
     count = 0
     for job in stale:

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 import sys
 import uuid
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -59,13 +60,20 @@ def _patch_log(tmp_path, monkeypatch):
     return log_path
 
 
-def _insert(conn, *, stage, stage_offset):
-    """Insert a row with stage_updated = datetime('now', stage_offset)."""
+def _insert(conn, *, stage, minutes_ago):
+    """Insert a row with stage_updated in Python ISO format (the production writer format).
+
+    Web handlers write stage_updated via datetime.now(UTC).isoformat(), producing
+    "YYYY-MM-DDTHH:MM:SS+00:00". Tests must mirror that format — fixtures that
+    used SQLite's datetime('now', ...) (space-separated, no TZ) previously hid
+    format-mismatch bugs in reader queries.
+    """
     job_id = str(uuid.uuid4())[:8]
+    stage_updated = (datetime.now(UTC) - timedelta(minutes=minutes_ago)).isoformat()
     conn.execute(
         """INSERT INTO jobs (id, fingerprint, url, title, company, stage, stage_updated)
-           VALUES (?, ?, ?, 'Ops', 'Acme', ?, datetime('now', ?))""",
-        (job_id, f"fp_{job_id}", f"https://example.com/{job_id}", stage, stage_offset),
+           VALUES (?, ?, ?, 'Ops', 'Acme', ?, ?)""",
+        (job_id, f"fp_{job_id}", f"https://example.com/{job_id}", stage, stage_updated),
     )
     conn.commit()
     return job_id
@@ -78,8 +86,8 @@ def _read_events(log_path: Path) -> list[dict]:
 
 
 def test_resets_stale_row_only(db, _patch_log):
-    stale_id = _insert(db, stage="prep_in_progress", stage_offset="-2 hours")
-    fresh_id = _insert(db, stage="prep_in_progress", stage_offset="-5 minutes")
+    stale_id = _insert(db, stage="prep_in_progress", minutes_ago=120)
+    fresh_id = _insert(db, stage="prep_in_progress", minutes_ago=5)
     fresh_stage_before = db.execute("SELECT stage_updated FROM jobs WHERE id=?", (fresh_id,)).fetchone()[
         "stage_updated"
     ]
@@ -94,7 +102,7 @@ def test_resets_stale_row_only(db, _patch_log):
 
 
 def test_audit_log_records_transition(db):
-    stale_id = _insert(db, stage="prep_in_progress", stage_offset="-2 hours")
+    stale_id = _insert(db, stage="prep_in_progress", minutes_ago=120)
 
     watchdog.run_watchdog(db)
 
@@ -121,9 +129,9 @@ class _ConnWrapper:
 
 
 def test_main_emits_watchdog_run_event(db, monkeypatch, _patch_log):
-    _insert(db, stage="prep_in_progress", stage_offset="-2 hours")
-    _insert(db, stage="prep_in_progress", stage_offset="-90 minutes")
-    _insert(db, stage="scored", stage_offset="-1 day")  # unrelated row
+    _insert(db, stage="prep_in_progress", minutes_ago=120)
+    _insert(db, stage="prep_in_progress", minutes_ago=90)
+    _insert(db, stage="scored", minutes_ago=60 * 24)  # unrelated row
 
     monkeypatch.setattr(watchdog.sqlite3, "connect", lambda *a, **kw: _ConnWrapper(db))
 
@@ -133,6 +141,21 @@ def test_main_emits_watchdog_run_event(db, monkeypatch, _patch_log):
     watchdog_events = [e for e in events if e["event"] == "watchdog_run"]
     assert len(watchdog_events) == 1
     assert watchdog_events[0]["stale_reset"] == 2
+
+
+def test_resets_iso_t_timestamps_on_same_day(db, _patch_log):
+    """Regression: stuck prep rows written in ISO-T format (the production format)
+    must be reset even when they fall on the same calendar date as `now`.
+    Pre-fix, `stage_updated < datetime('now', '-60 minutes')` was always false
+    for same-day ISO-T rows because lexical T > space at char 10 of the string."""
+    stale_id = _insert(db, stage="prep_in_progress", minutes_ago=75)
+    fresh_id = _insert(db, stage="prep_in_progress", minutes_ago=10)
+
+    count = watchdog.run_watchdog(db)
+
+    assert count == 1
+    assert db.execute("SELECT stage FROM jobs WHERE id=?", (stale_id,)).fetchone()["stage"] == "scored"
+    assert db.execute("SELECT stage FROM jobs WHERE id=?", (fresh_id,)).fetchone()["stage"] == "prep_in_progress"
 
 
 def test_empty_db_emits_zero_count(db, monkeypatch, _patch_log):


### PR DESCRIPTION
## Summary

- Fixes #205 — watchdog never reset same-day stuck `prep_in_progress` jobs due to `T` vs space format mismatch at pos 10 of the lexical compare
- Operator unblocked at 2026-04-23T18:11Z by manual `reset_prep_to_scored` on three latched jobs; this PR keeps it from recurring
- Applies the same fix to `scripts/triage.py:104` (NULL-score retry window — same class, inverted polarity, off by up to 24h on same-day rows)
- Regression test in `tests/test_watchdog.py` — fixture now writes `stage_updated` in the actual production format (ISO-T), previously hid the bug

## Why this slipped through

The test fixture used `datetime('now', '-2 hours')` embedded in SQL, which writes naïve space-separated format. That matched the reader's cutoff format, so the tests were green while production (which writes ISO-T via `datetime.now(UTC).isoformat()`) was broken. Consolidated the helper to use the production format.

## Out of scope, deliberately

`jobs.stage_updated` diverges from the naïve-UTC convention used for `audit_log`. Reader-side fix is the safe unblock; normalizing writers is a follow-up with migration risk. Noted for a later pass.

## Test plan

- [x] `uv run pytest tests/test_watchdog.py` — 5 pass including new regression
- [x] `uv run pytest tests/test_triage_null_retry.py` — 4 pass
- [x] `uv run pytest` — 739 pass
- [x] `uv run ruff check` + `ruff format --check` on changed files — clean
- [x] Mypy — unchanged from `main` (one pre-existing triage.py annotation warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)