### PR TITLE
fix(docker): bake docs/ into image so /docs/ slug routes resolve (#224)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,10 +5,14 @@
 .gitignore
 .github
 
-# Docs / dev artifacts
-docs
+# Dev artifacts
 tests
 README.md
+
+# docs/ is included in the image — the /docs/ viewer serves the user guides
+# (usage, troubleshooting, setup/*) from /app/docs/. Exclude only the
+# internal plan/spec subtree which is large and not user-facing.
+docs/superpowers
 
 # Python caches (glob patterns need ** to recurse in .dockerignore)
 **/__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/docs/` slug routes now actually resolve in the shipped image (#224 follow-up).** v0.3.1 shipped the `/docs/` viewer but the Dockerfile didn't `COPY docs/` into `/app/docs/`, so the route served a 200 index but every slug link 404'd post-deploy. Fixed by copying `docs/` into the image at build time; added a `/docs/` + slug assertion to `scripts/test_container_integration.sh` so the regression can't recur silently — the v0.3.1 pre-tag smoke would have caught this if it had covered the route.
+
 ## [0.3.1] — 2026-04-24
 
 Patch bump. Two bugfixes for reliability issues surfaced during Alice's morning triage (#222, #223), plus the last-mile `/docs/` viewer that makes user-facing guides reachable from inside the web UI (#224). No migration required — rolling `docker compose pull && up -d` picks it up cleanly.

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ RUN pip install --no-cache-dir --break-system-packages -e .
 # shadowing tracked config.
 COPY scripts/ /app/scripts/
 COPY config/ /opt/findajob/bundled-config/
+COPY docs/ /app/docs/
 COPY ops/aichat-ng/ /opt/findajob/bundled-aichat/
 COPY ops/crontab /app/crontab
 COPY ops/entrypoint.sh /entrypoint.sh

--- a/scripts/test_container_integration.sh
+++ b/scripts/test_container_integration.sh
@@ -336,6 +336,17 @@ if ! echo "$BODY" | grep -q "In flight"; then
 fi
 echo "  index renders with expected sections"
 
+# /docs/ must be reachable — regression guard for #224: docs/ was not baked
+# into the image in v0.3.1, so the slug routes 404'd post-deploy.
+for slug in "" usage troubleshooting setup setup/install-docker; do
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${VIEWER_PORT}/docs/${slug}" || echo "FAIL")
+    if [ "$HTTP_CODE" != "200" ]; then
+        echo "ERROR: /docs/${slug} returned $HTTP_CODE (expected 200)" >&2
+        exit 1
+    fi
+done
+echo "  /docs/ + slug routes: 200 OK"
+
 if (cd "$SCRATCH" && docker compose exec -T scheduler which rclone >/dev/null 2>&1); then
     echo "ERROR: rclone is still in the image" >&2
     exit 1


### PR DESCRIPTION
## Summary

**v0.3.1 regression.** Shipped `/docs/` but docs weren't in the image — every slug link 404'd post-deploy. Fix + smoke assertion so it can't recur silently.

- `Dockerfile`: `COPY docs/ /app/docs/`
- `scripts/test_container_integration.sh`: assert `/docs/` + 4 slug routes all return 200
- `CHANGELOG.md`: `[Unreleased] Fixed` bullet

## Why the v0.3.1 smoke missed it

The TestClient suite mounts a synthetic `docs/` tree under `tmp_path`, so the route layer passes. The smoke ran fresh-install against `findajob:local` and only verified `/healthz` + `/materials/`. A route can work in the unit tests and 404 in the shipped image — that's the coverage gap this PR closes.

## Test plan

- [ ] CI green (lint, mypy, unit tests — expect no delta; docker-build-smoke will exercise the new smoke assertion)
- [ ] Pre-tag smoke run locally on docker.lan before v0.3.2 tag cut
- [ ] Post-deploy: curl /docs/setup etc. on both stacks returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)