### PR TITLE
OpenRouter Phase 2 cutover — 10 roles + Opus 4.7 (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Changed
+
+- **OpenRouter Phase 2 cutover (#250).** Ten of eleven pipeline roles now route via OpenRouter as a single gateway: `resume_tailor` and `cover_letter_writer` upgraded to **Opus 4.7** (same pricing as 4.6 per OR catalog, small-to-moderate quality edge on real-pipeline prompts per Phase 1 verdict #22); `briefing_writer` and `outreach_drafter` to `openrouter:anthropic/claude-sonnet-4.6`; `company_researcher` and `fit_analyst` to `openrouter:perplexity/sonar-reasoning-pro` (OR's Perplexity path returns structured URL citations, direct path strips them); `resume_change_reviewer`, `network_analyst`, and the default model to `openrouter:google/gemini-3-flash-preview`. Embedding (`gemini-embed:gemini-embedding-001`) stays on the direct Google client — OR has zero embedding endpoints. `job_scorer` unchanged (already on OR).
+
+### Migration required
+
+- **Edit `state/aichat_ng/config.yaml` on each deployed stack** to change the top-level `model:` line from `gemini:gemini-3-flash-preview` to `openrouter:google/gemini-3-flash-preview`. The image's `ops/aichat-ng/config.yaml.example` template seeds this file only on first install; existing installs keep their pre-upgrade default otherwise.
+- **Diff `state/aichat_ng/models-override.yaml` against `ops/aichat-ng/models-override.yaml` in this release** and append the two new openrouter catalog entries if absent: `anthropic/claude-opus-4.7` and `google/gemini-3-flash-preview`. Without these, the role files will reference models aichat-ng does not know about.
+- **Ensure `OPENROUTER_API_KEY` is set** in `state/config/.env` (or equivalent). Ten of eleven roles now depend on it.
+
 ## [0.3.3] — 2026-04-24
 
 Patch bump. Three additive `/board/*` UI improvements surfaced during the 2026-04-24 structural review (waitlist scores, Archive score-6 browse + promote, dashboard/waitlist company application history), plus a regression fix for Greenhouse fetcher URL parsing that was silently dropping Tier 1 additions using the newer `job-boards.*` subdomain. No migration required — rolling `docker compose pull && up -d` picks it up cleanly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 - **Edit `state/aichat_ng/config.yaml` on each deployed stack** to change the top-level `model:` line from `gemini:gemini-3-flash-preview` to `openrouter:google/gemini-3-flash-preview`. The image's `ops/aichat-ng/config.yaml.example` template seeds this file only on first install; existing installs keep their pre-upgrade default otherwise.
 - **Diff `state/aichat_ng/models-override.yaml` against `ops/aichat-ng/models-override.yaml` in this release** and append the two new openrouter catalog entries if absent: `anthropic/claude-opus-4.7` and `google/gemini-3-flash-preview`. Without these, the role files will reference models aichat-ng does not know about.
-- **Ensure `OPENROUTER_API_KEY` is set** in `state/config/.env` (or equivalent). Ten of eleven roles now depend on it.
+- **Ensure `OPENROUTER_API_KEY` is set** in `state/data/.env` (or equivalent). Ten of eleven roles now depend on it.
 
 ## [0.3.3] — 2026-04-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,15 +73,15 @@ file. If you're refactoring an old hardcoded section, add a note to `docs/GENERA
 
 | Item | Value |
 |------|-------|
-| Default model | `gemini:gemini-3-flash-preview` |
+| Default model | `openrouter:google/gemini-3-flash-preview` |
 | Embedding model | `gemini-embed:gemini-embedding-001` — dedicated named client, never touched by `--sync-models` |
 | `job_scorer` | `openrouter:deepseek/deepseek-v3.2` — profile.md injected directly; `--rag` NEVER used |
-| `resume_tailor` / `cover_letter_writer` | `claude:claude-opus-4-6:thinking`, `max_tokens: 4096` |
-| `company_researcher` | `perplexity:sonar-reasoning-pro` |
-| `briefing_writer` | `claude:claude-sonnet-4-6:thinking` |
-| `outreach_drafter` | `claude:claude-sonnet-4-6` — profile injected directly |
-| `fit_analyst` | `perplexity:sonar-reasoning-pro` — appended to company briefing |
-| `resume_change_reviewer` / `network_analyst` | `gemini:gemini-3-flash-preview` |
+| `resume_tailor` / `cover_letter_writer` | `openrouter:anthropic/claude-opus-4.7`, `max_tokens: 4096` |
+| `company_researcher` | `openrouter:perplexity/sonar-reasoning-pro` |
+| `briefing_writer` | `openrouter:anthropic/claude-sonnet-4.6` |
+| `outreach_drafter` | `openrouter:anthropic/claude-sonnet-4.6` — profile injected directly |
+| `fit_analyst` | `openrouter:perplexity/sonar-reasoning-pro` — appended to company briefing |
+| `resume_change_reviewer` / `network_analyst` | `openrouter:google/gemini-3-flash-preview` |
 | Job ingestion | jobs-api14 (RapidAPI) — LinkedIn (`datePosted: 'day'`) + Indeed; Gmail OAuth2 |
 | Package manager | `uv sync` for dev deps; `uv run` prefix for pytest/ruff/mypy/uvicorn |
 | Path resolution | `src/findajob/paths.py` — reads `config/paths.env`; BASE derived from `__file__` |

--- a/config/roles/briefing_writer.md
+++ b/config/roles/briefing_writer.md
@@ -1,5 +1,5 @@
 ---
-model: claude:claude-sonnet-4-6:thinking
+model: openrouter:anthropic/claude-sonnet-4.6
 max_tokens: 4096
 temperature: 0.3
 ---

--- a/config/roles/company_researcher.md
+++ b/config/roles/company_researcher.md
@@ -1,5 +1,5 @@
 ---
-model: perplexity:sonar-reasoning-pro
+model: openrouter:perplexity/sonar-reasoning-pro
 temperature: 0.2
 ---
 You research companies for a job candidate.

--- a/config/roles/cover_letter_writer.md
+++ b/config/roles/cover_letter_writer.md
@@ -1,5 +1,5 @@
 ---
-model: claude:claude-opus-4-6:thinking
+model: openrouter:anthropic/claude-opus-4.7
 max_tokens: 4096
 temperature: 0.6
 ---

--- a/config/roles/fit_analyst.md
+++ b/config/roles/fit_analyst.md
@@ -1,5 +1,5 @@
 ---
-model: perplexity:sonar-reasoning-pro
+model: openrouter:perplexity/sonar-reasoning-pro
 temperature: 0.2
 ---
 You are an impartial career fit analyst. Given a job description, company briefing, candidate profile, and master resume, produce a structured fit analysis.

--- a/config/roles/network_analyst.md
+++ b/config/roles/network_analyst.md
@@ -1,5 +1,5 @@
 ---
-model: gemini:gemini-3-flash-preview
+model: openrouter:google/gemini-3-flash-preview
 temperature: 0.2
 ---
 You analyze professional network connections for job search relevance.

--- a/config/roles/outreach_drafter.md
+++ b/config/roles/outreach_drafter.md
@@ -1,5 +1,5 @@
 ---
-model: claude:claude-sonnet-4-6
+model: openrouter:anthropic/claude-sonnet-4.6
 temperature: 0.5
 ---
 You draft personalized outreach messages for a job candidate's search.

--- a/config/roles/resume_change_reviewer.md
+++ b/config/roles/resume_change_reviewer.md
@@ -1,5 +1,5 @@
 ---
-model: gemini:gemini-3-flash-preview
+model: openrouter:google/gemini-3-flash-preview
 temperature: 0.1
 ---
 You are reviewing changes between an original master resume and a tailored

--- a/config/roles/resume_tailor.md
+++ b/config/roles/resume_tailor.md
@@ -1,5 +1,5 @@
 ---
-model: claude:claude-opus-4-6:thinking
+model: openrouter:anthropic/claude-opus-4.7
 max_tokens: 4096
 temperature: 0.4
 ---

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -262,7 +262,7 @@ With Phase 2 of the OpenRouter cutover, 10 of 11 roles depend on
 
 1. Generate a new key in the OpenRouter dashboard and note both the
    old and new values.
-2. Edit your stack's env file (`/opt/stacks/findajob-<you>/state/config/.env`
+2. Edit your stack's env file (`/opt/stacks/findajob-<you>/state/data/.env`
    or wherever you keep credentials — check your compose file's
    `env_file:` directive) and replace the `OPENROUTER_API_KEY=…` line.
 3. Recreate the container so aichat-ng picks up the new value:
@@ -270,8 +270,11 @@ With Phase 2 of the OpenRouter cutover, 10 of 11 roles depend on
 4. Verify with a smoke call: `docker compose exec scheduler aichat-ng --model openrouter:google/gemini-3-flash-preview "say hello"`.
    If the call succeeds, revoke the old key in the OpenRouter dashboard.
 
-The same pattern applies to `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and
-`PERPLEXITY_API_KEY` if you rotate those (Phase 2 leaves them in the
-config for the embedding client and as fallbacks). Keep rotations
-staggered — don't revoke the old key until the new one has served at
-least one live pipeline run without error.
+`GOOGLE_API_KEY` remains live after Phase 2 — it still powers the
+Gemini embedding client (`gemini-embed:gemini-embedding-001`) that
+the RAG index uses. Rotate it the same way. `ANTHROPIC_API_KEY` and
+`PERPLEXITY_API_KEY` are still declared in the aichat-ng config but
+no live role routes to them after the cutover; they are retirement
+candidates rather than fallbacks. Keep rotations staggered — don't
+revoke the old key until the new one has served at least one live
+pipeline run without error.

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -254,3 +254,24 @@ it defeats the whole purpose.
 
 See also `docs/GENERALIZATION.md` for the broader tracking of domain-specific content that
 should not land in tracked files.
+
+## Rotating API keys on a deployed stack
+
+With Phase 2 of the OpenRouter cutover, 10 of 11 roles depend on
+`OPENROUTER_API_KEY`. Rotating it cleanly on a running stack:
+
+1. Generate a new key in the OpenRouter dashboard and note both the
+   old and new values.
+2. Edit your stack's env file (`/opt/stacks/findajob-<you>/state/config/.env`
+   or wherever you keep credentials — check your compose file's
+   `env_file:` directive) and replace the `OPENROUTER_API_KEY=…` line.
+3. Recreate the container so aichat-ng picks up the new value:
+   `docker compose up -d --force-recreate` from the stack directory.
+4. Verify with a smoke call: `docker compose exec scheduler aichat-ng --model openrouter:google/gemini-3-flash-preview "say hello"`.
+   If the call succeeds, revoke the old key in the OpenRouter dashboard.
+
+The same pattern applies to `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and
+`PERPLEXITY_API_KEY` if you rotate those (Phase 2 leaves them in the
+config for the embedding client and as fallbacks). Keep rotations
+staggered — don't revoke the old key until the new one has served at
+least one live pipeline run without error.

--- a/docs/superpowers/plans/2026-04-24-openrouter-phase-2-cutover.md
+++ b/docs/superpowers/plans/2026-04-24-openrouter-phase-2-cutover.md
@@ -591,7 +591,7 @@ Under the `## [Unreleased]` heading, insert:
 
 - **Edit `state/aichat_ng/config.yaml` on each deployed stack** to change the top-level `model:` line from `gemini:gemini-3-flash-preview` to `openrouter:google/gemini-3-flash-preview`. The image's `ops/aichat-ng/config.yaml.example` template seeds this file only on first install; existing installs keep their pre-upgrade default otherwise.
 - **Diff `state/aichat_ng/models-override.yaml` against `ops/aichat-ng/models-override.yaml` in this release** and append the two new openrouter catalog entries if absent: `anthropic/claude-opus-4.7` and `google/gemini-3-flash-preview`. Without these, the role files will reference models aichat-ng does not know about.
-- **Ensure `OPENROUTER_API_KEY` is set** in `state/config/.env` (or equivalent). Ten of eleven roles now depend on it.
+- **Ensure `OPENROUTER_API_KEY` is set** in `state/data/.env` (or equivalent). Ten of eleven roles now depend on it.
 ```
 
 Place this block immediately after `## [Unreleased]` and immediately before `## [0.3.3] — 2026-04-24`.
@@ -661,7 +661,7 @@ With Phase 2 of the OpenRouter cutover, 10 of 11 roles depend on
 
 1. Generate a new key in the OpenRouter dashboard and note both the
    old and new values.
-2. Edit your stack's env file (`/opt/stacks/findajob-<you>/state/config/.env`
+2. Edit your stack's env file (`/opt/stacks/findajob-<you>/state/data/.env`
    or wherever you keep credentials — check your compose file's
    `env_file:` directive) and replace the `OPENROUTER_API_KEY=…` line.
 3. Recreate the container so aichat-ng picks up the new value:
