### PR TITLE
feat(web): Archive score filter + Promote for score-6 queue (#238)

### DIFF
--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -361,7 +361,7 @@ def rejected_rows(
 
 
 _ARCHIVE_COLS = [
-    ("Score", "fit_score"),
+    ("Rel", "relevance_score"),
     ("Title", "title"),
     ("Company", "company"),
     ("Stage", "stage"),
@@ -376,12 +376,32 @@ _ARCHIVE_DEFAULT_SORT = "created_at"
 _ARCHIVE_PAGE_SIZE = 100
 
 
-def _archive_select_sql(sort_col: str, order: str) -> str:
-    return (
-        "SELECT fingerprint, title, company, stage, fit_score, location, remote_status, "
-        "source, url, created_at, stage_updated "
-        f"FROM jobs ORDER BY {sort_col} {order} LIMIT ? OFFSET ?"
+def _archive_score_where(min_score: int | None, max_score: int | None) -> tuple[str, list[int]]:
+    """Build a WHERE clause fragment (including 'WHERE ') and bind params for
+    optional relevance_score bounds. Returns ('', []) if both bounds are None."""
+    clauses: list[str] = []
+    params: list[int] = []
+    if min_score is not None:
+        clauses.append("relevance_score >= ?")
+        params.append(min_score)
+    if max_score is not None:
+        clauses.append("relevance_score <= ?")
+        params.append(max_score)
+    if not clauses:
+        return "", []
+    return " WHERE " + " AND ".join(clauses), params
+
+
+def _archive_select_sql(
+    sort_col: str, order: str, min_score: int | None = None, max_score: int | None = None
+) -> tuple[str, list[int]]:
+    where_sql, where_params = _archive_score_where(min_score, max_score)
+    sql = (
+        "SELECT fingerprint, title, company, stage, relevance_score, fit_score, "
+        "probability_score, location, remote_status, source, url, created_at, stage_updated "
+        f"FROM jobs{where_sql} ORDER BY {sort_col} {order} LIMIT ? OFFSET ?"
     )
+    return sql, where_params
 
 
 @router.get("/board/archive", response_class=HTMLResponse)
@@ -390,11 +410,14 @@ def archive(
     sort: str = Query(default=""),
     desc: int = Query(default=1),
     density: str = Query(default=_DEFAULT_DENSITY),
+    min_score: int | None = Query(default=None),
+    max_score: int | None = Query(default=None),
     db: sqlite3.Connection = Depends(get_db),  # noqa: B008
 ) -> HTMLResponse:
     sort_col = sort if sort in _ARCHIVE_SORTABLE else _ARCHIVE_DEFAULT_SORT
     order = "DESC" if desc else "ASC"
-    rows = db.execute(_archive_select_sql(sort_col, order), (_ARCHIVE_PAGE_SIZE, 0)).fetchall()
+    sql, where_params = _archive_select_sql(sort_col, order, min_score, max_score)
+    rows = db.execute(sql, (*where_params, _ARCHIVE_PAGE_SIZE, 0)).fetchall()
     has_more = len(rows) == _ARCHIVE_PAGE_SIZE
     materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
     templates = request.app.state.templates
@@ -410,6 +433,8 @@ def archive(
             "tab": "archive",
             "next_offset": _ARCHIVE_PAGE_SIZE if has_more else None,
             "materials_base_url": materials_base_url,
+            "min_score": min_score,
+            "max_score": max_score,
         },
     )
 
@@ -420,11 +445,14 @@ def archive_rows(
     offset: int = Query(default=0),
     sort: str = Query(default=""),
     desc: int = Query(default=1),
+    min_score: int | None = Query(default=None),
+    max_score: int | None = Query(default=None),
     db: sqlite3.Connection = Depends(get_db),  # noqa: B008
 ) -> HTMLResponse:
     sort_col = sort if sort in _ARCHIVE_SORTABLE else _ARCHIVE_DEFAULT_SORT
     order = "DESC" if desc else "ASC"
-    rows = db.execute(_archive_select_sql(sort_col, order), (_ARCHIVE_PAGE_SIZE, offset)).fetchall()
+    sql, where_params = _archive_select_sql(sort_col, order, min_score, max_score)
+    rows = db.execute(sql, (*where_params, _ARCHIVE_PAGE_SIZE, offset)).fetchall()
     has_more = len(rows) == _ARCHIVE_PAGE_SIZE
     materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
     templates = request.app.state.templates
@@ -439,6 +467,8 @@ def archive_rows(
             "sort": sort_col,
             "desc": desc,
             "materials_base_url": materials_base_url,
+            "min_score": min_score,
+            "max_score": max_score,
         },
     )
 

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -18,6 +18,8 @@
   {% if tab in ('dashboard', 'applied', 'review', 'waitlist') %}
     {% include "board/_status_cell.html" %}
     {% include "board/_reject_cell.html" %}
+  {% elif tab == 'archive' %}
+    {% include "board/_archive_promote_cell.html" %}
   {% endif %}
   {% for display, field in columns %}
     {% if tab == 'applied' and field == 'user_notes' %}

--- a/src/findajob/web/templates/board/_archive_promote_cell.html
+++ b/src/findajob/web/templates/board/_archive_promote_cell.html
@@ -1,0 +1,15 @@
+{#
+  Archive-tab-only: Promote action cell. Renders a button for rows at
+  stage='scored' (the pool that can still be promoted to manual_review
+  for Dashboard triage). Empty cell for rows already past that stage.
+  Inputs: row — sqlite3.Row with fingerprint + stage.
+#}
+<td class="px-3 py-1 align-top text-sm whitespace-nowrap">
+  {% if row.stage == 'scored' %}
+    <button type="button"
+            class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+            hx-post="/board/jobs/{{ row.fingerprint }}/promote"
+            hx-target="closest tr"
+            hx-swap="outerHTML">Promote</button>
+  {% endif %}
+</td>

--- a/src/findajob/web/templates/board/_archive_rows.html
+++ b/src/findajob/web/templates/board/_archive_rows.html
@@ -2,9 +2,9 @@
   {% include "_job_row.html" %}
 {% endfor %}
 {% if next_offset is not none %}
-  <tr hx-get="/board/archive/rows?offset={{ next_offset }}&sort={{ sort }}&desc={{ desc }}"
+  <tr hx-get="/board/archive/rows?offset={{ next_offset }}&sort={{ sort }}&desc={{ desc }}{% if min_score is not none %}&min_score={{ min_score }}{% endif %}{% if max_score is not none %}&max_score={{ max_score }}{% endif %}"
       hx-trigger="revealed"
       hx-swap="outerHTML">
-    <td colspan="{{ columns|length }}" class="px-3 py-2 text-xs text-slate-400">loading…</td>
+    <td colspan="{{ columns|length + 1 }}" class="px-3 py-2 text-xs text-slate-400">loading…</td>
   </tr>
 {% endif %}

--- a/src/findajob/web/templates/board/archive.html
+++ b/src/findajob/web/templates/board/archive.html
@@ -3,16 +3,28 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Archive ({{ rows|length }}{% if next_offset %}+{% endif %})</h1>
 {% include "board/_tabs.html" %}
-<div class="mb-3 text-xs text-slate-600 flex items-center gap-1">
-  <span>Rows:</span>
+<div class="mb-3 text-xs text-slate-600 flex items-center gap-2">
+  <span class="mr-2">Rows:</span>
   <a href="?sort={{ sort }}&desc={{ desc }}&density=compact"
      class="rounded px-2 py-1 {% if (density | default('compact')) == 'compact' %}bg-slate-900 text-white{% else %}bg-slate-100 text-slate-700 hover:bg-slate-200{% endif %}">Compact</a>
   <a href="?sort={{ sort }}&desc={{ desc }}&density=expanded"
      class="rounded px-2 py-1 {% if density == 'expanded' %}bg-slate-900 text-white{% else %}bg-slate-100 text-slate-700 hover:bg-slate-200{% endif %}">Expanded</a>
+  <span class="mx-2 text-slate-300">|</span>
+  <span>Quick filters:</span>
+  <a href="?min_score=6&max_score=6&sort=relevance_score&desc=1"
+     class="rounded px-2 py-1 {% if min_score == 6 and max_score == 6 %}bg-amber-600 text-white{% else %}bg-amber-100 text-amber-800 hover:bg-amber-200{% endif %}"
+     title="Near-miss review queue — promote to Dashboard">Score 6</a>
+  <a href="?min_score=7&sort=relevance_score&desc=1"
+     class="rounded px-2 py-1 {% if min_score == 7 and max_score is none %}bg-emerald-600 text-white{% else %}bg-emerald-100 text-emerald-800 hover:bg-emerald-200{% endif %}">Score 7+</a>
+  {% if min_score is not none or max_score is not none %}
+    <a href="?sort={{ sort }}&desc={{ desc }}"
+       class="rounded px-2 py-1 bg-slate-200 text-slate-700 hover:bg-slate-300">Clear</a>
+  {% endif %}
 </div>
 <table class="min-w-full bg-white shadow-sm rounded-sm density-{{ density | default('compact') }}">
   <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
     <tr>
+      <th class="px-3 py-2"></th>
       {% for display, field in columns %}
       <th class="px-3 py-2">
         <a href="?sort={{ field }}&desc={% if sort == field and desc %}0{% else %}1{% endif %}">

--- a/tests/test_web_board_archive.py
+++ b/tests/test_web_board_archive.py
@@ -16,14 +16,15 @@ def client(tmp_path: Path) -> TestClient:
     conn = sqlite3.connect(db)
     conn.execute(
         "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
-        "fit_score REAL, location TEXT, remote_status TEXT, source TEXT, url TEXT, "
-        "created_at TEXT, stage_updated TEXT)"
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, location TEXT, "
+        "remote_status TEXT, source TEXT, url TEXT, created_at TEXT, stage_updated TEXT)"
     )
     for i in range(150):
         conn.execute(
-            "INSERT INTO jobs (fingerprint, title, company, stage, fit_score, created_at) "
-            "VALUES (?, ?, ?, 'scored', ?, '2026-01-01')",
-            (f"fp-{i:03}", f"Role {i}", f"Co {i}", 1.0 + i % 10),
+            "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score, "
+            "fit_score, created_at) "
+            "VALUES (?, ?, ?, 'scored', ?, ?, '2026-01-01')",
+            (f"fp-{i:03}", f"Role {i}", f"Co {i}", 1 + i % 10, 1.0 + i % 10),
         )
     conn.commit()
     conn.close()
@@ -53,3 +54,99 @@ def test_archive_rows_endpoint_returns_fragment_not_full_page(client: TestClient
     r = client.get("/board/archive/rows?offset=0")
     assert r.status_code == 200
     assert "<body" not in r.text.lower()
+
+
+@pytest.fixture
+def scored_client(tmp_path: Path) -> TestClient:
+    """Small hand-crafted fixture with varied relevance_score + stage for filter/promote tests."""
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, location TEXT, "
+        "remote_status TEXT, source TEXT, url TEXT, created_at TEXT, stage_updated TEXT)"
+    )
+    # Two score-6 rows at stage='scored' — should appear with min_score=6 and have Promote button
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) "
+        "VALUES ('id-6a','fp-6a','Six Alpha','Co6A','scored',6,'2026-04-24')"
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) "
+        "VALUES ('id-6b','fp-6b','Six Bravo','Co6B','scored',6,'2026-04-24')"
+    )
+    # One score-3 row (below min_score=6, should be filtered out)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) "
+        "VALUES ('id-3','fp-3','Three Only','Co3','scored',3,'2026-04-24')"
+    )
+    # One score-9 row at stage='applied' — appears with min_score=6 but NO Promote button (already applied)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) "
+        "VALUES ('id-9','fp-9','Nine Applied','Co9','applied',9,'2026-04-24')"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+def test_archive_min_score_filters_rows(scored_client: TestClient) -> None:
+    """#238: /board/archive?min_score=6 hides rows with relevance_score < 6."""
+    r = scored_client.get("/board/archive?min_score=6")
+    assert r.status_code == 200
+    assert "Six Alpha" in r.text
+    assert "Six Bravo" in r.text
+    assert "Nine Applied" in r.text  # score=9 passes filter
+    assert "Three Only" not in r.text  # score=3 filtered out
+
+
+def test_archive_max_score_filters_rows(scored_client: TestClient) -> None:
+    """#238: /board/archive?max_score=5 hides rows with relevance_score > 5."""
+    r = scored_client.get("/board/archive?max_score=5")
+    assert r.status_code == 200
+    assert "Three Only" in r.text  # score=3 passes
+    assert "Six Alpha" not in r.text
+    assert "Nine Applied" not in r.text
+
+
+def test_archive_promote_button_on_scored_rows(scored_client: TestClient) -> None:
+    """#238: rows at stage='scored' render a Promote button (POST to /board/jobs/.../promote)."""
+    r = scored_client.get("/board/archive?min_score=6")
+    assert r.status_code == 200
+    # Promote button for fp-6a (stage=scored)
+    assert "/board/jobs/fp-6a/promote" in r.text
+
+
+def test_archive_no_promote_button_on_non_scored_rows(scored_client: TestClient) -> None:
+    """#238: rows at stages other than 'scored' do NOT render a Promote button."""
+    r = scored_client.get("/board/archive?min_score=6")
+    assert r.status_code == 200
+    # fp-9 is stage='applied' — no Promote button (already applied; promoting makes no sense)
+    assert "/board/jobs/fp-9/promote" not in r.text
+
+
+def test_archive_score6_preset_link_in_header(scored_client: TestClient) -> None:
+    """#238: Archive page has a one-click link to the score-6 review queue."""
+    r = scored_client.get("/board/archive")
+    assert r.status_code == 200
+    # Preset link with min_score=6 is the one-click entrypoint for weekend-dip triage
+    assert "min_score=6" in r.text
+
+
+def test_archive_rows_htmx_respects_min_score(scored_client: TestClient) -> None:
+    """#238: HTMX partial /board/archive/rows also filters on min_score for infinite-scroll consistency."""
+    r = scored_client.get("/board/archive/rows?offset=0&min_score=6")
+    assert r.status_code == 200
+    assert "Six Alpha" in r.text
+    assert "Three Only" not in r.text
+
+
+def test_archive_shows_relevance_score_column(scored_client: TestClient) -> None:
+    """#238: relevance_score is queried and rendered so operators can sort/filter by it."""
+    r = scored_client.get("/board/archive?min_score=6")
+    assert r.status_code == 200
+    # The sort link for relevance_score proves the column is in the header.
+    assert "sort=relevance_score" in r.text


