### PR TITLE
fix(web): serve /favicon.ico to suppress legacy 404 (#138)

### DIFF
--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -8,6 +8,7 @@ from collections.abc import Generator
 from pathlib import Path
 
 from fastapi import Depends, FastAPI  # noqa: F401 — Depends used in Task 6
+from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -33,6 +34,16 @@ def create_app(
 
     static_dir = Path(__file__).parent / "static"
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    # Browsers default-request /favicon.ico at the document root regardless
+    # of <link rel="icon">, producing a 404 on every page load (#138). Serve
+    # the existing SVG from that path; modern browsers accept SVG in the
+    # .ico slot.
+    favicon_path = static_dir / "favicon.svg"
+
+    @app.get("/favicon.ico", include_in_schema=False)
+    async def favicon() -> FileResponse:
+        return FileResponse(favicon_path, media_type="image/svg+xml")
 
     app.state.companies_root = companies_root
     app.state.db_path = db_path

--- a/tests/test_web_favicon.py
+++ b/tests/test_web_favicon.py
@@ -1,0 +1,36 @@
+"""GET /favicon.ico returns the SVG favicon, suppressing the legacy 404 (#138).
+
+Browsers default-request /favicon.ico at the document root regardless of any
+<link rel="icon"> tag, so the route must exist even though base.html points
+modern browsers at /static/favicon.svg.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE jobs (id TEXT)")
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    app = create_app(companies_root=companies, db_path=db, base_root=tmp_path)
+    return TestClient(app)
+
+
+def test_favicon_ico_returns_svg(client: TestClient) -> None:
+    r = client.get("/favicon.ico")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("image/svg+xml")
+    assert r.text.lstrip().startswith("<svg")


### PR DESCRIPTION
## Summary

- Adds a one-line `@app.get(\"/favicon.ico\")` handler in `src/findajob/web/app.py` that serves the existing `static/favicon.svg` with `image/svg+xml` media type. Modern browsers accept SVG in the `.ico` slot; the 404 on default browser fetch is gone.
- The existing `<link rel=\"icon\" type=\"image/svg+xml\" href=\"/static/favicon.svg\">` in `base.html` stays as the primary hint; the new route is the fallback for the default-fetch path.

Closes #138.

## Out of scope

Per-stack favicon tinting (bonus criterion in the issue body) is intentionally not done — can land separately if the operator/tester visual distinction is desired.

## Test plan

- [x] `uv run pytest -q` — 843 passed, no regressions
- [x] New `tests/test_web_favicon.py` asserts `GET /favicon.ico` → 200, content-type starts with `image/svg+xml`, body starts with `<svg`
- [x] Existing `tests/test_web_nav.py` still passes
- [x] `uv run ruff check` and `ruff format --check` clean
- [ ] After merge + deploy: browser devtools Network tab on any `/board/*` page should show `/favicon.ico` as 200, no console error

🤖 Generated with [Claude Code](https://claude.com/claude-code)