### PR TITLE
feat(web): company application history on dashboard/waitlist rows (#234)

### DIFF
--- a/src/findajob/web/company_history.py
+++ b/src/findajob/web/company_history.py
@@ -1,0 +1,165 @@
+"""Prior-application history per company — powers the Dashboard + Waitlist
+history cell added in #234.
+
+A row on /board/dashboard or /board/waitlist shows, alongside the job, the
+operator's prior dealings with the same company: how many applications are
+currently pending, and how many have been marked not_selected by the company.
+
+Company matching uses the first normalized word (`normalize(company).split()[0]`)
+so "Meta" and "Meta Platforms" collapse (AC5). Operator-side `rejected` jobs
+are excluded (AC7 — noise for this decision, not signal). Not_selected within
+90 days flags yellow; an offer anywhere at the company flags green (AC3).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from findajob.cleaning import normalize
+
+# Stages counted as "pending" per AC1 — strictly post-application, excluding
+# materials_drafted/prep_in_progress which are pre-submission.
+_PENDING_STAGES = ("applied", "interview", "offer")
+
+_NOT_SELECTED_RECENT_DAYS = 90
+
+
+def _company_key(company: str | None) -> str:
+    """First normalized word — the loose-match key for company history.
+
+    Collapses "Meta" and "Meta Platforms", "Google" and "Google Cloud", etc.
+    Returns an empty string for blank input.
+    """
+    if not company:
+        return ""
+    words = normalize(company).split()
+    return words[0] if words else ""
+
+
+@dataclass(frozen=True)
+class _HistoryEntry:
+    id: str
+    fingerprint: str
+    title: str
+    company: str
+    stage: str
+    prep_folder_path: str | None
+    not_selected_at: str | None  # naive-space timestamp from audit_log, or None
+
+
+def _parse_audit_timestamp(raw: str | None) -> datetime | None:
+    """audit_log.changed_at is naive space-format ('YYYY-MM-DD HH:MM:SS')."""
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def fetch_company_history(db: sqlite3.Connection) -> dict[str, dict]:
+    """Return {company_key: {entries: [...], has_offer: bool, has_recent_not_selected: bool}}.
+
+    One SQL scan of the jobs table, grouped in Python by first-normalized-word
+    of `company`. Each entry carries enough data for the row-level annotator
+    to build counts, color flags, and the expand-detail listing.
+    """
+    sql = """
+    SELECT j.id, j.fingerprint, j.title, j.company, j.stage, j.prep_folder_path,
+           al.changed_at AS not_selected_at
+    FROM jobs j
+    LEFT JOIN (
+      SELECT job_id, MAX(changed_at) AS changed_at
+      FROM audit_log
+      WHERE field_changed = 'stage' AND new_value = 'not_selected'
+      GROUP BY job_id
+    ) al ON al.job_id = j.id
+    WHERE j.stage IN ('applied','interview','offer','not_selected')
+    """
+    rows = db.execute(sql).fetchall()
+
+    cutoff = datetime.now(UTC) - timedelta(days=_NOT_SELECTED_RECENT_DAYS)
+    buckets: dict[str, dict] = {}
+    for row in rows:
+        key = _company_key(row["company"])
+        if not key:
+            continue
+        bucket = buckets.setdefault(key, {"entries": [], "has_offer": False, "has_recent_not_selected": False})
+        entry = _HistoryEntry(
+            id=row["id"],
+            fingerprint=row["fingerprint"],
+            title=row["title"],
+            company=row["company"],
+            stage=row["stage"],
+            prep_folder_path=row["prep_folder_path"] if "prep_folder_path" in row.keys() else None,
+            not_selected_at=row["not_selected_at"],
+        )
+        bucket["entries"].append(entry)
+        if entry.stage == "offer":
+            bucket["has_offer"] = True
+        if entry.stage == "not_selected":
+            ts = _parse_audit_timestamp(entry.not_selected_at)
+            if ts is not None and ts >= cutoff:
+                bucket["has_recent_not_selected"] = True
+    return buckets
+
+
+def history_for_row(
+    row: sqlite3.Row,
+    company_history: dict[str, dict],
+) -> dict:
+    """Per-row history annotation — counts, flag color, and expand-detail list.
+
+    Excludes the row's own fingerprint from its own history (no self-count).
+    The returned dict is template-ready:
+        {
+          "pending_count": int,
+          "not_selected_count": int,
+          "flag": "green" | "yellow" | "",
+          "entries": [ {title, stage, fingerprint, prep_folder_path, not_selected_at}, ... ],
+        }
+    """
+    key = _company_key(row["company"])
+    bucket = company_history.get(key)
+    if not bucket:
+        return {"pending_count": 0, "not_selected_count": 0, "flag": "", "entries": []}
+
+    entries: Sequence[_HistoryEntry] = bucket["entries"]
+    own_fp = row["fingerprint"]
+    pending = [e for e in entries if e.fingerprint != own_fp and e.stage in _PENDING_STAGES]
+    not_selected = [e for e in entries if e.fingerprint != own_fp and e.stage == "not_selected"]
+
+    cutoff = datetime.now(UTC) - timedelta(days=_NOT_SELECTED_RECENT_DAYS)
+    has_offer = any(e.stage == "offer" for e in pending)
+    has_recent_ns = any(
+        (_parse_audit_timestamp(e.not_selected_at) or datetime.min.replace(tzinfo=UTC)) >= cutoff for e in not_selected
+    )
+    flag = "green" if has_offer else ("yellow" if has_recent_ns else "")
+
+    return {
+        "pending_count": len(pending),
+        "not_selected_count": len(not_selected),
+        "flag": flag,
+        "entries": [
+            {
+                "title": e.title,
+                "stage": e.stage,
+                "fingerprint": e.fingerprint,
+                "prep_folder_path": e.prep_folder_path,
+                "not_selected_at": e.not_selected_at,
+            }
+            for e in (pending + not_selected)
+        ],
+    }
+
+
+def build_history_by_fp(
+    rows: Sequence[sqlite3.Row],
+    company_history: dict[str, dict],
+) -> dict[str, dict]:
+    """Precompute per-row history annotations keyed by fingerprint so templates
+    can look up with a single dict access instead of re-running the filter."""
+    return {row["fingerprint"]: history_for_row(row, company_history) for row in rows}

--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -8,6 +8,7 @@ import sqlite3
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse
 
+from findajob.web.company_history import build_history_by_fp, fetch_company_history
 from findajob.web.routes.materials import get_db
 
 router = APIRouter()
@@ -33,6 +34,7 @@ _DASHBOARD_COLS = [
     ("Likelihood", "interview_likelihood"),
     ("Title", "title"),
     ("Company", "company"),
+    ("History", "company_history"),
     ("Location", "location"),
     ("Remote", "remote_status"),
     ("Contacts", "known_contacts"),
@@ -41,7 +43,9 @@ _DASHBOARD_COLS = [
     ("Date", "created_at"),
 ]
 
-_DASHBOARD_SORTABLE = {c for _, c in _DASHBOARD_COLS}
+# company_history is a synthetic column — computed in Python from one
+# full-table scan per render — not a sortable DB field.
+_DASHBOARD_SORTABLE = {c for _, c in _DASHBOARD_COLS if c != "company_history"}
 _DASHBOARD_DEFAULT_SORT = "relevance_score"
 
 _VALID_DENSITIES = {"compact", "expanded"}
@@ -85,6 +89,7 @@ def dashboard(
         f"FROM jobs WHERE {_DASHBOARD_WHERE} "
         f"ORDER BY {sort_col} {order}"
     ).fetchall()
+    history_by_fp = build_history_by_fp(rows, fetch_company_history(db))
     materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
     templates = request.app.state.templates
     return templates.TemplateResponse(
@@ -93,6 +98,7 @@ def dashboard(
         context={
             "columns": _DASHBOARD_COLS,
             "rows": rows,
+            "history_by_fp": history_by_fp,
             "sort": sort_col,
             "desc": desc,
             "density": _normalize_density(density),
@@ -212,6 +218,7 @@ def review(
 _WAITLIST_COLS = [
     ("Title", "title"),
     ("Company", "company"),
+    ("History", "company_history"),
     ("Rel", "relevance_score"),
     ("Fit", "fit_score"),
     ("Prob", "probability_score"),
@@ -221,7 +228,7 @@ _WAITLIST_COLS = [
     ("Date", "created_at"),
     ("Blocking app", "blocking_app"),
 ]
-_WAITLIST_SORTABLE = {c for _, c in _WAITLIST_COLS if c != "blocking_app"}
+_WAITLIST_SORTABLE = {c for _, c in _WAITLIST_COLS if c not in ("blocking_app", "company_history")}
 _WAITLIST_DEFAULT_SORT = "created_at"
 
 
@@ -252,6 +259,7 @@ def waitlist(
     ORDER BY {sort_col} {order}
     """
     rows = db.execute(sql).fetchall()
+    history_by_fp = build_history_by_fp(rows, fetch_company_history(db))
     materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
     templates = request.app.state.templates
     return templates.TemplateResponse(
@@ -260,6 +268,7 @@ def waitlist(
         context={
             "columns": _WAITLIST_COLS,
             "rows": rows,
+            "history_by_fp": history_by_fp,
             "sort": sort_col,
             "desc": desc,
             "density": _normalize_density(density),
@@ -498,6 +507,7 @@ def dashboard_rows(
         f"ORDER BY {sort_col} {order}",
         params,
     ).fetchall()
+    history_by_fp = build_history_by_fp(rows, fetch_company_history(db))
     materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
     templates = request.app.state.templates
     return templates.TemplateResponse(
@@ -506,6 +516,7 @@ def dashboard_rows(
         context={
             "columns": _DASHBOARD_COLS,
             "rows": rows,
+            "history_by_fp": history_by_fp,
             "tab": "dashboard",
             "materials_base_url": materials_base_url,
         },
@@ -615,6 +626,7 @@ def waitlist_rows(
     ORDER BY {sort_col} {order}
     """
     rows = db.execute(sql, params).fetchall()
+    history_by_fp = build_history_by_fp(rows, fetch_company_history(db))
     materials_base_url = os.environ.get("FINDAJOB_MATERIALS_BASE_URL", "")
     templates = request.app.state.templates
     return templates.TemplateResponse(
@@ -623,6 +635,7 @@ def waitlist_rows(
         context={
             "columns": _WAITLIST_COLS,
             "rows": rows,
+            "history_by_fp": history_by_fp,
             "tab": "waitlist",
             "materials_base_url": materials_base_url,
         },

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -30,6 +30,7 @@ from findajob.actions import (
 )
 from findajob.paths import BASE
 from findajob.utils import log_event, write_audit
+from findajob.web.company_history import build_history_by_fp, fetch_company_history
 from findajob.web.routes.board import _APPLIED_COLS, _DASHBOARD_COLS
 from findajob.web.routes.materials import get_db
 
@@ -82,15 +83,21 @@ def _fetch_dashboard_row(db: sqlite3.Connection, fingerprint: str) -> sqlite3.Ro
     return db.execute(_DASHBOARD_ROW_SQL, (fingerprint,)).fetchone()
 
 
-def _render_dashboard_row(request: Request, row: sqlite3.Row) -> HTMLResponse:
-    """Render a single dashboard row for HTMX outerHTML swap."""
+def _render_dashboard_row(request: Request, row: sqlite3.Row, db: sqlite3.Connection) -> HTMLResponse:
+    """Render a single dashboard row for HTMX outerHTML swap.
+
+    Annotates the row with its company-history cell (#234) so the HTMX
+    swap doesn't erase the history column until the next full-page reload.
+    """
     templates = request.app.state.templates
+    history_by_fp = build_history_by_fp([row], fetch_company_history(db))
     return templates.TemplateResponse(
         request=request,
         name="_job_row.html",
         context={
             "columns": _DASHBOARD_COLS,
             "row": row,
+            "history_by_fp": history_by_fp,
             "tab": "dashboard",
             "materials_base_url": os.environ.get("FINDAJOB_MATERIALS_BASE_URL", ""),
         },
@@ -194,7 +201,7 @@ def prep(
 
     # Idempotency: already in flight or already prepped — return current row unchanged.
     if row["stage"] in ("prep_in_progress", "materials_drafted"):
-        return _render_dashboard_row(request, row)
+        return _render_dashboard_row(request, row, db)
 
     if _prep_in_flight(db) >= MAX_CONCURRENT_PREPS:
         return _prep_queue_full_response()
@@ -222,7 +229,7 @@ def prep(
 
     updated = _fetch_dashboard_row(db, fingerprint)
     assert updated is not None  # we just updated this row
-    return _render_dashboard_row(request, updated)
+    return _render_dashboard_row(request, updated, db)
 
 
 @router.post("/board/jobs/{fingerprint}/regenerate", response_class=HTMLResponse)
@@ -238,7 +245,7 @@ def regenerate(
 
     # Idempotency: already running — don't clobber a live prep subprocess.
     if row["stage"] == "prep_in_progress":
-        return _render_dashboard_row(request, row)
+        return _render_dashboard_row(request, row, db)
 
     if _prep_in_flight(db) >= MAX_CONCURRENT_PREPS:
         return _prep_queue_full_response()
@@ -273,7 +280,7 @@ def regenerate(
 
     updated = _fetch_dashboard_row(db, fingerprint)
     assert updated is not None
-    return _render_dashboard_row(request, updated)
+    return _render_dashboard_row(request, updated, db)
 
 
 @router.post("/board/jobs/{fingerprint}/apply", response_class=HTMLResponse)

--- a/src/findajob/web/static/app.css
+++ b/src/findajob/web/static/app.css
@@ -8,6 +8,8 @@
   --color-interviewing:  #c8a2d8;  /* purple */
   --color-ghosted:       #d6d6d6;  /* gray */
   --color-contact-amber: #ffbf00;
+  --color-history-green: #c6e6b9;   /* offer anywhere at company (#234) */
+  --color-history-yellow: #fff3b0;  /* not_selected within 90d (#234) */
 }
 
 /* Apply via Tailwind arbitrary-value utilities: bg-[var(--color-applied-fresh)] */
@@ -20,6 +22,8 @@
 .row-interviewing   { background-color: var(--color-interviewing); }
 .row-ghosted        { background-color: var(--color-ghosted); }
 .cell-contact-amber { background-color: var(--color-contact-amber); }
+.history-green      { background-color: var(--color-history-green); padding: 0 4px; border-radius: 3px; }
+.history-yellow     { background-color: var(--color-history-yellow); padding: 0 4px; border-radius: 3px; }
 
 /* ── Row density toggle ───────────────────────────────────────────────────
    Compact: data cells truncate to one line with an ellipsis. Full text is

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -24,6 +24,8 @@
   {% for display, field in columns %}
     {% if tab == 'applied' and field == 'user_notes' %}
       {% include "board/_notes_cell.html" %}
+    {% elif field == 'company_history' %}
+      {% include "board/_company_history_cell.html" %}
     {% else %}
     <td class="px-3 py-1 align-top text-sm
                {% if field == 'known_contacts' and row[field] %}cell-contact-amber{% endif %}

--- a/src/findajob/web/templates/board/_company_history_cell.html
+++ b/src/findajob/web/templates/board/_company_history_cell.html
@@ -1,0 +1,41 @@
+{#
+  #234 — Company application history cell.
+
+  Inputs:
+    row — sqlite3.Row with fingerprint, company
+    history_by_fp — dict keyed by row.fingerprint from
+      findajob.web.company_history.build_history_by_fp
+
+  Behavior:
+    - Empty history → subtle em-dash
+    - Otherwise → "N pending" / "N not selected" badges
+    - Color: history-green if any offer; history-yellow if not_selected
+      within 90d; neutral otherwise
+    - <details> (native HTML, no JS) expands to show the per-row detail
+#}
+{% set h = history_by_fp.get(row.fingerprint) if history_by_fp else None %}
+<td class="px-3 py-1 align-top text-sm whitespace-nowrap" data-col="company_history">
+  {% if h and (h.pending_count or h.not_selected_count) %}
+  <details class="company-history {% if h.flag %}history-{{ h.flag }}{% endif %}">
+    <summary class="cursor-pointer">
+      {% if h.pending_count %}<span class="pending-count">{{ h.pending_count }} pending</span>{% endif %}
+      {% if h.pending_count and h.not_selected_count %} · {% endif %}
+      {% if h.not_selected_count %}<span class="not-selected-count">{{ h.not_selected_count }} not selected</span>{% endif %}
+    </summary>
+    <ul class="mt-1 text-xs">
+      {% for e in h.entries %}
+      <li>
+        {% if e.prep_folder_path and materials_base_url %}
+          <a class="underline" href="{{ materials_base_url }}/materials/{{ e.fingerprint }}">{{ e.title }}</a>
+        {% else %}
+          {{ e.title }}
+        {% endif %}
+        — {{ e.stage }}{% if e.stage == 'not_selected' and e.not_selected_at %} ({{ e.not_selected_at[:10] }}){% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </details>
+  {% else %}
+    <span class="text-slate-300">—</span>
+  {% endif %}
+</td>

--- a/tests/test_web_board_company_history.py
+++ b/tests/test_web_board_company_history.py
@@ -1,0 +1,408 @@
+"""#234 — Dashboard + Waitlist rows surface prior-application history by company.
+
+Counts split into `pending` (stage IN applied/interview/offer) and `not_selected`
+with a 90-day recency window for the yellow-flag signal. Company matching uses
+first-normalized-word (normalize(company).split()[0]) so "Meta" and "Meta
+Platforms" collapse. Operator-side `rejected` stage is excluded (AC7). The row's
+own fingerprint is excluded from its own history.
+
+Schema note: audit_log.job_id stores jobs.id (UUID), not jobs.fingerprint, so
+fixtures include jobs.id. See test_web_board_applied.py for the broader
+convention.
+"""
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+from findajob.web.company_history import _company_key
+
+
+def _iso_days_ago(days: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _make_client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, "
+        "company TEXT, stage TEXT, relevance_score INTEGER, fit_score REAL, "
+        "probability_score REAL, interview_likelihood REAL, location TEXT, "
+        "remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
+        "ai_notes TEXT, reject_reason TEXT, url TEXT, created_at TEXT, "
+        "stage_updated TEXT, updated_at TEXT, prep_folder_path TEXT, "
+        "apply_flag INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, "
+        "field_changed TEXT, old_value TEXT, new_value TEXT, changed_at TEXT, "
+        "changed_by TEXT)"
+    )
+    conn.commit()
+    return conn, db
+
+
+def _finalize(tmp_path: Path, conn: sqlite3.Connection, db: Path) -> TestClient:
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+# ── Helper unit tests ────────────────────────────────────────────────────────
+
+
+def test_company_key_first_word_match() -> None:
+    """Loose match by first normalized word — 'Meta' and 'Meta Platforms' collapse."""
+    assert _company_key("Meta") == "meta"
+    assert _company_key("Meta Platforms") == "meta"
+    assert _company_key("META, Inc.") == "meta"
+    assert _company_key("Google") == "google"
+    assert _company_key("Google Cloud") == "google"
+
+
+def test_company_key_blank_guard() -> None:
+    assert _company_key("") == ""
+    assert _company_key(None) == ""  # type: ignore[arg-type]
+
+
+# ── Integration tests ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def empty_history_client(tmp_path: Path) -> TestClient:
+    """Company with a single dashboard-eligible row and no prior applications."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-only", "fp-only", "Lead NPI", "OpenAI", "scored", 8, _iso_days_ago(1)),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_empty_history_renders_dash(empty_history_client: TestClient) -> None:
+    """AC2: empty history renders a subtle dash, not a zero, so high-signal rows stand out."""
+    r = empty_history_client.get("/board/dashboard")
+    assert r.status_code == 200
+    assert "Lead NPI" in r.text
+    idx = r.text.find('data-fingerprint="fp-only"')
+    assert idx > 0
+    row_end = r.text.find("</tr>", idx)
+    row = r.text[idx:row_end]
+    # history cell exists, content is an em-dash or empty
+    assert 'data-col="company_history"' in row
+    assert "0 pending" not in row and "0 not selected" not in row
+
+
+@pytest.fixture
+def pending_only_client(tmp_path: Path) -> TestClient:
+    """Meta has one scored-dashboard row + one applied sibling (pending)."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-dash", "fp-dash", "Data Center PM", "Meta", "scored", 8, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, stage_updated) VALUES (?,?,?,?,?,?)",
+        ("id-app", "fp-app", "NPI Lead", "Meta", "applied", _iso_days_ago(5)),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_pending_count_shows(pending_only_client: TestClient) -> None:
+    """AC1: 'N pending' for applied/interview/offer siblings at the same company."""
+    r = pending_only_client.get("/board/dashboard")
+    assert r.status_code == 200
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    assert idx > 0
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    assert "1 pending" in row
+
+
+@pytest.fixture
+def not_selected_only_client(tmp_path: Path) -> TestClient:
+    """Google has one scored-dashboard row + one not_selected 30d ago (within 90d)."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-dash", "fp-dash", "Infra PM", "Google", "scored", 8, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, reject_reason) VALUES (?,?,?,?,?,?)",
+        ("id-ns", "fp-ns", "NPI Lead", "Google", "not_selected", "No Response"),
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+        "VALUES (?,?,?,?,?,?)",
+        ("id-ns", "stage", "applied", "not_selected", _iso_days_ago(30), "user"),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_not_selected_count_shows(not_selected_only_client: TestClient) -> None:
+    """AC1: 'N not selected' for company-rejection siblings."""
+    r = not_selected_only_client.get("/board/dashboard")
+    assert r.status_code == 200
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    assert "1 not selected" in row
+
+
+def test_dashboard_recent_not_selected_flagged_yellow(not_selected_only_client: TestClient) -> None:
+    """AC3: not_selected within 90d renders a yellow flag class."""
+    r = not_selected_only_client.get("/board/dashboard")
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    # Yellow signaling uses an amber/yellow tailwind class on the history cell
+    assert "history-yellow" in row
+
+
+@pytest.fixture
+def old_not_selected_client(tmp_path: Path) -> TestClient:
+    """Not_selected OUTSIDE the 90-day window — counts but not yellow."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-dash", "fp-dash", "Infra PM", "Amazon", "scored", 8, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-ns", "fp-ns", "Old Role", "Amazon", "not_selected"),
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+        "VALUES (?,?,?,?,?,?)",
+        ("id-ns", "stage", "applied", "not_selected", _iso_days_ago(120), "user"),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_old_not_selected_counts_but_no_yellow(old_not_selected_client: TestClient) -> None:
+    """AC3: not_selected >90d ago counts in the tally but does NOT trigger yellow."""
+    r = old_not_selected_client.get("/board/dashboard")
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    assert "1 not selected" in row
+    assert "history-yellow" not in row
+
+
+@pytest.fixture
+def offer_green_client(tmp_path: Path) -> TestClient:
+    """Anthropic has an offer-stage sibling — dashboard row should render green."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-dash", "fp-dash", "Research Eng", "Anthropic", "scored", 9, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-offer", "fp-offer", "Infra Lead", "Anthropic", "offer"),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_offer_flagged_green(offer_green_client: TestClient) -> None:
+    """AC3: offer anywhere at the company renders a strong green signal."""
+    r = offer_green_client.get("/board/dashboard")
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    assert "history-green" in row
+
+
+@pytest.fixture
+def mixed_client(tmp_path: Path) -> TestClient:
+    """xAI — 2 pending + 1 recent not_selected. Tests that both counts surface."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-dash", "fp-dash", "Systems Eng", "xAI", "scored", 8, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-app1", "fp-app1", "Infra Lead", "xAI", "applied"),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-app2", "fp-app2", "Hardware Eng", "xAI", "interview"),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-ns", "fp-ns", "PM", "xAI", "not_selected"),
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+        "VALUES (?,?,?,?,?,?)",
+        ("id-ns", "stage", "applied", "not_selected", _iso_days_ago(45), "user"),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_mixed_history_shows_both_counts(mixed_client: TestClient) -> None:
+    r = mixed_client.get("/board/dashboard")
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    assert "2 pending" in row
+    assert "1 not selected" in row
+
+
+@pytest.fixture
+def loose_match_client(tmp_path: Path) -> TestClient:
+    """Dashboard row company='Meta' matches applied row company='Meta Platforms'."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-dash", "fp-dash", "Data Center Lead", "Meta", "scored", 8, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-app", "fp-app", "NPI Lead", "Meta Platforms", "applied"),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_loose_company_match(loose_match_client: TestClient) -> None:
+    """AC5: 'Meta' and 'Meta Platforms' collapse via first-normalized-word match."""
+    r = loose_match_client.get("/board/dashboard")
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    assert "1 pending" in row
+
+
+@pytest.fixture
+def rejected_excluded_client(tmp_path: Path) -> TestClient:
+    """Operator-rejected jobs must NOT count in history (AC7)."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-dash", "fp-dash", "Infra PM", "Microsoft", "scored", 8, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, reject_reason) VALUES (?,?,?,?,?,?)",
+        ("id-rej", "fp-rej", "Wrong Stack", "Microsoft", "rejected", "Tech Stack Mismatch"),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_dashboard_operator_rejected_not_counted(rejected_excluded_client: TestClient) -> None:
+    """AC7: operator-rejected rows are noise for this decision, not signal."""
+    r = rejected_excluded_client.get("/board/dashboard")
+    idx = r.text.find('data-fingerprint="fp-dash"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    # Scope to the history cell — the word "pending" appears elsewhere in row
+    # markup (HTMX pendingAction wiring on the reject cell).
+    hist_start = row.find('data-col="company_history"')
+    assert hist_start > 0
+    hist_end = row.find("</td>", hist_start)
+    hist_cell = row[hist_start:hist_end]
+    assert "pending" not in hist_cell
+    assert "not selected" not in hist_cell
+
+
+@pytest.fixture
+def self_exclusion_client(tmp_path: Path) -> TestClient:
+    """A row must not count itself in its own history."""
+    conn, db = _make_client(tmp_path)
+    # One waitlisted row at Meta with no siblings — should see no history,
+    # not "1 pending" counting itself.
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, created_at) VALUES (?,?,?,?,?,?)",
+        ("id-sole", "fp-sole", "Sole Role", "Meta", "waitlisted", _iso_days_ago(0)),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_waitlist_self_not_in_own_history(self_exclusion_client: TestClient) -> None:
+    r = self_exclusion_client.get("/board/waitlist")
+    idx = r.text.find('data-fingerprint="fp-sole"')
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    hist_start = row.find('data-col="company_history"')
+    assert hist_start > 0
+    hist_end = row.find("</td>", hist_start)
+    hist_cell = row[hist_start:hist_end]
+    assert "pending" not in hist_cell
+    assert "not selected" not in hist_cell
+
+
+@pytest.fixture
+def waitlist_history_client(tmp_path: Path) -> TestClient:
+    """A waitlisted Meta row with an applied Meta Platforms sibling (loose match)."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) VALUES (?,?,?,?,?,?,?)",
+        ("id-wait", "fp-wait", "Ops Lead", "Meta", "waitlisted", 8, _iso_days_ago(0)),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-app", "fp-app", "NPI Lead", "Meta Platforms", "applied"),
+    )
+    return _finalize(tmp_path, conn, db)
+
+
+def test_waitlist_history_cell_present_and_loose_match(waitlist_history_client: TestClient) -> None:
+    r = waitlist_history_client.get("/board/waitlist")
+    assert r.status_code == 200
+    idx = r.text.find('data-fingerprint="fp-wait"')
+    assert idx > 0
+    row = r.text[idx : r.text.find("</tr>", idx)]
+    assert "1 pending" in row
+
+
+# ── HTMX row-swap coverage ──────────────────────────────────────────────────
+# Every POST handler in board_actions.py that re-renders a dashboard row must
+# pass history_by_fp to the template, or the swapped-in row loses its history
+# cell until the user reloads the page.
+
+
+@pytest.fixture
+def swap_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """Prep-dispatches a scored Meta row that has one applied sibling at the
+    same company — the swapped row should render '1 pending' in its history cell."""
+    conn, db = _make_client(tmp_path)
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, url, created_at) "
+        "VALUES (?,?,?,?,?,?,?,?)",
+        (
+            "id-dash",
+            "fp-dash",
+            "Data Center Lead",
+            "Meta",
+            "scored",
+            8,
+            "https://example.com/j",
+            _iso_days_ago(0),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage) VALUES (?,?,?,?,?)",
+        ("id-app", "fp-app", "NPI Lead", "Meta", "applied"),
+    )
+    client = _finalize(tmp_path, conn, db)
+
+    # Don't actually fork prep_application.py when the POST handler dispatches.
+    from findajob.web.routes import board_actions
+
+    class _FakePopen:
+        def __init__(self, *_a, **_kw) -> None:  # noqa: ANN003
+            pass
+
+    monkeypatch.setattr(board_actions.subprocess, "Popen", _FakePopen)
+    return client
+
+
+def test_prep_swap_includes_company_history(swap_client: TestClient) -> None:
+    """POST /board/jobs/{fp}/prep returns the new <tr> as HTMX outerHTML — the
+    swapped row must still render the company-history cell (#234). Without
+    history_by_fp in the render context, the cell falls back to the empty
+    em-dash state and the operator loses context until the next reload."""
+    r = swap_client.post("/board/jobs/fp-dash/prep")
+    assert r.status_code == 200
+    assert 'data-fingerprint="fp-dash"' in r.text
+    assert "1 pending" in r.text

--- a/tests/test_web_board_dashboard.py
+++ b/tests/test_web_board_dashboard.py
@@ -20,6 +20,11 @@ def client(tmp_path: Path) -> TestClient:
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
         "ai_notes TEXT, created_at TEXT, stage_updated TEXT, url TEXT, prep_folder_path TEXT)"
     )
+    # #234 — /board/dashboard now LEFT JOINs audit_log for the company-history cell.
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
     conn.execute(
         "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score, url) "
         "VALUES ('fp1','Senior DC Ops','Meta','scored',8,'https://example.com/meta-dc-ops')"

--- a/tests/test_web_board_filter.py
+++ b/tests/test_web_board_filter.py
@@ -20,6 +20,11 @@ def client(tmp_path: Path) -> TestClient:
         "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
         "ai_notes TEXT, url TEXT, created_at TEXT, stage_updated TEXT, prep_folder_path TEXT)"
     )
+    # #234 — dashboard + waitlist LEFT JOIN audit_log for the company-history cell.
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
     for fp, title, company in [
         ("fp1", "NPI PM", "Meta"),
         ("fp2", "Staff Eng", "Anthropic"),

--- a/tests/test_web_board_waitlist.py
+++ b/tests/test_web_board_waitlist.py
@@ -15,10 +15,15 @@ def client(tmp_path: Path) -> TestClient:
     db = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db)
     conn.execute(
-        "CREATE TABLE jobs (fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
         "relevance_score INTEGER, fit_score REAL, probability_score REAL, "
         "location TEXT, remote_status TEXT, ai_notes TEXT, "
-        "url TEXT, created_at TEXT, stage_updated TEXT)"
+        "url TEXT, created_at TEXT, stage_updated TEXT, prep_folder_path TEXT)"
+    )
+    # #234 — /board/waitlist LEFT JOINs audit_log for the company-history cell.
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
     )
     # Meta has two jobs: one waitlisted (with all three scores), one actively applied
     conn.execute(


### PR DESCRIPTION
Closes #234.

## Summary
- New compact "History" cell on `/board/dashboard` and `/board/waitlist` rows: "N pending" + "N not selected" counts of prior applications to the same company, with a green flag for any offer and a yellow flag for not_selected within 90 days.
- Company matching uses first-normalized-word (`normalize(company).split()[0]`) so "Meta" / "Meta Platforms" and "Google" / "Google Cloud" collapse onto the same bucket.
- Empty history renders a subtle em-dash; operator-side `rejected` jobs are excluded (noise, not signal); each row's own fingerprint is excluded from its own history.
- HTMX row-swap path in `board_actions.py` also passes the history cell so post-action re-renders keep the context — otherwise the cell would fall back to the empty state until full-page reload.

Implementation is one SQL fetch per page render, grouped in Python on the `normalize()` key (not expressible in SQLite stdlib). No schema migration; no new hot paths.

Filed #243 separately for an adjacent UX issue on `/board/archive` where Promote buttons appear empty under the score-filter quick links.

## Test plan
- [x] `uv run pytest` — 886 passed (13 new tests for the helper + cells + HTMX swap)
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] `uv run mypy src/findajob/web/` — clean
- [ ] Deploy to `findajob-brock` + `findajob-amy` stacks on docker.lan
- [ ] Visual check on live Dashboard: empty row, pending-only row, not_selected-only row, mixed row, green (offer) row

## Documentation Impact
None externally — new UI cell is self-explanatory. `CLAUDE.md` `/board/*` section already describes the Dashboard + Waitlist tabs abstractly; adding a synthetic column doesn't change the schema or the board-write-surface contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)