@@ -669,11 +669,14 @@ With Phase 2 of the OpenRouter cutover, 10 of 11 roles depend on
 4. Verify with a smoke call: `docker compose exec scheduler aichat-ng --model openrouter:google/gemini-3-flash-preview "say hello"`.
    If the call succeeds, revoke the old key in the OpenRouter dashboard.
 
-The same pattern applies to `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and
-`PERPLEXITY_API_KEY` if you rotate those (Phase 2 leaves them in the
-config for the embedding client and as fallbacks). Keep rotations
-staggered — don't revoke the old key until the new one has served at
-least one live pipeline run without error.
+`GOOGLE_API_KEY` remains live after Phase 2 — it still powers the
+Gemini embedding client (`gemini-embed:gemini-embedding-001`) that
+the RAG index uses. Rotate it the same way. `ANTHROPIC_API_KEY` and
+`PERPLEXITY_API_KEY` are still declared in the aichat-ng config but
+no live role routes to them after the cutover; they are retirement
+candidates rather than fallbacks. Keep rotations staggered — don't
+revoke the old key until the new one has served at least one live
+pipeline run without error.
 ```
 
 - [ ] **Step 3: Verify**

--- a/ops/aichat-ng/config.yaml.example
+++ b/ops/aichat-ng/config.yaml.example
@@ -15,7 +15,7 @@
 # Do NOT add a top-level `models:` block here or inline `models:` blocks
 # under existing clients — they will shadow models-override.yaml.
 
