### PR TITLE
feat(web): fit + probability scores on waitlist (#237)

### DIFF
--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -213,6 +213,8 @@ _WAITLIST_COLS = [
     ("Title", "title"),
     ("Company", "company"),
     ("Rel", "relevance_score"),
+    ("Fit", "fit_score"),
+    ("Prob", "probability_score"),
     ("Location", "location"),
     ("Remote", "remote_status"),
     ("AI notes", "ai_notes"),
@@ -234,7 +236,9 @@ def waitlist(
     sort_col = sort if sort in _WAITLIST_SORTABLE else _WAITLIST_DEFAULT_SORT
     order = "DESC" if desc else "ASC"
     sql = f"""
-    SELECT w.fingerprint, w.title, w.company, w.relevance_score, w.location, w.remote_status,
+    SELECT w.fingerprint, w.title, w.company, w.relevance_score,
+           w.fit_score, w.probability_score,
+           w.location, w.remote_status,
            w.ai_notes, w.created_at, w.stage, w.url,
            (SELECT j2.title || ' (' || j2.stage || ')'
               FROM jobs j2
@@ -565,7 +569,9 @@ def waitlist_rows(
     filter_sql, params = _filter_clause(q)
     qualified_filter = filter_sql.replace("title", "w.title").replace("company", "w.company")
     sql = f"""
-    SELECT w.fingerprint, w.title, w.company, w.relevance_score, w.location, w.remote_status,
+    SELECT w.fingerprint, w.title, w.company, w.relevance_score,
+           w.fit_score, w.probability_score,
+           w.location, w.remote_status,
            w.ai_notes, w.created_at, w.stage, w.url,
            (SELECT j2.title || ' (' || j2.stage || ')'
               FROM jobs j2

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -32,7 +32,7 @@
       {% elif field == 'company' and row.fingerprint and row.stage in folder_stages and materials_base_url %}
         <a class="underline" href="{{ materials_base_url }}/materials/{{ row.fingerprint }}">{{ row[field] }}</a>
       {% elif field in ('fit_score', 'probability_score') %}
-        {{ row[field] | round | int if row[field] is not none else '' }}
+        {{ row[field] | round | int if row[field] is not none else '—' }}
       {% else %}
         {{ row[field] if row[field] is not none else '' }}
       {% endif %}

--- a/tests/test_web_board_waitlist.py
+++ b/tests/test_web_board_waitlist.py
@@ -16,19 +16,21 @@ def client(tmp_path: Path) -> TestClient:
     conn = sqlite3.connect(db)
     conn.execute(
         "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "relevance_score INTEGER, location TEXT, remote_status TEXT, ai_notes TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, "
+        "location TEXT, remote_status TEXT, ai_notes TEXT, "
         "url TEXT, created_at TEXT, stage_updated TEXT)"
     )
-    # Meta has two jobs: one waitlisted, one actively applied — blocking_app should surface
+    # Meta has two jobs: one waitlisted (with all three scores), one actively applied
     conn.execute(
-        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score, stage_updated) "
-        "VALUES ('fp-wait','Ops Lead','Meta','waitlisted',8,'2026-04-18')"
+        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score, "
+        "fit_score, probability_score, stage_updated) "
+        "VALUES ('fp-wait','Ops Lead','Meta','waitlisted',8,72.0,48.0,'2026-04-18')"
     )
     conn.execute(
         "INSERT INTO jobs (fingerprint, title, company, stage, stage_updated) "
         "VALUES ('fp-blocker','NPI PM','Meta','applied','2026-04-20')"
     )
-    # Anthropic has only a waitlisted job; blocking_app should be NULL
+    # Anthropic has only a waitlisted job with NULL fit/prob scores — should render a dash
     conn.execute(
         "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score) "
         "VALUES ('fp-solo','Eng','Anthropic','waitlisted',6)"
@@ -49,3 +51,27 @@ def test_waitlist_shows_waitlisted_and_blocking_app(client: TestClient) -> None:
     # Meta's blocking app appears in the same row
     assert "NPI PM" in r.text
     assert "applied" in r.text
+
+
+def test_waitlist_shows_fit_and_probability_scores(client: TestClient) -> None:
+    """#237: waitlist view surfaces fit_score + probability_score for triage ranking."""
+    r = client.get("/board/waitlist")
+    assert r.status_code == 200
+    # Meta 'Ops Lead' row has fit_score=72.0, probability_score=48.0 — both render as integers.
+    assert "72" in r.text
+    assert "48" in r.text
+
+
+def test_waitlist_renders_dash_for_null_scores(client: TestClient) -> None:
+    """#237: NULL fit/prob scores render as '—' dash, not 0, so zero-signal rows don't
+    get mistaken for real zeros. Anthropic 'Eng' row has NULL in both columns."""
+    r = client.get("/board/waitlist")
+    assert r.status_code == 200
+    # Scope the check to the Anthropic <tr> so nav/header em-dashes don't leak in.
+    anthropic_idx = r.text.find("Anthropic")
+    assert anthropic_idx > 0, "Anthropic row not rendered"
+    row_end = r.text.find("</tr>", anthropic_idx)
+    assert row_end > anthropic_idx, "malformed HTML — no </tr> after Anthropic"
+    row = r.text[anthropic_idx:row_end]
+    # Expect at least two em-dashes in the row — one for NULL fit_score, one for NULL probability_score
+    assert row.count("—") >= 2, f"expected >=2 em-dashes in Anthropic row, got {row.count('—')}: {row[:500]}"


### PR DESCRIPTION
## Summary

- Adds `fit_score` and `probability_score` columns to `/board/waitlist` (main + HTMX partial).
- NULL scores render as em-dash (`—`) in the shared `_job_row.html` partial — applies to every tab using the partial.

Closes #237.

## Why

Operator uses waitlist as the active-triage surface on weekend Dashboard dips (diagnostic from today's structural review: 7+ jobs avg ~7/day but dips to 1 on Sun/Mon). With only `relevance_score` showing, ranking deferred jobs requires opening each one. Fit + probability are already in the DB — just weren't queried or rendered.

## Test plan

- [x] `uv run pytest tests/test_web_board_waitlist.py` — 3/3 pass (1 existing + 2 new)
- [x] `uv run pytest` — 865/865 pass (no regressions)
- [x] `uv run ruff check` + `ruff format --check` clean
- [ ] Visual smoke on `/board/waitlist` after merge + deploy — confirm columns render and em-dash shows for waitlist jobs with NULL fit/prob

🤖 Generated with [Claude Code](https://claude.com/claude-code)