### PR TITLE
fix(web/board): persist 'Not Selected' status, highlight reject cell (#214)

### DIFF
--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -41,20 +41,26 @@
       data-fp="{{ fp }}"
       onchange="if(!this.value)return;
         const tr=this.closest('tr');
+        const rejectSel=this.closest('td').nextElementSibling && this.closest('td').nextElementSibling.querySelector('select');
+        const hint=this.parentElement.querySelector('.js-status-hint');
         if(this.value==='not-selected'){
           tr.dataset.pendingAction='not-selected';
-          this.nextElementSibling && (this.nextElementSibling.textContent='Pick a reason in the Reject cell');
+          if(hint)hint.textContent='Pick a reason →';
+          if(rejectSel){rejectSel.classList.add('ring-2','ring-amber-400','animate-pulse');rejectSel.focus();}
         } else {
+          delete tr.dataset.pendingAction;
+          if(hint)hint.textContent='';
+          if(rejectSel)rejectSel.classList.remove('ring-2','ring-amber-400','animate-pulse');
           htmx.ajax('POST',`/board/jobs/{{ fp }}/${this.value}`,{target:tr,swap:'outerHTML'});
-        }
-        this.value='';">
+          this.value='';
+        }">
       <option value="">— Change status —</option>
       {% if stage != 'interview' %}<option value="interview">Interviewing</option>{% endif %}
       {% if stage != 'offer' %}<option value="offer">Offer</option>{% endif %}
       <option value="withdraw">Withdrew</option>
       <option value="not-selected">Not Selected</option>
     </select>
-    <span class="ml-2 text-xs text-slate-500"></span>
+    <span class="js-status-hint ml-2 text-xs font-medium text-amber-700"></span>
     {% endif %}
   {% elif tab == 'review' %}
     <button type="button"


### PR DESCRIPTION
## Summary
- Applied-tab STATUS dropdown no longer visually "reverts" when the operator picks **Not Selected** — the option stays selected until the reason is chosen.
- Reject-reason cell in the same row gets an amber `ring-2` + `animate-pulse` + `.focus()` so the required next click is unmissable.
- Status cell's inline hint span is upgraded from `text-slate-500 "Pick a reason in the Reject cell"` to `text-amber-700 font-medium "Pick a reason →"`.
- Two-cell write architecture + `tr.dataset.pendingAction` routing are unchanged — `POST /not-selected` still fires on reason-pick, `POST /reject` still fires for the user-rejection-of-applied path.

Closes #214.

## Design notes
Option 1 variant from the issue — kept the existing two-cell structure instead of collapsing into per-reason STATUS entries (would duplicate the 11 reject-reason options across two dropdowns) or defaulting to "Unspecified" (would pollute rejection-data quality the Rejected Applications tab is built on).

The `else` branch of the onchange handler now proactively clears `pendingAction`, removes the ring, and blanks the hint before firing the non-not-selected POST — so an operator who picks "Not Selected" and then changes their mind (e.g., picks "Withdrew") leaves no orphan state.

## Test plan
- [x] Scratch DB with one `stage=applied` row + audit_log entry; served via `uvicorn findajob.web.app:default_app --factory`
- [x] Playwright drive: select `Not Selected` → assert `statusSel.value==='not-selected'`, `ring-2 ring-amber-400 animate-pulse` on reject select, `document.activeElement===rejectSel`, `pendingAction==='not-selected'`, hint text `"Pick a reason →"`
- [x] Follow-through: pick reason `Company Not a Fit` → row disappears from `/board/applied` (HTMX outerHTML replace), DB `stage=not_selected`, `reject_reason='Company Not a Fit'`, `audit_log` has both transitions, `feedback_log` is empty (confirms `/not-selected` fired, not `/reject`)
- [x] Cancel path: pick `Not Selected` → pick `Withdrew` instead → ring removed, pendingAction deleted, htmx.ajax called with `/board/jobs/{fp}/withdraw`
- [x] `uv run ruff check .` + `ruff format --check .` + `mypy src/findajob/web/` clean
- [x] `uv run pytest tests/test_board_actions.py tests/test_web_routes.py tests/test_actions.py tests/test_actions_resurface.py` — 122 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)