-model: gemini:gemini-3-flash-preview
+model: openrouter:google/gemini-3-flash-preview
 temperature: 0
 rag_embedding_model: gemini-embed:gemini-embedding-001
 rag_reranker_model: null

--- a/ops/aichat-ng/models-override.yaml
+++ b/ops/aichat-ng/models-override.yaml
@@ -1330,6 +1330,13 @@ list:
     input_price: 0.04
     output_price: 0.16
     supports_function_calling: true
+  - name: google/gemini-3-flash-preview
+    type: chat
+    max_input_tokens: 1048576
+    input_price: 0.3
+    output_price: 2.5
+    supports_vision: true
+    supports_function_calling: true
   - name: google/gemini-2.5-flash
     type: chat
     max_input_tokens: 1048576
@@ -1369,6 +1376,15 @@ list:
     max_input_tokens: 131072
     input_price: 0.1
     output_price: 0.2
+  - name: anthropic/claude-opus-4.7
+    type: chat
+    max_input_tokens: 200000
+    input_price: 5.0
+    output_price: 25.0
+    max_output_tokens: 8192
+    require_max_tokens: true
+    supports_vision: true
+    supports_function_calling: true
   - name: anthropic/claude-opus-4.6
     type: chat
     max_input_tokens: 200000


### PR DESCRIPTION
Closes #250. Parent #240.

