### PR TITLE
feat(notify): de-jargon user-facing subcommand strings (#151)

### DIFF
--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -1,16 +1,23 @@
 #!/usr/bin/env python3
 # ~/JobSearchPipeline/scripts/notify.py
 """
-ntfy push notification suite for the JobSearchPipeline.
+ntfy push notification suite for findajob.
 
-Usage:
-  notify.py daily-stats      — morning stats: queue depth, recent activity
-  notify.py health-check     — surface errors from logs, confirm automations ran
-  notify.py issues-ping      — open GitHub issues (run every other day)
-  notify.py apply-reminder   — humorous daily nudge to submit at least one application
-  notify.py feedback-review  — alert when feedback_log has enough data to be useful
+Subcommands:
+  daily-stats     — morning summary of pipeline state (user-facing)
+  apply-reminder  — daily nudge with quip + checklist (user-facing)
+  feedback-review — analysis of jobs you've passed on (user-facing)
+  health-check    — operator diagnostic: surface errors and stale automations
+  issues-ping     — open GitHub issues (operator)
+  ci-check        — alert on latest main-branch CI failure (operator)
+  scoreboard      — refresh the pipeline funnel issue (operator)
+  send-raw        — passthrough; usage: notify.py send-raw <title> <body>
 
-ntfy topic is read from NTFY_TOPIC in data/.env, or falls back to NTFY_TOPIC env var.
+User-facing subcommand strings stay in plain English (#151). Operator
+diagnostics keep their technical detail; only their titles are branded.
+
+ntfy topic is read from NTFY_TOPIC in data/.env, or falls back to the
+NTFY_TOPIC env var.
 """
 
 import json
@@ -59,6 +66,11 @@ def send(title, body, priority="default", tags=None):
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
+def _p(n, singular, plural=None):
+    """Pluralize for user-facing notification strings (#151)."""
+    return f"{n} {singular}" if n == 1 else f"{n} {plural or singular + 's'}"
+
+
 def db_connect():
     conn = sqlite3.connect(DB_PATH, timeout=30)
     conn.row_factory = sqlite3.Row
@@ -168,17 +180,19 @@ def cmd_daily_stats():
     conn.close()
 
     lines = [
-        f"Queue (score≥7, unprepped): {queue_count} jobs",
-        f"Flagged, awaiting prep:     {flagged_unprepped}",
-        f"Materials drafted:          {prepped}",
-        f"Applied:                    {applied}",
-        f"Rejected (user):            {rejected}",
-        f"Not selected (company):     {not_selected}",
-        f"New jobs scored today:      {new_today}",
-        f"Total in pipeline:          {total}",
+        "Good morning! Here's where things stand:",
+        "",
+        f"  {_p(new_today, 'new job')} ranked overnight",
+        f"  {_p(queue_count, 'strong match', 'strong matches')} waiting for you",
+        f"  {_p(flagged_unprepped, 'job')} you've flagged but haven't started yet",
+        f"  {_p(prepped, 'application')} ready to send (resume and cover letter drafted)",
+        f"  {_p(applied, 'application')} submitted overall",
+        f"  {_p(rejected, 'job')} you've passed on",
+        f"  {_p(not_selected, 'application')} where the company said no",
+        f"  {_p(total, 'job')} tracked in total",
     ]
     body = "\n".join(lines)
-    send("JSP Daily Stats", body, priority="default", tags="bar_chart")
+    send("💼 findajob — good morning!", body, priority="default", tags="bar_chart")
 
 
 SHEET1_ROW_WARN = 5000  # warn if Sheet1 would sync more than this many rows
@@ -430,7 +444,7 @@ def cmd_health_check():
         priority = "high" if any("ERROR" in i for i in issues) else "default"
         tags = "warning"
 
-    send("JSP Health Check", body, priority=priority, tags=tags)
+    send("💼 findajob — health check", body, priority=priority, tags=tags)
 
 
 def cmd_issues_ping():
@@ -444,21 +458,25 @@ def cmd_issues_ping():
             lines.append(f"{i}. {iss}")
         body = "\n".join(lines)
         tags = "memo"
-    send("JSP Open Issues", body, priority="default", tags=tags)
+    send("💼 findajob — open issues", body, priority="default", tags=tags)
 
 
 def cmd_apply_reminder():
     QUIPS = [
         "The perfect resume is the enemy of the submitted one. Go click Apply.",
-        "GPT-6 isn't submitting your application. You are. Open a tab.",
+        "Your resume can't apply to itself. We checked. Open a tab.",
         "Somewhere a hiring manager is waiting for your resume. Don't keep them waiting.",
         "Every application you don't submit is a job you definitely didn't get.",
-        "The pipeline doesn't apply for you. That's still a manual step. Do it.",
+        "Today's to-do list: 1) breathe, 2) hydrate, 3) submit one application. You've already crushed two of three.",
         "Your future self is staring at you. They look annoyed. Apply to something.",
-        "DeepSeek scored it a 9. Your mouse is scored a 0. Click Apply.",
+        "What did the cover letter say to the resume? 'I've got you covered.' Now go give them something to cover.",
         "Reject the fear of rejection. Apply anyway. Preferably today.",
         "Fun fact: 0% of jobs you don't apply to result in interviews.",
-        "The Dashboard is not an art installation. It has checkboxes for a reason.",
+        (
+            "Why did the job seeker bring a ladder to the interview? "
+            "Heard there were openings on a higher floor. "
+            "Speaking of openings — apply to one."
+        ),
     ]
     # Rotate by day-of-year in PT so the quip changes at midnight Pacific
     from zoneinfo import ZoneInfo
@@ -481,17 +499,16 @@ def cmd_apply_reminder():
 
     checklist = (
         f"\n---\n"
-        f"1. Dashboard: {n_dashboard} high-score jobs to Flag for Prep or Reject\n"
-        f"2. Ready to Apply: {n_ready} jobs with materials drafted — review and submit\n"
-        f"3. Review tab: {n_review} jobs in manual review — Promote or Reject\n"
-        f"4. Scan Sheet1 for mis-scored target company jobs\n"
-        f"5. Check ntfy health notification for pipeline warnings\n"
+        f"1. {_p(n_dashboard, 'strong match', 'strong matches')} waiting — "
+        f"flag the keepers, pass on the rest\n"
+        f"2. {_p(n_ready, 'application')} ready to send — review and submit\n"
+        f"3. {_p(n_review, 'job')} for you to review — promote or pass\n"
         f"---\n"
-        f"Applied so far: {n_applied}\n"
-        f"Waitlisted: {n_waitlisted} deferred jobs"
+        f"Applications submitted to date: {n_applied}\n"
+        f"Set aside for later: {n_waitlisted}"
     )
 
-    send("Apply To Something Today", quip + checklist, priority="default", tags="rocket")
+    send("💼 findajob — apply to something today!", quip + checklist, priority="default", tags="rocket")
 
 
 def cmd_feedback_review():
@@ -528,22 +545,17 @@ def cmd_feedback_review():
             kw["keyword"] for kw in data.get("keyword_signals", []) if kw["ratio"] < 0.4 and kw["rejected_n"] >= 3
         ][:4]
         body = (
-            f"{count} rejections in feedback_log\n"
-            f"False positives (score 8+): {fp} ({fp_pct}%)\n"
-            f"Top reason: {top_reason[0]} ({top_reason[1]})\n"
-            f"Top FP company: {top_company[0]} ({top_company[1]} rejections)\n"
-            + (f"Prefilter candidates: {', '.join(bad_kws)}\n" if bad_kws else "")
-            + f"Trends: {WEB_BASE_URL}/stats/feedback\n"
-            + "Run: python3 scripts/analyze_feedback.py"
+            f"You've passed on {count} jobs so far.\n"
+            f"{fp} of those were strong matches the ranker recommended ({fp_pct}%) — these are where it got it wrong.\n"
+            f"Most common reason for passing: {top_reason[0]} ({top_reason[1]} times)\n"
+            f"Company you keep passing on: {top_company[0]} ({top_company[1]} times)\n"
+            + (f"Words that often signal a pass: {', '.join(bad_kws)}\n" if bad_kws else "")
+            + f"See the trends: {WEB_BASE_URL}/stats/feedback"
         )
     else:
-        body = (
-            f"feedback_log has {count} rejection entries.\n"
-            f"Trends: {WEB_BASE_URL}/stats/feedback\n"
-            f"Run: python3 scripts/analyze_feedback.py"
-        )
+        body = f"You've passed on {count} jobs so far.\nSee the trends: {WEB_BASE_URL}/stats/feedback"
 
-    send("JSP Feedback Analysis", body, priority="default", tags="magnifying")
+    send("💼 findajob — feedback check", body, priority="default", tags="magnifying")
 
 
 def cmd_send_raw():
@@ -567,7 +579,7 @@ def cmd_ci_check():
         timeout=30,
     )
     if result.returncode != 0:
-        send("JSP CI Check", f"gh run list failed: {result.stderr[:200]}", priority="default", tags="warning")
+        send("💼 findajob — CI check", f"gh run list failed: {result.stderr[:200]}", priority="default", tags="warning")
         return
 
     import json as _json
@@ -590,7 +602,7 @@ def cmd_ci_check():
         f"  {latest.get('displayTitle', '?')}",
         f"  {latest.get('url', '')}",
     ]
-    send("JSP CI Failure", "\n".join(lines), priority="high", tags="x")
+    send("💼 findajob — CI failed", "\n".join(lines), priority="high", tags="x")
 
 
 SCOREBOARD_ISSUE = 31
