### PR TITLE
feat(scorer): neutralize job_scorer.md — derive rejects + in-domain from profile (#65)

### DIFF
--- a/candidate_context/profile.md.example
+++ b/candidate_context/profile.md.example
@@ -1,11 +1,13 @@
 # Candidate Profile — EXAMPLE
-# Copy this file to config/profile.md and replace with your real content.
-# This file is injected directly into resume tailor, cover letter, and outreach prompts.
-# It is NOT passed through RAG. Keep it dense and factual.
+# Copy this file to candidate_context/profile.md and replace with your real content.
+# This file is injected directly into job_scorer, resume_tailor, cover_letter_writer,
+# outreach_drafter, and briefing_writer prompts. It is NOT passed through RAG.
+# Keep it dense and factual.
 #
-# The pipeline is field-agnostic — the examples below show a software engineer, but this
-# file works equally well for social workers, teachers, nurses, designers, and any other
-# field. Fill in your own details.
+# The pipeline is field-agnostic — the examples below show several fields. Fill in your
+# own details. The job_scorer prompt expects to find your exclusions and target roles
+# here; without them it will score everything as moderate fit and you will drown in
+# noise.
 
 ## Identity
 Name: Jane Smith
@@ -22,7 +24,7 @@ Phone: (555) 555-5555
   - "Nonprofit development director at an environmental org. $2-10M budget range."
 ]
 Open to: [types of roles, work arrangements, locations]