## Summary

- Flips 10 of 11 pipeline roles to `openrouter:*` routes. Embedding stays direct.
- Upgrades `resume_tailor` and `cover_letter_writer` from Opus 4.6 to **4.7** (same pricing, small-to-moderate quality edge per Phase 1 verdict #22).
- Adds the two missing openrouter catalog entries (`anthropic/claude-opus-4.7`, `google/gemini-3-flash-preview`).
- Pure config — no code, no schema, no scheduler changes.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-04-24-openrouter-phase-2-cutover-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-openrouter-phase-2-cutover.md`

## Parallel eval gate

Pre-merge shadow-role eval on 4 jobs × 4 quality-critical roles passed. Verdict:
- resume_tailor (4.6 → 4.7): 4/4 better
- cover_letter_writer (4.6 → 4.7): 3/4 parity-or-better
- briefing_writer (route-only): 4/4 parity
- outreach_drafter (route-only): 3/3 parity

Full verdict comment: https://github.com/brockamer/findajob/issues/250#issuecomment-4317334405

## Migration required

- Edit `state/aichat_ng/config.yaml` top-level `model:` on each deployed stack.
- Diff + append to `state/aichat_ng/models-override.yaml` (two new entries: `anthropic/claude-opus-4.7`, `google/gemini-3-flash-preview`).
- Ensure `OPENROUTER_API_KEY` is set.

Full migration text is in the CHANGELOG [Unreleased] entry.

## Test plan

- [ ] Existing `uv run pytest tests/ -q` passes locally (ran after each commit, 893/893)
- [ ] CI pipeline green (ruff, mypy, pytest)
- [x] Eval gate passed pre-merge (session comment on #250)
- [ ] Post-merge: operator stack runs one triage + one prep cleanly, no new log_event error classes in 24h
- [ ] Post-merge: pin-advanced beta-tester stack(s) verify same