### PR TITLE
fix(fetchers): parse job-boards.greenhouse.io URLs + bare-slug entries (#199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Greenhouse fetcher now recognizes `job-boards.greenhouse.io` URLs and bare-slug entries (#199).** Adding `https://job-boards.greenhouse.io/xai` or `https://boards.greenhouse.io/asteralabs` to `config/feed_urls.txt` now ingests; the previous regex only matched `boards(.eu)?.greenhouse.io/{slug}/` with a required trailing path segment (e.g. `/jobs.rss`), so any addition using Greenhouse's newer `job-boards.*` subdomain or a bare-slug URL was silently dropped. Existing entries continue to parse unchanged; the newer URL shapes now also parse. Discovered while widening Tier 1 coverage (xAI, Nscale, Astera Labs — all served under `job-boards.*`).
+
 ## [0.3.2] — 2026-04-24
 
 Patch bump. Hotfix for a v0.3.1 regression: the shipped image didn't include the `docs/` tree, so every `/docs/` slug link 404'd post-deploy. Rolling `docker compose pull && up -d` fixes it.

--- a/src/findajob/fetchers.py
+++ b/src/findajob/fetchers.py
@@ -178,7 +178,7 @@ def fetch_greenhouse_jobs(feed_urls_path):
     except FileNotFoundError:
         return jobs
 
-    slug_re = re.compile(r"boards(?:\.eu)?\.greenhouse\.io/([^/]+)/")
+    slug_re = re.compile(r"(?:job-)?boards(?:\.eu)?\.greenhouse\.io/([A-Za-z0-9_.-]+)")
     seen_slugs: set[str] = set()
     slugs = []
     for url in urls:

--- a/tests/test_fetchers_greenhouse_slug.py
+++ b/tests/test_fetchers_greenhouse_slug.py
@@ -1,0 +1,111 @@
+"""Greenhouse slug parsing from feed_urls.txt.
+
+Covers the URL shapes Greenhouse now serves boards under — including the
+newer `job-boards.greenhouse.io/{slug}` subdomain and bare-slug (no
+trailing path) URLs that the earlier regex silently dropped.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from findajob import fetchers
+
+
+@pytest.fixture
+def feed_urls(tmp_path):
+    def _write(urls):
+        p = tmp_path / "feed_urls.txt"
+        p.write_text("\n".join(urls) + "\n")
+        return str(p)
+
+    return _write
+
+
+def _empty_board_response():
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = {"jobs": []}
+    return r
+
+
+def _hit_slugs(monkeypatch):
+    """Capture the slug from every Greenhouse API URL fetched."""
+    hits: list[str] = []
+
+    def fake_get(url, **_):
+        # api_url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs?content=true"
+        prefix = "https://boards-api.greenhouse.io/v1/boards/"
+        assert url.startswith(prefix), url
+        slug = url[len(prefix) :].split("/", 1)[0]
+        hits.append(slug)
+        return _empty_board_response()
+
+    # fetchers imports `requests as req` inside each function — patching the
+    # underlying module attribute works because `req` is the same module object.
+    monkeypatch.setattr("requests.get", fake_get)
+    return hits
+
+
+def test_parses_classic_boards_subdomain_with_rss_suffix(feed_urls, monkeypatch):
+    hits = _hit_slugs(monkeypatch)
+    fetchers.fetch_greenhouse_jobs(feed_urls(["https://boards.greenhouse.io/anthropic/jobs.rss"]))
+    assert hits == ["anthropic"]
+
+
+def test_parses_eu_boards_subdomain(feed_urls, monkeypatch):
+    hits = _hit_slugs(monkeypatch)
+    fetchers.fetch_greenhouse_jobs(feed_urls(["https://boards.eu.greenhouse.io/somecorp/jobs.rss"]))
+    assert hits == ["somecorp"]
+
+
+def test_parses_job_boards_subdomain_bare_slug(feed_urls, monkeypatch):
+    """Newer Greenhouse URL: `job-boards.greenhouse.io/{slug}` with no suffix."""
+    hits = _hit_slugs(monkeypatch)
+    fetchers.fetch_greenhouse_jobs(feed_urls(["https://job-boards.greenhouse.io/xai"]))
+    assert hits == ["xai"]
+
+
+def test_parses_job_boards_eu_subdomain_bare_slug(feed_urls, monkeypatch):
+    hits = _hit_slugs(monkeypatch)
+    fetchers.fetch_greenhouse_jobs(feed_urls(["https://job-boards.eu.greenhouse.io/nscaleoperationsukltd"]))
+    assert hits == ["nscaleoperationsukltd"]
+
+
+def test_parses_classic_boards_subdomain_bare_slug(feed_urls, monkeypatch):
+    """Classic subdomain with no trailing path — previously dropped silently."""
+    hits = _hit_slugs(monkeypatch)
+    fetchers.fetch_greenhouse_jobs(feed_urls(["https://boards.greenhouse.io/asteralabs"]))
+    assert hits == ["asteralabs"]
+
+
+def test_dedupes_same_slug_across_url_shapes(feed_urls, monkeypatch):
+    """A company listed twice in any URL shape fetches once."""
+    hits = _hit_slugs(monkeypatch)
+    fetchers.fetch_greenhouse_jobs(
+        feed_urls(
+            [
+                "https://job-boards.greenhouse.io/xai",
+                "https://boards.greenhouse.io/xai/jobs.rss",
+            ]
+        )
+    )
+    assert hits == ["xai"]
+
+
+def test_mixed_feed_file_parses_all_shapes(feed_urls, monkeypatch):
+    hits = _hit_slugs(monkeypatch)
+    fetchers.fetch_greenhouse_jobs(
+        feed_urls(
+            [
+                "# Tier 1",
+                "https://boards.greenhouse.io/anthropic/jobs.rss",
+                "https://job-boards.greenhouse.io/xai",
+                "https://job-boards.eu.greenhouse.io/nscaleoperationsukltd",
+                "https://boards.greenhouse.io/asteralabs",
+                "# non-Greenhouse URL is ignored",
+                "https://jobs.ashbyhq.com/openai",
+            ]
+        )
+    )
+    assert set(hits) == {"anthropic", "xai", "nscaleoperationsukltd", "asteralabs"}


### PR DESCRIPTION
## Summary

- Greenhouse slug regex widened to accept the newer `job-boards.greenhouse.io` subdomain **and** bare-slug URLs (no trailing `/jobs.rss` required). Previous regex silently dropped both shapes.
- 7 new unit tests in `tests/test_fetchers_greenhouse_slug.py` cover every URL shape (classic, EU, job-boards, job-boards EU, bare-slug, mixed feed file, dedup).
- No config format change — existing feed_urls.txt entries continue to parse.

Discovered while servicing #199: adding xAI / Nscale / Astera Labs to `config/feed_urls.txt` (all served under `job-boards.*`) ingested zero jobs — slug regex wasn't matching. All three now ingest correctly.

## Pre-merge dry run (live API, patched code)

| Source | URL | Jobs |
|---|---|---|
| Ashby | `jobs.ashbyhq.com/openai` | 656 |
| Greenhouse | `job-boards.greenhouse.io/xai` | 229 |
| Greenhouse | `job-boards.eu.greenhouse.io/nscaleoperationsukltd` | 180 |
| Greenhouse | `boards.greenhouse.io/asteralabs` | 144 |
| | **Total** | **1,209** |

All four companies normalize correctly through \`clean_company\`. No fetch errors, no empty responses.

## Test plan

- [x] \`uv run pytest tests/test_fetchers_greenhouse_slug.py\` — 7 new tests pass
- [x] \`uv run pytest tests/\` — full suite (893 tests) passes, no regressions
- [x] \`uv run ruff check\` + \`ruff format --check\` — clean
- [x] \`uv run mypy src/findajob/fetchers.py\` — clean
- [x] Pre-merge live API dry run — 1,209 jobs fetched across 4 new feed entries
- [ ] Post-deploy: next 00:00 PT triage on operator stack ingests from new feed_urls.txt entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)