### PR DESCRIPTION
## Summary

- `/board/archive?min_score=N&max_score=M` filters rows on `relevance_score` (bounds optional, inclusive).
- Promote button on `stage='scored'` rows in Archive — backs the existing `/board/jobs/{fp}/promote` handler.
- Preset "Score 6" and "Score 7+" quick filters in the Archive header + a Clear link.
- HTMX infinite-scroll sentinel carries the filter params so pagination stays consistent.

Closes #238.

## Why

Diagnostic from today's structural review: feeds produce 7+ at ~7/day but dip to 1 on Sundays. Score-6 bucket has 2-3 rows/day of real supply that was invisible — Dashboard filters >=7, Archive had no filter or row-level actions. Lowering Dashboard cutoff would flood the triage queue with false positives; Archive-browse-and-promote is the right shape.

## Test plan

- [x] `uv run pytest tests/test_web_board_archive.py` — 10/10 pass (3 existing + 7 new)
- [x] `uv run pytest` — 872/872 pass (no regressions)
- [x] `uv run ruff check` + `ruff format --check` clean
- [ ] Visual smoke after deploy:
  - Click "Score 6" preset → only score-6 rows visible, all stage=scored rows show Promote button
  - Click Promote on one → row disappears from Archive, appears on `/board/review` (manual_review stage)
  - Dashboard pulls it up on next page load
  - Clear filter → full Archive visible again

🤖 Generated with [Claude Code](https://claude.com/claude-code)