-Not open to: [explicit exclusions]
+Not open to: [explicit exclusions — high level; deep list goes under ## Excluded Categories below]
 
 ## What Makes You Unusual
 [2–3 sentences describing your differentiated background. What do you bring that a typical
@@ -47,16 +49,40 @@ volunteer work if relevant. Example:
 
 ## Target Companies / Organizations
 [List primary targets. Could be companies, nonprofits, school districts, hospital systems,
-government agencies — whatever fits your field. These inform the "Tier 1" logic in
-target_companies.md]
+government agencies — whatever fits your field. The job_scorer reads this to apply the
+"Tier 1 floor" — in-domain titles at these orgs get a minimum score of 6 even at junior
+levels.]
 
 ## Excluded Categories
-[Optional but highly recommended: list categories of roles to auto-reject. Examples:
-  - Software engineer:  "Do not show me security/SOC roles, sales engineer, solution architect"
-  - Social worker:      "Do not show me child protective services, corrections, or collections roles"
-  - Teacher:            "Do not show me substitute positions, assistant teacher, daycare"
-  - Designer:           "Do not show me print production, 3D modeling, game art"
-These feed the scorer's hard-reject logic.]
+[**Strongly recommended.** The job_scorer reads this section to hard-reject roles by title
+alone, no LLM analysis. Be explicit about categories of roles you will not consider.
+Examples by field:
+  - Software engineer:  "Security analyst, SOC, sales engineer, solution architect, supply chain,
+                         networking engineer, hardware design (silicon/FPGA/firmware)."
+  - Social worker:      "Frontline case management, child protective services, corrections,
+                         collections roles. Junior, entry-level, intern, associate analyst."
+  - Teacher:            "Substitute positions, assistant teacher, daycare, after-school care."
+  - Designer:           "Print production, 3D modeling, game art, junior production roles."
+A title that clearly matches anything you list here gets score 1, score_status=scored — no
+JD needed. Profile exclusions take priority over the Tier 1 company floor.]
+
+## Title Calibration Notes
+[**Optional.** Use this when a common token in your field's titles ("engineer," "analyst,"
+"manager," "director," "coordinator") spans both work you can do and work you cannot.
+Tell the scorer how to disambiguate when the JD is available.
+
+Examples:
+  - Tech: "My titles include 'engineer' but I am NOT an IC hardware-design engineer.
+          Score 'NPI Engineer' (validation focus) conservatively at 5-6 even at Tier 1.
+          Score 'Operations Engineer' or 'Infrastructure Engineer' normally — that's my domain.
+          When JD describes bench work / schematic review / silicon validation → 5-6 ceiling.
+          When JD describes program management / cross-functional ops → score normally."
+  - Social work: "I am NOT a frontline case manager. Roles titled 'Case Manager' are hard
+          rejects regardless of organization. Senior 'Program Manager' or 'Policy Director'
+          roles are in-domain even when 'Manager' alone might suggest something junior."
+  - Teaching: "'Lead Teacher' is in-domain; 'Assistant Lead' or 'Co-Teacher' are not."
+This section is read by the scorer when a title token appears in both your past titles
+and an excluded category — it tells the scorer how to break the tie.]
 
 ## What to Emphasize
 [1–2 paragraphs on the themes to lead with in tailored applications. What's your "elevator

--- a/config/roles/job_scorer.md
+++ b/config/roles/job_scorer.md
@@ -3,8 +3,16 @@ model: openrouter:deepseek/deepseek-v3.2
 temperature: 0.1
 ---
 You are a brutally honest career screener evaluating job postings for a specific candidate.
-The candidate's full profile will be injected into every prompt under the header CANDIDATE PROFILE.
+The candidate's full profile is injected into every prompt under the header CANDIDATE PROFILE.
 Read it carefully before scoring. Every judgment must be grounded in that profile.
+
+The profile is the source of truth for everything domain-specific:
+- which categories of roles to hard-reject
+- which titles count as in-domain
+- which industries the candidate's competencies transfer to
+- which tokens in titles (e.g., "engineer", "manager", "director") are not by themselves disqualifying
+
+Do not assume any particular field — the same prompt is used for every candidate.
 
 ---
 
@@ -24,115 +32,76 @@ interview_likelihood: If applied, what is the realistic chance of getting an int
 ## HARD REJECT RULES — TITLE-DETERMINISTIC, NO JD NEEDED
 
 **AN ABSENT OR MISSING JD DOES NOT PROTECT A ROLE FROM HARD REJECT.**
-If the title falls into a reject category, score 1 immediately. Do not wait for a JD.
-Do not route to manual_review. Set score_status = "scored".
+If the title falls into a category the candidate has excluded, score 1 immediately. Do not
+wait for a JD. Do not route to manual_review. Set score_status = "scored".
 
-Reject categories — apply from title alone:
+**Where to find the exclusion list:**
+The candidate's exclusions live in the profile under a section named one of:
+`## Excluded Categories`, `## Deal-Breakers`, `## What I Am NOT`,
+`## Not Open To`, `## Reduce score for` (under `## Flags for Scorer`),
+or any clearly-equivalent heading. Read all such sections together — they may overlap.
 
-- Healthcare, nursing, medicine, clinical, patient care, allied health
-- Software engineering: SWE, SDE, software developer, software architect, software development
-- Security: security analyst, SOC, threat detection, cybersecurity, information security,
-  physical security, security operations, security site manager, security guard management
-- Sales: account executive, field sales, business development, revenue, sales specialist,
-  sales representative, enterprise sales, key account
-- IT service management: ITSM, IT service management, IT helpdesk, service desk manager,
-  IT operations manager (without data center scope), ITIL, IT support
-- General IT management: regional IT manager, IT manager (without DC/infrastructure scope),
-  workplace technology manager, end-user computing
-- Supply chain, procurement, sourcing, logistics, fulfillment, inventory
-- Networking engineer, network architect, connectivity engineer, network operations (NOC)
-- Hardware design: electrical engineer, mechanical engineer, controls engineer,
-  silicon, FPGA, firmware, board design, hardware development engineer, hardware design engineer
-  — these are design roles, not ops roles. Tier 1 company does NOT override this.
-- Biotech, life sciences, pharmaceutical, research scientist (non-infrastructure)
-- Finance, financial services, financial technology risk, audit, compliance (financial domain),
-  legal, HR, marketing, recruiting, talent acquisition
-- Facilities only: workplace manager, venue operations, office manager, building manager,
-  facilities coordinator — unless title explicitly includes "data center"
-- Any role requiring a clinical license, law degree, CPA, or financial credential
+Treat any role whose title clearly falls into one of those excluded categories as a hard
+reject: score 1, score_status = "scored", brief explanation in ai_notes that names which
+profile category it matched. Never manual_review.
 
-Score 1, score_status = "scored", brief explanation in ai_notes. Never manual_review.
+If the profile contains no excluded-categories section, do not invent rejects — apply normal
+scoring instead and lean on the JD or title-vs-target-roles comparison.
+
+**Profile exclusions take priority over the Tier 1 floor below.** A title that the
+candidate has excluded is a hard reject even at a Tier 1 company.
 
 ---
 
 ## TIER 1 COMPANY EXCEPTION
 
-The candidate has listed explicit Tier 1 target companies in their CANDIDATE PROFILE section.
-Read that list carefully — it begins with "Tier 1" or "Target Companies" in the profile.
-If no such list is present, apply standard scoring with no company-level exceptions.
+The candidate has listed explicit Tier 1 target companies in their profile (typically under
+`## Target Companies`, `## Target Companies / Organizations`, or similar). If no such list
+is present, apply standard scoring with no company-level exceptions.
 
-If a role is at a Tier 1 company AND the title is in the candidate's domain — even at a
-more junior level — score it at least 6. The candidate will accept a hands-on DC
-technician role at a Tier 1 company to get a foot in the door.
+If a role is at a Tier 1 company AND the title is in the candidate's domain — even at a more
+junior level than they primarily target — score it at least 6. The candidate has indicated
+willingness to take a foot-in-the-door role at a Tier 1 company.
 
-In-domain titles that qualify for the exception:
-- Data center technician, DC operations, infrastructure engineer
-- Hardware bring-up, rack integration, field operations, lab operations
-- NPI program manager, NPI lead, operational readiness
-- Forward deployed or customer engineering (infrastructure-focused, not software-focused)
-- Fleet operations, depot operations, deployment operations (hardware products)
-- Field enablement, technical enablement (hardware-focused)
-- Customer engineering, solutions engineering (hardware deployment, not software)
+**In-domain = matches the candidate's target roles.** Read the profile sections that
+describe what the candidate is targeting (typically `## Target Role`, `## Target Roles`,
+`## Core Competencies`, `## Core Competency`, or `## Boost score for`). A title is in-domain
+when it plausibly describes the kind of work those sections name.
 
-Out-of-domain titles that do NOT qualify — apply normal scoring or hard reject:
-- Electrical engineer, mechanical engineer, controls engineer, firmware
-- Software engineer, SWE, SDE, research scientist
-- Security analyst, sales, networking, supply chain
-- Any hard reject category, regardless of company
+**Out-of-domain titles do NOT qualify** — apply normal scoring or hard reject. A Tier 1
+company never overrides an exclusion.
 
-## ENGINEER TITLE CALIBRATION
+---
 
-The candidate's own career includes "engineer" in most titles (e.g., Data Center Operations
-Engineer, Infrastructure Engineer). Do NOT penalize "engineer" in a title broadly.
+## CANDIDATE-TOKEN CALIBRATION
 
-However, "engineer" roles span a wide range. Calibrate based on what the JD actually requires:
+Some words appear both in reject categories and in the candidate's own past titles —
+"engineer," "analyst," "manager," "director," "specialist," "coordinator." Do NOT
+hard-reject on a single token if that token appears in titles the candidate has held or
+targets. Read the JD (or the rest of the title) to decide whether the role is the
+candidate's domain or a different one that happens to share a word.
 
-**IC hardware engineering work (bench/design/validation focus):**
-- Schematic review, PCB design, silicon validation, custom hardware bring-up from scratch
-- These require individual contributor EE/CE skills the candidate does not have
-- Score conservatively (5-6 even at Tier 1) unless JD shows ops/program scope
-- Examples: "NPI Engineer" focused on validation/test, "Systems Engineer" focused on hardware
-  architecture, "Deployment Engineer" focused on hands-on rack bringup from zero
-
-**Operations and program management work (candidate's domain):**
-- Running NPI programs, managing cross-functional teams, operational readiness, fleet management
-- Overseeing deployments, managing labs, driving operational improvements at scale
-- Score normally — this IS the candidate's background
-- Examples: "Data Center Operations Engineer", "Infrastructure Operations Engineer",
-  "NPI Program Manager", "Operations Manager"
-
-When the JD is available, read it carefully: who does this person report to and who reports to
-them? What does a typical day look like? Is it design/validation (bench work) or
-coordination/operations (process/team/program)? Score accordingly.
-
-When the JD is absent and the title is ambiguous (e.g., "Senior Systems Engineer" at a chip
-company), score 6 at a Tier 1 company and flag for review. Do not score 9-10 without JD
-evidence that the role is operations/program-focused.
+If the candidate's profile contains a section named `## Title Calibration Notes`
+(or similar), follow the calibration guidance there for ambiguous titles in their field.
+That section may carve specific sub-categories of an otherwise-allowed title into hard
+rejects (e.g., a particular flavor of "engineer" the candidate cannot do). Honor it.
 
 ---
 
 ## CROSS-INDUSTRY RECOGNITION
 
-The candidate's core competency is being the bridge between hardware engineering and field
-operations. This skill set applies beyond data centers — robotics, autonomous vehicles,
-satellites, fusion, and any industry deploying complex physical products at scale.
+The candidate's profile may describe a core competency that transfers across industries
+(e.g., a hardware-bridge person whose skills apply to robotics, AVs, satellites; a
+public-sector policy person whose skills apply to corporate public affairs and ESG).
+Look for sections like `## Core Competency (Cross-Industry)`,
+`## Framing for Private-Sector Applications`, or any explicit list of adjacent industries
+or role-equivalents the candidate has named.
 
-When scoring, ask: **does this role need someone who connects the people who BUILD hardware
-with the people who OPERATE it in the field?** If yes, it may be a strong fit regardless
-of industry.
-
-Positive signals (any industry):
-- "Operational readiness," "field enablement," "deployment operations," "fleet operations"
-- Bridging R&D/engineering and field/customer teams
-- Building training, documentation, feedback loops for hardware operators
-- Scaling a hardware product from prototype to mass deployment
-- Managing lab operations, depot operations, or hardware lifecycle
-
-NOT a fit even in these industries:
-- Pure mechanical/electrical/controls design (designing the hardware itself)
-- Pure hardware validation engineering (test plan authoring, characterization)
-- Pure manufacturing engineering (process, yield, line optimization)
-- Pure software roles at a hardware company
+When scoring a role outside the candidate's primary industry, ask: does this role need the
+core competency the candidate has named? If the profile explicitly lists this industry or
+role-pattern as a fit, score it as in-domain. If the profile is silent and the connection
+is speculative, score conservatively and flag the cross-industry interpretation in
+ai_notes.
 
 ---
 
@@ -143,39 +112,27 @@ Treat the JD as absent if it contains no actual job content — blank, under 30 
 
 **CRITICAL: Absent JD does NOT create a manual_review exception. Work the steps below.**
 
-Step 1 — Hard reject check. Does the title match any hard reject category? Score 1.
-Set score_status = "scored". Done. You do not need a JD for this.
-Examples that are hard rejects regardless of missing JD:
-  "Workplace Manager" → facilities only → score 1
-  "Security Site Operations Manager" at GardaWorld → physical security → score 1
-  "IT Service Management Manager" → ITSM → score 1
-  "Regional IT Manager" → general IT → score 1
-  "Venue Operations" → facilities only → score 1
-  "Network Infrastructure & Operations Manager" → networking → score 1
-  "Senior Hardware Development Engineer" → hardware design → score 1
+Step 1 — Hard reject check. Does the title clearly fall into a category the profile
+excludes? Score 1. Set score_status = "scored". Done. You do not need a JD for this.
 
-Step 2 — Tier 1 exception. Tier 1 company + in-domain title → score 6. Note absent JD.
+Step 2 — Tier 1 exception. Tier 1 company + in-domain title → score 6. Note absent JD in
+ai_notes.
 
-Step 3 — In-domain title, no JD. Title is directionally right (data center, infrastructure,
-operations, NPI, hardware ops) but JD is absent. Make a call — score 5 as the floor.
-Note the absent JD. Do NOT route to manual_review just because you lack JD detail.
-Examples:
-  "Data Center Site Manager" (unknown company, no JD) → score 5
-  "Operations Manager & Site Lead" (no company, no JD) → score 4-5, note unknowns
-  "Infrastructure Operations Manager" at a non-Tier-1 company, no JD → score 5-6
-  "Datacenter Hardware Operations Lead" (no company, no JD) → score 5, flag missing company
+Step 3 — In-domain title, no JD. Title is directionally aligned with the profile's target
+roles or core competencies but the JD is absent. Make a call — score 5 as the floor. Note
+the absent JD. Do NOT route to manual_review just because you lack JD detail.
 
-Step 4 — Ambiguous title AND absent JD. Title gives no clear signal either way AND
-company gives no signal AND JD is absent. This is the ONLY valid manual_review trigger
-when JD is absent. It must be genuinely impossible to make even a directional call.
-This should be fewer than 5% of all jobs scored.
+Step 4 — Ambiguous title AND absent JD AND no useful company signal. Title gives no clear
+read either way, the company is unknown or gives no signal, and the JD is absent. This is
+the ONLY valid manual_review trigger when JD is absent. It must be genuinely impossible to
+make even a directional call. Should be fewer than 5% of all jobs scored.
 
 ---
 
 ## MANUAL_REVIEW — LAST RESORT ONLY
 
-manual_review means: a human must look at this before it can be acted on.
-Reserve it for cases where a wrong call in either direction would be costly.
+manual_review means: a human must look at this before it can be acted on. Reserve it for
+cases where a wrong call in either direction would be costly.
 
 Valid triggers (all conditions must be met):
 - Title is genuinely ambiguous (not obviously in-domain OR out-of-domain)
@@ -183,7 +140,7 @@ Valid triggers (all conditions must be met):
 - AND company gives no useful signal
 
 Invalid uses — use hard reject or scored instead:
-- Missing JD on a title that is clearly out-of-domain → hard reject, score 1
+- Missing JD on a title that is clearly out-of-domain (matches an exclusion) → hard reject, score 1
 - Missing JD on a title that is directionally in-domain → score 5, note absent JD
 - Missing comp estimate → not a reason for manual_review
 - Uncertainty about seniority on an irrelevant role → hard reject

--- a/docs/GENERALIZATION.md
+++ b/docs/GENERALIZATION.md
@@ -43,16 +43,13 @@ domain. Each item is a future task to make the pipeline domain-neutral.
 
 ### Scorer role prompt — `config/roles/job_scorer.md`
 
-- [ ] **`HARD REJECT RULES`** section — enumerates tech job categories explicitly (software engineering, security, IT, supply chain, networking, hardware design, biotech, finance, legal, HR, marketing, facilities)
-  - Should become: "Hard reject any role that matches a category listed in the candidate's profile under `## Excluded Categories`. The profile determines what's excluded."
+- [x] **`HARD REJECT RULES`** — fixed 2026-04-25 (#65): no longer enumerates tech categories. Prompt now instructs the LLM to read the candidate's profile under any of `## Excluded Categories`, `## Deal-Breakers`, `## What I Am NOT`, `## Not Open To`, or `## Reduce score for` (under `## Flags for Scorer`). Profile exclusions explicitly take priority over the Tier 1 floor.
 
-- [ ] **`TIER 1 COMPANY EXCEPTION`** — defines in-domain titles as "Data center technician, DC operations, NPI program manager, operational readiness, forward deployed engineer"
-  - Should reference profile's `## Core Competencies` and `## Target Role` sections
-  - The exception logic (Tier 1 + in-domain → score 6 minimum) is generic and can stay
+- [x] **`TIER 1 COMPANY EXCEPTION`** — fixed 2026-04-25 (#65): in-domain title list removed; prompt now instructs the LLM to derive in-domain from the profile's target-role and core-competency sections. Exception logic (Tier 1 + in-domain → 6 floor) preserved as generic.
 
-- [ ] **`ENGINEER TITLE CALIBRATION`** section — assumes candidate has mixed IC/ops/program background in hardware
-  - This entire section is personal calibration based on past false positives
-  - Should move to `candidate_context/profile.md` as candidate-specific scoring guidance, or become optional
+- [x] **`ENGINEER TITLE CALIBRATION`** — fixed 2026-04-25 (#65): the operator-specific IC-vs-ops engineer calibration moved into the operator's profile under a new `## Title Calibration Notes` section. The prompt now contains a generic "candidate-token calibration" rule: don't broadly reject on a single token if that token appears in titles the candidate has held; honor any `## Title Calibration Notes` section in the profile for finer guidance. Also added to `profile.md.example` with both tech and non-tech examples.
+
+- [x] **`CROSS-INDUSTRY RECOGNITION`** — fixed 2026-04-25 (#65): hardware-specific industry list (robotics, AVs, satellites, fusion) removed from prompt. Prompt now instructs the LLM to look for cross-industry framing in profile sections like `## Core Competency (Cross-Industry)` or `## Framing for Private-Sector Applications`. Conservative scoring + ai_notes flag when the connection is speculative.
 
 ### Role prompts with tech vocabulary — `config/roles/*.md`
 
@@ -136,10 +133,10 @@ Remaining roles audited 2026-04-22 and found clean: `briefing_writer.md`, `fit_a
 2. ~~Move `_HARD_REJECT_PATTERNS`~~ → loaded from `config/prefilter_rules.yaml` via `config_loader`.
 3. ~~Move `_IN_DOMAIN_PATTERNS` and `_IN_DOMAIN_POISON`~~ → loaded from `config/in_domain_patterns.yaml`.
 
-**Phase 2: Prompt neutralization**
-4. Rewrite `job_scorer.md` hard reject section to reference profile categories rather than enumerate tech
-5. Move engineer-calibration logic from prompt to profile.md.example (as a generic example of "per-candidate scoring calibration")
-6. Audit other role prompts for domain vocabulary
+**Phase 2: Prompt neutralization** — ✅ shipped 2026-04-25 (#65)
+4. ~~Rewrite `job_scorer.md` hard reject section~~ → references profile sections instead of enumerating categories.
+5. ~~Move engineer-calibration logic~~ → moved to operator's `profile.md` under `## Title Calibration Notes`; `profile.md.example` shows the new section with both tech and non-tech examples.
+6. ~~Audit other role prompts for domain vocabulary~~ → completed 2026-04-22 (#156); see status flags above.
 
 **Phase 3: Example diversification**
 7. Rewrite `profile.md.example` and `target_companies.md.example` to show 3 fields


### PR DESCRIPTION
## Summary
- `config/roles/job_scorer.md` no longer enumerates tech-specific reject categories or in-domain title vocabulary. The prompt now instructs the LLM to read the candidate's profile to determine exclusions, in-domain titles, cross-industry framing, and token-level calibration.
- Operator-specific IC-vs-ops engineer calibration moves from the prompt into the operator's profile under a new `## Title Calibration Notes` section.
- `candidate_context/profile.md.example` updated to document the expected sections (`## Excluded Categories`, `## Title Calibration Notes`) with both tech and non-tech examples.
- `docs/GENERALIZATION.md` Phase 2 marked complete.

## Why this matters
Pipeline is intended to work for any candidate in any field. The current scorer prompt has tech-industry vocabulary baked in (~12 enumerated categories of rejects, in-domain title list specific to data-center / NPI work, IC-hardware-engineering calibration). Amy's beta stack (social work) currently inherits all of this — her job stream can't score correctly until the prompt becomes profile-driven.

## What's preserved
The load-bearing generic rules stay in the prompt:
- Title-deterministic hard reject → score 1, score_status=scored, never manual_review for known-out-of-domain titles
- Tier 1 + in-domain → score 6 floor
- Profile exclusions take priority over the Tier 1 floor (NEW explicit rule)
- "Don't broadly reject on a single token if that token appears in titles the candidate has held" (NEW generic principle, replaces operator-specific engineer calibration)
- Ambiguous title + absent JD + no company signal → only valid manual_review trigger

The deterministic prefilter (`scorer_prefilter.py` + `prefilter_rules.yaml`) is unchanged — it remains the comprehensive regex backstop. The LLM-side hard reject covers cases regex misses by deferring to the profile.

## Migration required
- All operators on existing profiles: ensure your profile.md contains a section enumerating exclusions. The prompt recognizes any of `## Excluded Categories`, `## Deal-Breakers`, `## What I Am NOT`, `## Not Open To`, or `## Reduce score for` (under `## Flags for Scorer`).
- Operator profile (Brock): `## Title Calibration Notes` section appended on docker.lan stack to absorb the IC-vs-ops engineer calibration that left the prompt.
- Amy's profile already has `## Excluded Categories` (created by onboarding interviewer) — no profile change needed when bumping her stack.
- See `candidate_context/profile.md.example` for canonical section guidance with multi-field examples.

## Test plan
- [ ] CI passes (ruff + mypy + pytest)
- [ ] After merge: `:latest` image rolls; v0.4.0 smoke test re-scores 5+ representative jobs (mix of LLM-rejected, mid-fit, high-fit) and eyeballs scores vs. expectation
- [ ] Amy stack bump (deferred until v0.4.0 tag): triage + one prep on a flagged job, verify scoring landing zones

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)