@@ -858,9 +870,14 @@ Cumulative counts — how many jobs ever reached each stage, not just current st
     )
     if rc.returncode == 0:
         msg = f"Pipeline funnel scoreboard (#31) updated for {today}."
-        send("Scoreboard Updated", msg, priority="low", tags="bar_chart")
+        send("💼 findajob — scoreboard updated", msg, priority="low", tags="bar_chart")
     else:
-        send("Scoreboard Update Failed", f"gh issue edit failed: {rc.stderr[:200]}", priority="high", tags="warning")
+        send(
+            "💼 findajob — scoreboard update failed",
+            f"gh issue edit failed: {rc.stderr[:200]}",
+            priority="high",
+            tags="warning",
+        )
 
 
 # ── Dispatch ───────────────────────────────────────────────────────────────────

--- a/tests/test_notify_dejargon.py
+++ b/tests/test_notify_dejargon.py
@@ -1,0 +1,174 @@
+"""De-jargon guard for notify.py user-facing subcommands (#151).
+
+Three subcommands are direct user nudges (notifications a non-technical
+beta tester reads): daily-stats, apply-reminder, feedback-review. Their
+body strings must avoid pipeline-internal jargon. Operator diagnostics
+(health-check, ci-check, scoreboard) keep their technical detail; only
+the titles are branded.
+
+This test imports scripts/notify.py with DB_PATH and send() monkeypatched,
+calls each subcommand, and asserts on the captured send() args.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+NOTIFY_PATH = REPO / "scripts" / "notify.py"
+
+# Pipeline-internal terms that must not appear in user-facing notification bodies.
+# Operator-facing subcommands (health-check, ci-check, scoreboard) are exempt.
+USER_FACING_JARGON = (
+    "manual_review",
+    "feedback_log",
+    "Sheet1",
+    "ntfy",
+    "DeepSeek",
+    "GPT-",
+    "Materials drafted",
+    "False positives",
+    "False positive",
+    "Top FP",
+    "Prefilter candidates",
+    "triage backlog",
+    "Flag for Prep",
+    "Dashboard",  # web /board page name; surface as "matches" / "review" instead
+)
+
+BRAND = "💼 findajob"
+
+
+def _load_notify_module(db_path: Path):
+    """Import scripts/notify.py as a module so we can monkeypatch its globals."""
+    spec = importlib.util.spec_from_file_location("notify_under_test", NOTIFY_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["notify_under_test"] = mod
+    spec.loader.exec_module(mod)
+    mod.DB_PATH = str(db_path)
+    return mod
+
+
+@pytest.fixture
+def notify_module(tmp_path, monkeypatch):
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            company TEXT NOT NULL DEFAULT '',
+            stage TEXT DEFAULT 'scored',
+            relevance_score INTEGER,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            stage_updated TEXT,
+            apply_flag INTEGER DEFAULT 0,
+            dupe_of TEXT DEFAULT '',
+            prep_folder_path TEXT
+        );
+        CREATE TABLE feedback_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id TEXT,
+            reason TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        INSERT INTO jobs (id, title, stage, relevance_score) VALUES ('a','t','scored',8);
+        INSERT INTO jobs (id, title, stage, relevance_score, apply_flag)
+            VALUES ('b','t','scored',9,1);
+        INSERT INTO jobs (id, title, stage) VALUES ('c','t','materials_drafted');
+        INSERT INTO jobs (id, title, stage) VALUES ('d','t','applied');
+        INSERT INTO jobs (id, title, stage) VALUES ('e','t','rejected');
+        INSERT INTO jobs (id, title, stage) VALUES ('f','t','waitlisted');
+        INSERT INTO jobs (id, title, stage) VALUES ('g','t','manual_review');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    mod = _load_notify_module(db)
+    sent: list[dict] = []
+
+    def fake_send(title, body, **kw):
+        sent.append({"title": title, "body": body, **kw})
+
+    monkeypatch.setattr(mod, "send", fake_send)
+    mod._sent = sent  # type: ignore[attr-defined]
+    return mod
+
+
+def _assert_no_jargon(body: str, label: str):
+    for token in USER_FACING_JARGON:
+        assert token not in body, f"{label} body contains pipeline jargon {token!r}: {body!r}"
+
+
+def test_daily_stats_is_branded_and_plain_english(notify_module):
+    notify_module.cmd_daily_stats()
+    assert notify_module._sent, "send() not called"
+    msg = notify_module._sent[0]
+    assert msg["title"].startswith(BRAND), f"title not branded: {msg['title']!r}"
+    _assert_no_jargon(msg["body"], "daily-stats")
+
+
+def test_apply_reminder_is_branded_and_plain_english(notify_module):
+    notify_module.cmd_apply_reminder()
+    assert notify_module._sent, "send() not called"
+    msg = notify_module._sent[0]
+    assert msg["title"].startswith(BRAND), f"title not branded: {msg['title']!r}"
+    _assert_no_jargon(msg["body"], "apply-reminder")
+
+
+def test_apply_reminder_quips_have_no_tech_specific_jokes(notify_module):
+    quips = [
+        "The perfect resume is the enemy of the submitted one. Go click Apply.",
+        "Your resume can't apply to itself. We checked. Open a tab.",
+    ]
+    # Fetch the actual QUIPS list from the module to guard against any new entry
+    # sneaking in tech-specific terms.
+    import inspect
+
+    src = inspect.getsource(notify_module.cmd_apply_reminder)
+    for token in ("DeepSeek", "GPT-", "ChatGPT", "Claude ", "the pipeline", "the Dashboard"):
+        assert token not in src, f"cmd_apply_reminder source contains tech-specific token {token!r}"
+    # Sanity: at least the kept quips are still present.
+    for q in quips:
+        assert q in src, f"expected quip missing: {q!r}"
+
+
+def test_feedback_review_is_branded_and_plain_english(notify_module):
+    # cmd_feedback_review only sends when feedback_log has >= 10 entries.
+    conn = sqlite3.connect(notify_module.DB_PATH)
+    for i in range(15):
+        conn.execute(
+            "INSERT INTO feedback_log (job_id, reason) VALUES (?, ?)",
+            (f"j{i}", "too senior"),
+        )
+    conn.commit()
+    conn.close()
+
+    notify_module.cmd_feedback_review()
+    assert notify_module._sent, "send() not called for >=10 feedback entries"
+    msg = notify_module._sent[0]
+    assert msg["title"].startswith(BRAND), f"title not branded: {msg['title']!r}"
+    _assert_no_jargon(msg["body"], "feedback-review")
+
+
+def test_all_send_titles_are_branded():
+    """Every send() call site (except the passthrough send-raw) must use the
+    💼 findajob brand prefix on its title literal."""
+    import re
+
+    text = NOTIFY_PATH.read_text()
+    # Capture the first string-literal arg to send(...) calls; matches both
+    # `send("Title", ...)` and `send(\n    "Title",\n    ...)`.
+    titles = re.findall(r'send\(\s*["\']([^"\']+)["\']', text)
+    assert titles, "regex failed to find any send() title literals"
+    unbranded = [t for t in titles if not t.startswith(BRAND)]
+    assert not unbranded, f"unbranded send() titles: {unbranded}"


### PR DESCRIPTION
## Summary

- Rewrites `daily-stats`, `apply-reminder`, and `feedback-review` notification bodies in plain English (closes #151).
- Brands all subcommand titles with a friendly `💼 findajob` prefix; user-facing notifications open with personified greetings ("Good morning! Here's where things stand:", "💼 findajob — apply to something today!").
- Replaces tech-specific apply-reminder quips (DeepSeek/GPT-6/"the pipeline"/"the Dashboard") with field-agnostic dad-joke equivalents so the nudge lands for any beta tester (e.g. Alice / Amy on `findajob-amy`).
- Operator subcommands (`health-check`, `ci-check`, `scoreboard`, `issues-ping`) keep their technical body content — only their titles get the brand prefix.
- Adds a tiny `_p()` pluralization helper so counts read correctly at 0/1/many ("1 application ready to send" vs "5 applications ready to send").

## Behavior preserved

SQL queries, ntfy routing, COMMANDS dispatcher, supercronic schedule, priorities, tags, and trigger thresholds (e.g. feedback-review's `THRESHOLD = 10`) are all unchanged. Strings only.

## Sample renders

```
💼 findajob — good morning!
─────────────────────────────
Good morning! Here's where things stand:

  4 new jobs ranked overnight
  5 strong matches waiting for you
  1 job you've flagged but haven't started yet
  1 application ready to send (resume and cover letter drafted)
  2 applications submitted overall
  1 job you've passed on
  0 applications where the company said no
  8 jobs tracked in total
```

```
💼 findajob — apply to something today!
─────────────────────────────────────────
Every application you don't submit is a job you definitely didn't get.
---
1. 4 strong matches waiting — flag the keepers, pass on the rest
2. 1 application ready to send — review and submit
3. 1 job for you to review — promote or pass
---
Applications submitted to date: 2
Set aside for later: 0
```

## Test plan

- [x] `uv run pytest -q` — 842 passed, no regressions
- [x] `uv run ruff check` and `uv run ruff format --check` clean on edited files
- [x] New `tests/test_notify_dejargon.py` (5 tests) imports `notify.py` with `DB_PATH` and `send()` monkeypatched, calls each user-facing cmd, asserts captured title is branded and body contains none of: `manual_review`, `feedback_log`, `Sheet1`, `ntfy`, `DeepSeek`, `GPT-`, `Materials drafted`, `False positives`, `Top FP`, `Prefilter candidates`, `triage backlog`, `Flag for Prep`, `Dashboard`. Also greps the source file for any unbranded `send()` title literal.
- [x] Existing `test_notify_health_split.py` and `test_crontab_notify_alignment.py` still pass (no changes to SQL or `COMMANDS` keys).
- [ ] After merge: next supercronic firing of each subcommand on `docker.lan` and `findajob-amy` should produce the new rendered notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)