### PR TITLE
docs: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-04-23
+
+Minor bump. Web UI becomes the primary write surface for the board, replacing Google Sheet edits and the Google Form JD-ingest loop. Adds a `/config/` in-browser editor, the first two `/stats/` dashboards, and the `/board/*` read/write views. Introduces two-tier dedup and a new nullable `loose_fingerprint` column on `jobs` — **operators upgrading from v0.1.4 must run `scripts/migrate_add_loose_fingerprint.py` once after pulling** (see Migration required below). Several prep/sync reliability fixes surfaced during the #61 PR-B smoke are also included.
+
 ### Added
 
 - **`/config/` in-browser editor — edit pipeline config files without SSH.** New top-nav page `/config/` lists the editable config files by category (candidate context, search config, role prompts) and opens each in a plain `<textarea>` with a save button. An allowlist module (`src/findajob/web/config_files.py`) enumerates the editable paths (`candidate_context/profile.md`, `candidate_context/master_resume.md`, `config/prefilter_rules.yaml`, `config/in_domain_patterns.yaml`, `config/jsearch_queries.txt`, `config/feed_urls.txt`, `config/roles/*.md`) — every other path returns 403. Writes are atomic (tmpfile + `os.replace`). Missing files render as an empty textarea and are created on save, so the editor works on a fresh stack before the onboarding flow (#148) has run. `/tools/` bumped from placeholder to a real page linking to the editor. Closes #149; unblocks the tuning section of #11 (user-facing docs).
@@ -173,7 +177,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/brockamer/findajob/releases/tag/v0.2.0
 [0.1.4]: https://github.com/brockamer/findajob/releases/tag/v0.1.4
 [0.1.3]: https://github.com/brockamer/findajob/releases/tag/v0.1.3
 [0.1.2]: https://github.com/brockamer/findajob/releases/tag/v0.1.2


### PR DESCRIPTION
## Summary

- Moves `[Unreleased]` → `[0.2.0] — 2026-04-23` in CHANGELOG.md.
- Adds the 0.2.0 compare link at the bottom and re-points `[Unreleased]` at the new tag.

## Version rationale

Minor bump (0.1.4 → 0.2.0) because PR #187 added a nullable `loose_fingerprint` column on `jobs` plus a required `scripts/migrate_add_loose_fingerprint.py` for existing stacks. Per `docs/release-process.md` "A minor bump signals a breaking change. Examples that qualify: a SQLite schema change that needs a migration."

## Release-range PRs (since v0.1.4)

15 PRs. `migration-required` labeled: #187 (schema), #189 (crontab change — Google Form poll retired).

- #207 feat(web/config): in-browser config editor at /config/ (#149)
- #206 fix(watchdog): compare stage_updated as ISO string (#205)
- #201 feat(ingest): smart duplicate handling on /ingest/manual
- #200 feat(web): /stats/feedback dashboard — rejection-reason trends (#193)
- #198 feat(web): /stats/funnel dashboard + 14e infrastructure (#63)
- #192 feat(web): sub-tab nav + /board/rejected view
- #189 feat(14d): web form replaces Google Form for manual JD ingest (#62) **[migration-required]**
- #187 fix(ingest): two-tier dedup cluster (#182) **[migration-required]**
- #180 feat(web): 14c PR-C — dashboard UX polish (#61)
- #179 feat(14c): pivot to web writes + drop poll_flags.py (#61 PR-B)
- #178 feat(web): 14c PR-A — STATUS + REJECT_REASON web write handlers (#61)
- #177 fix(prep): quarantine stale prep folders before creating new one (#174)
- #176 fix(sync): verify Sheets updatedRows matches request size (#171)
- #175 fix(prep): audit + log every stage rollback from prep_in_progress (#172)
- #170 fix(triage): log triage_sync_failed when sync_sheet exits non-zero (#145)

## Pre-tag smoke

Skipped per session direction — the smoke script's sheet-write assertion (sync_complete with sheet1/dashboard >= 1) is vestigial now that the Sheet is DB→Sheet read-only. Follow-up issue to purge the Sheet dependency from `scripts/test_container_integration.sh` to be filed after this tag ships. CI green on all 15 merged PRs in the range; `:latest` image has been running on both operator and beta-tester stacks since their respective merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)