### PR TITLE
chore(openrouter-cleanup): drop direct-Anthropic + direct-Perplexity clients and keys (#251 #261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Removed
+
+- **Direct-Anthropic and direct-Perplexity aichat-ng client blocks (#251).** `ops/aichat-ng/config.yaml.example` no longer seeds `type: claude` or `type: openai-compatible name: perplexity` clients. Both providers are reached through OpenRouter as of the #250 Phase 2 cutover, so the inline blocks were inert. Same cleanup applied to the legacy native-install paths in `scripts/bootstrap.sh`, `docs/setup/install-linux.md`, and `docs/setup/configure.md`.
+- **`ANTHROPIC_API_KEY` and `PERPLEXITY_API_KEY` env vars (#261).** `data/.env.example` no longer asks for them; `ops/entrypoint.sh` no longer substitutes them when seeding `state/aichat_ng/config.yaml`; `docs/setup/prerequisites.md` retired the Anthropic and Perplexity sections (Anthropic models now route via `openrouter:anthropic/...`, Perplexity via `openrouter:perplexity/sonar-reasoning-pro`). Existing stacks: the variables are simply unused — leaving them in `state/data/.env` is harmless. Closes the #250 cutover loop.
+
 ### Added
 
 - **Onboarding interview now collects voice samples + auto-cleans (#262).** The interview prompt at `config/roles/onboarding_interviewer.md` adds a new Phase 3f that asks the user to paste 3,000–8,000 words of their own long-form prose (blog posts, essays, long emails) for cover-letter / outreach voice calibration. The interview emits an optional eighth file `voice-samples.md`; the paste-back injector runs the body through `findajob.onboarding.voice_processor.process_voice_samples`, which (1) deterministically strips markdown structure (headers, images, link syntax, bold/italic, blockquotes, code fences, footnote markers, HTML tags, tables, frontmatter) without altering prose, then (2) calls Opus 4.7 to generalize personal identifiers the user may not have thought to scrub (specific dates, named third parties, exact geographic specifiers, named institutions) while preserving voice. The cleaned-and-generalized text lands at `candidate_context/voice_samples/voice-samples.md`. Voice samples are **optional** — absence yields no error and falls back to resume-based voice calibration. LLM redaction failure degrades to cleaned-only with a flag the caller can surface. Closes the onboarding gap left by #257.

--- a/data/.env.example
+++ b/data/.env.example
@@ -6,10 +6,8 @@
 # This file is gitignored. Never commit your actual .env.
 
 # ── LLM APIs ─────────────────────────────────────────────────────────────────
-ANTHROPIC_API_KEY=your_key_here
-OPENROUTER_API_KEY=your_key_here       # Used for DeepSeek v3 job scoring
-GOOGLE_API_KEY=your_key_here           # Gemini (default model + embeddings)
-PERPLEXITY_API_KEY=your_key_here       # Company research (sonar-reasoning-pro)
+OPENROUTER_API_KEY=your_key_here       # 10 of 11 pipeline roles (Opus 4.7, Sonnet 4.6, Gemini 3 Flash, DeepSeek v3, Sonar)
+GOOGLE_API_KEY=your_key_here           # Gemini embeddings (RAG)
 GROQ_API_KEY=your_key_here             # Optional
 XAI_API_KEY=your_key_here              # Optional
 

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -106,10 +106,8 @@ Linux defaults are already built into `src/findajob/paths.py`. If everything is 
 API keys and secrets. See `data/.env.example` for the full list.
 
 ```bash
-ANTHROPIC_API_KEY=sk-ant-...
 OPENROUTER_API_KEY=sk-or-...
 GOOGLE_API_KEY=AIza...
-PERPLEXITY_API_KEY=pplx-...
 RAPIDAPI_KEY=...
 NTFY_TOPIC=your-topic-name
 ```
@@ -124,20 +122,14 @@ Located at `~/.config/aichat_ng/config.yaml`.
 
 Full template:
 ```yaml
-model: gemini:gemini-3-flash-preview
+model: openrouter:google/gemini-3-flash-preview
 
 clients:
   - type: gemini
     api_key: ${GOOGLE_API_KEY}
 
-  - type: claude
-    api_key: ${ANTHROPIC_API_KEY}
-
   - type: openrouter
     api_key: ${OPENROUTER_API_KEY}
-
-  - type: perplexity
-    api_key: ${PERPLEXITY_API_KEY}
 
   # Dedicated embedding client — name must match what triage.py passes to --rag
   # Do NOT include this client in --sync-models runs
@@ -157,7 +149,7 @@ rag_reranker_model: ~
 
 **Critical:** API keys MUST use `${VAR_NAME}` syntax, not literal values. The variables must be in your environment when you run aichat-ng. The pipeline's scripts load `data/.env` at startup, but REPL usage needs the env vars set in your shell profile.
 
-**`type: claude` not `type: anthropic`** — aichat-ng uses `claude` as the type identifier.
+Anthropic and Perplexity model access routes through OpenRouter — there are no direct `claude` or `perplexity` clients in the config since v0.4.0. If your pre-v0.4.0 stack still has those blocks in `state/aichat_ng/config.yaml`, they are inert and safe to remove.
 
 ---
 
@@ -273,8 +265,7 @@ With Phase 2 of the OpenRouter cutover, 10 of 11 roles depend on
 `GOOGLE_API_KEY` remains live after Phase 2 — it still powers the
 Gemini embedding client (`gemini-embed:gemini-embedding-001`) that
 the RAG index uses. Rotate it the same way. `ANTHROPIC_API_KEY` and
-`PERPLEXITY_API_KEY` are still declared in the aichat-ng config but
-no live role routes to them after the cutover; they are retirement
-candidates rather than fallbacks. Keep rotations staggered — don't
+`PERPLEXITY_API_KEY` were retired in v0.4.0 — both providers are
+reached through OpenRouter now. Keep rotations staggered — don't
 revoke the old key until the new one has served at least one live
 pipeline run without error.

--- a/docs/setup/install-linux.md
+++ b/docs/setup/install-linux.md
@@ -120,20 +120,14 @@ mkdir -p ~/.config/aichat_ng/roles
 Create `~/.config/aichat_ng/config.yaml`:
 ```yaml
 # See docs/setup/configure.md for full config template
-model: gemini:gemini-3-flash-preview
+model: openrouter:google/gemini-3-flash-preview
 
 clients:
   - type: gemini
     api_key: ${GOOGLE_API_KEY}
 
-  - type: claude
-    api_key: ${ANTHROPIC_API_KEY}
-
   - type: openrouter
     api_key: ${OPENROUTER_API_KEY}
-
-  - type: perplexity
-    api_key: ${PERPLEXITY_API_KEY}
 
   - type: gemini
     name: gemini-embed

--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -6,46 +6,30 @@ Everything you need before running the setup guide.
 
 ## Required Accounts and API Keys
 
-### 1. Anthropic (Claude)
-Used by: `resume_tailor`, `cover_letter_writer`, `briefing_writer`, `outreach_drafter`
-
-- Sign up at https://console.anthropic.com
-- Create an API key
-- Add to `data/.env` as `ANTHROPIC_API_KEY`
-- Models used: `claude-opus-4-6:thinking`, `claude-sonnet-4-6`
-
-### 2. OpenRouter
-Used by: `job_scorer` (DeepSeek v3.2)
+### 1. OpenRouter
+Used by: 10 of 11 pipeline roles — `job_scorer`, `resume_tailor`, `cover_letter_writer`, `briefing_writer`, `outreach_drafter`, `company_researcher`, `fit_analyst`, `recruiter_critic`, `resume_change_reviewer`, `network_analyst`, plus the default model.
 
 - Sign up at https://openrouter.ai
 - Create an API key
 - Add to `data/.env` as `OPENROUTER_API_KEY`
-- Model: `deepseek/deepseek-v3.2` — very cheap, accurate for structured JSON
+- Models routed: `anthropic/claude-opus-4.7`, `anthropic/claude-sonnet-4.6`, `google/gemini-3-flash-preview`, `deepseek/deepseek-v3.2`, `perplexity/sonar-reasoning-pro`
 
-### 3. Google AI (Gemini)
-Used by: default aichat-ng model, `resume_change_reviewer`, `network_analyst`, embedding model
+### 2. Google AI (Gemini)
+Used by: embedding model only (`gemini-embedding-001`) for RAG indexing of `candidate_context/`. Direct-Gemini chat models were retired from the pipeline in v0.4.0 — Gemini chat now routes through OpenRouter as well.
 
 - Sign up at https://aistudio.google.com
 - Create an API key
 - Add to `data/.env` as `GOOGLE_API_KEY`
-- Models: `gemini-3-flash-preview`, `gemini-embedding-001`
+- Model: `gemini-embedding-001` (embedding endpoint; no OpenRouter equivalent)
 
-### 4. Perplexity
-Used by: `company_researcher`
-
-- Sign up at https://www.perplexity.ai
-- Create an API key
-- Add to `data/.env` as `PERPLEXITY_API_KEY`
-- Model: `sonar-reasoning-pro` (real-time web access with reasoning)
-
-### 5. RapidAPI — jobs-api14
+### 3. RapidAPI — jobs-api14
 Used by: LinkedIn and Indeed job search in `triage.py`
 
 - Sign up at https://rapidapi.com
 - Subscribe to **jobs-api14** (has a free tier)
 - Add API key to `data/.env` as `RAPIDAPI_KEY`
 
-### 6. Google Cloud — Sheets API + Gmail API
+### 4. Google Cloud — Sheets API + Gmail API
 
 **Why:** The pipeline reads/writes Google Sheets and reads Gmail for job emails.
 

--- a/ops/aichat-ng/config.yaml.example
+++ b/ops/aichat-ng/config.yaml.example
@@ -37,10 +37,6 @@ clients:
   - type: openai
     api_key: ${OPENAI_API_KEY}
 
-  - type: claude
-    api_base: https://api.anthropic.com/v1
-    api_key: ${ANTHROPIC_API_KEY}
-
   - type: gemini
     api_base: https://generativelanguage.googleapis.com/v1beta
     api_key: ${GOOGLE_API_KEY}
@@ -78,11 +74,6 @@ clients:
     name: openrouter
     api_base: https://openrouter.ai/api/v1
     api_key: ${OPENROUTER_API_KEY}
-
-  - type: openai-compatible
-    name: perplexity
-    api_base: https://api.perplexity.ai
-    api_key: ${PERPLEXITY_API_KEY}
 
   - type: openai-compatible
     name: groq

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -65,8 +65,8 @@ if [ -d /opt/findajob/bundled-aichat ]; then
     if [ ! -f "$AICHAT_CFG_DIR/config.yaml" ] && [ -f /opt/findajob/bundled-aichat/config.yaml.example ]; then
         cp /opt/findajob/bundled-aichat/config.yaml.example "$AICHAT_CFG_DIR/config.yaml"
         # aichat-ng does not perform ${VAR} substitution at load time — inject keys now.
-        for _var in OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY \
-                    OPENROUTER_API_KEY PERPLEXITY_API_KEY GROQ_API_KEY XAI_API_KEY; do
+        for _var in OPENAI_API_KEY GOOGLE_API_KEY \
+                    OPENROUTER_API_KEY GROQ_API_KEY XAI_API_KEY; do
             eval "_val=\"\${${_var}:-}\""
             sed -i "s|\${${_var}}|${_val}|g" "$AICHAT_CFG_DIR/config.yaml"
         done

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -164,20 +164,14 @@ setup_aichat_config_dir() {
 # API keys come from environment variables. Source data/.env before running aichat-ng.
 # Add to ~/.bashrc: set -a; source ~/findajob/data/.env; set +a
 
-model: gemini:gemini-2.5-flash
+model: openrouter:google/gemini-3-flash-preview
 
 clients:
   - type: gemini
     api_key: ${GOOGLE_API_KEY}
 
-  - type: claude
-    api_key: ${ANTHROPIC_API_KEY}
-
   - type: openrouter
     api_key: ${OPENROUTER_API_KEY}
-
-  - type: perplexity
-    api_key: ${PERPLEXITY_API_KEY}
 
   # Dedicated embedding client — name must match what triage.py passes to --rag
   # Do NOT include in --sync-models runs

--- a/tests/test_aichat_config_template.py
+++ b/tests/test_aichat_config_template.py
@@ -1,10 +1,11 @@
 """Tests for the aichat-ng config template shipped in ops/aichat-ng/.
 
 The template is YAML-valid and contains the client entries the pipeline
-expects (claude, openai, gemini, openrouter, perplexity). We can't run
-aichat-ng against the template itself (no API keys loaded at test time),
-but we can assert structure so a future edit doesn't accidentally break
-parseability.
+expects. As of v0.4.0 (#251) the direct `claude` and `perplexity` clients
+were removed — both providers are reached through OpenRouter now. We
+can't run aichat-ng against the template itself (no API keys loaded at
+test time), but we can assert structure so a future edit doesn't
+accidentally break parseability.
 """
 
 from __future__ import annotations
@@ -32,10 +33,16 @@ def test_template_has_required_clients():
     names = set()
     for c in data["clients"]:
         names.add(c.get("name") or c.get("type"))
-    # These are the clients the roles config actually invokes.
-    required = {"claude", "openai", "gemini", "openrouter", "perplexity"}
+    # These are the clients the roles config actually invokes. claude and
+    # perplexity were retired in #251 — both providers route through
+    # openrouter now (see openrouter:anthropic/* and openrouter:perplexity/*
+    # model IDs in config/roles/).
+    required = {"openai", "gemini", "openrouter"}
     missing = required - names
     assert not missing, f"template missing required clients: {missing}"
+    # gemini-embed is a separately-named gemini client used for RAG; the
+    # template seeds it as a sibling of the chat-gemini client.
+    assert "gemini-embed" in names, "template missing gemini-embed client"
 
 
 def test_template_has_no_literal_keys():


### PR DESCRIPTION
## Summary
Closes the #250 OpenRouter Phase 2 cutover loop. Both providers are reached through OpenRouter as of #250; the standalone clients and env vars have been inert since that PR merged.

**#251 — drop unused aichat-ng client blocks:**
- `ops/aichat-ng/config.yaml.example`: remove `type: claude` and `type: openai-compatible name: perplexity` clients
- `scripts/bootstrap.sh`: same blocks pruned from native-install template; default model bumped from `gemini:gemini-2.5-flash` to `openrouter:google/gemini-3-flash-preview` to match container default
- `docs/setup/install-linux.md`, `docs/setup/configure.md`: yaml templates updated; rotation note rewritten — ANTHROPIC + PERPLEXITY keys are no longer "retirement candidates," they are retired

**#261 — retire `ANTHROPIC_API_KEY` + `PERPLEXITY_API_KEY` env vars:**
- `data/.env.example`: remove both lines; OPENROUTER comment updated to reflect the 10-of-11-roles surface area
- `ops/entrypoint.sh`: drop both vars from the seed-time substitution loop
- `docs/setup/prerequisites.md`: drop §1 Anthropic + §4 Perplexity; renumber Google Cloud section from §6 to §4

**Preserved:** OpenRouter catalog entries for `perplexity/sonar*` in `ops/aichat-ng/models-override.yaml` stay — those describe how to call Perplexity models THROUGH OpenRouter and are in active use.

## Existing stacks
No migration required for v0.4.0 to function. Leftover `ANTHROPIC_API_KEY` / `PERPLEXITY_API_KEY` lines in `state/data/.env` are unused but harmless. Old `type: claude` / perplexity client blocks in pre-existing `state/aichat_ng/config.yaml` are inert and safe to remove (operators may delete them if they want a clean config).

## Test plan
- [ ] CI passes (ruff + mypy + pytest)
- [ ] Smoke (post-image-build): `docker compose exec scheduler aichat-ng --model openrouter:google/gemini-3-flash-preview "say hello"` still works (OpenRouter client still seeded)
- [ ] Smoke: `docker compose exec scheduler env | grep -E '^(ANTHROPIC|PERPLEXITY)_API_KEY'` — operators with leftover values still see them, fresh stacks won't

Closes #251, closes #261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)