### PR TITLE
fix(prep): drop Perplexity model_override hardcodes (#254)

### DIFF
--- a/scripts/prep_application.py
+++ b/scripts/prep_application.py
@@ -230,7 +230,7 @@ def main():
 
     # ── Step 2: Company briefing FIRST — gives all downstream steps rich context ──
     brief_prompt = f"Research {company} thoroughly.\nJob title: {title}\nJD excerpt:\n{jd_text[:2000]}"
-    raw_briefing = aichat("company_researcher", brief_prompt, model_override="perplexity:sonar-reasoning-pro")
+    raw_briefing = aichat("company_researcher", brief_prompt)
 
     # Pass raw research through briefing_writer with candidate context for stories
     formatted_brief_prompt = (
@@ -260,7 +260,7 @@ def main():
         f"JD:\n{jd_text[:3000]}\n\n"
         f"COMPANY BRIEFING:\n{briefing}"
     )
-    fit_analysis = aichat("fit_analyst", fit_prompt, model_override="perplexity:sonar-reasoning-pro")
+    fit_analysis = aichat("fit_analyst", fit_prompt)
 
     # Combine briefing and fit analysis into one document.
     # The briefing ends with an Overall Recommendation verdict; fit analysis


### PR DESCRIPTION
Closes #254. Follows #253 (Phase 2 cutover).

## Summary

Two-line fix: remove `model_override="perplexity:sonar-reasoning-pro"` from `scripts/prep_application.py:233,263`. Lets the role front-matter (now `openrouter:perplexity/sonar-reasoning-pro` post-#253) actually govern these calls.

## Why

Phase 2 cutover's spec described it as "pure config, no code" — wrong. These two hardcodes were overriding the new OR routes at runtime. Empirically confirmed post-#253 deploy: zero Perplexity traffic in OR logs despite the role files pointing at OR. Users were silently losing the structured `url_citation` annotations that were the main Phase 1 rationale for routing these two roles through OR.

## Test plan

- [x] `uv run pytest tests/ -q` passes locally (893/893)
- [ ] CI green
- [ ] Post-deploy: one prep run shows `perplexity/sonar-reasoning-pro` calls in OR logs