### PR TITLE
fix(web/archive): Promote 409 on score-6 stage='scored' rows (#282)

### DIFF
--- a/src/findajob/actions.py
+++ b/src/findajob/actions.py
@@ -191,12 +191,15 @@ def promote_to_scored(
     job: Any,
     reason: str = "Promoted from web UI",
 ) -> None:
-    """Promote a manual_review job to scored with relevance_score=7.
+    """Promote a job to stage='scored' with relevance_score=7.
 
-    Used when the operator marks a Review-tab job as "Promote" — bumps the
-    score so it lands on the Dashboard for a Flag for Prep decision. The
-    caller is responsible for checking that the job's stage is manual_review
-    (handlers return 409 otherwise).
+    Used when the operator marks a job as "Promote" from either:
+    - Review tab (stage='manual_review' → 'scored'), or
+    - Archive tab (stage='scored', score<7 → score=7).
+
+    Bumps the score so it lands on the Dashboard's score>=7 filter for a
+    Flag for Prep decision. The caller (web handler) is responsible for
+    verifying the source stage is in the promotable set.
     """
     now = datetime.now(UTC).isoformat()
     old_stage = job["stage"]

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -387,18 +387,27 @@ def reactivate(
     return HTMLResponse("")
 
 
+_PROMOTABLE_STAGES = ("manual_review", "scored")
+
+
 @router.post("/board/jobs/{fingerprint}/promote", response_class=HTMLResponse)
 def promote(
     fingerprint: str,
     request: Request,  # noqa: ARG001
     db: sqlite3.Connection = Depends(get_db),  # noqa: B008
 ) -> HTMLResponse:
-    """Promote a manual_review job onto the Dashboard."""
+    """Promote a job onto the Dashboard with relevance_score=7.
+
+    Two surfaces invoke this:
+    - Review tab: rows at stage='manual_review' (raises score, keeps stage)
+    - Archive tab: rows at stage='scored' with score<7 (bumps score to 7
+      so the row appears on the Dashboard's score>=7 filter).
+    """
     job = _fetch_job(db, fingerprint)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
-    if job["stage"] != "manual_review":
-        raise HTTPException(status_code=409, detail="Job is not in manual_review")
+    if job["stage"] not in _PROMOTABLE_STAGES:
+        raise HTTPException(status_code=409, detail="Job is not promotable from its current stage")
     promote_to_scored(db, job, reason="Promoted from web UI")
     return HTMLResponse("")
 

--- a/src/findajob/web/templates/board/_archive_promote_cell.html
+++ b/src/findajob/web/templates/board/_archive_promote_cell.html
@@ -1,7 +1,8 @@
 {#
   Archive-tab-only: Promote action cell. Renders a button for rows at
-  stage='scored' (the pool that can still be promoted to manual_review
-  for Dashboard triage). Empty cell for rows already past that stage.
+  stage='scored' — clicking bumps relevance_score to 7 so the row
+  surfaces on the Dashboard for a Flag for Prep decision. Empty cell
+  for rows already past that stage.
   Inputs: row — sqlite3.Row with fingerprint + stage.
 #}
 <td class="px-3 py-1 align-top text-sm whitespace-nowrap">

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -782,11 +782,28 @@ class TestPromote:
         audit = _fetch_audit(client, "fp_manual")
         assert any(a == ("stage", "manual_review", "scored") for a in audit)
 
-    def test_409_on_non_manual_review_job(self, client: TestClient):
-        response = client.post("/board/jobs/fp_scored/promote")
+    def test_happy_path_from_archive_scored(self, client: TestClient):
+        """Archive-tab Promote on a score-6 stage='scored' row bumps to score=7."""
+        conn = sqlite3.connect(client._db_path)
+        _insert_job(conn, fingerprint="fp_archive_6", stage="scored", score=6)
+        conn.close()
+
+        response = client.post("/board/jobs/fp_archive_6/promote")
+
+        assert response.status_code == 200
+        assert response.text == ""
+
+        conn = sqlite3.connect(client._db_path)
+        row = conn.execute("SELECT stage, relevance_score FROM jobs WHERE fingerprint='fp_archive_6'").fetchone()
+        conn.close()
+        assert row[0] == "scored"
+        assert row[1] == 7
+
+    def test_409_on_post_application_stage(self, client: TestClient):
+        response = client.post("/board/jobs/fp_applied/promote")
 
         assert response.status_code == 409
-        assert _fetch_stage(client, "fp_scored") == "scored"
+        assert _fetch_stage(client, "fp_applied") == "applied"
 
     def test_404_on_unknown_fingerprint(self, client: TestClient):
         response = client.post("/board/jobs/fp_nonexistent/promote")


### PR DESCRIPTION
## Summary
- Promote handler now accepts `stage` in (`manual_review`, `scored`) instead of only `manual_review`. Closes #282.
- Archive-tab Promote button on score-6 rows now bumps them to score=7 (stage stays `scored`) so they surface on the Dashboard's score>=7 filter.
- Updated docstrings on `promote_to_scored` and the archive promote template to reflect the dual surface (Review tab + Archive tab).

## Test plan
- [x] `uv run pytest tests/test_board_actions.py::TestPromote -v` — 4 pass (added `test_happy_path_from_archive_scored`, replaced `test_409_on_non_manual_review_job` with `test_409_on_post_application_stage` since `scored` is no longer a 409 case)
- [x] `uv run pytest` — 1048 pass
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy src/findajob/web/routes/board_actions.py src/findajob/actions.py` — all green
- [ ] Post-merge: verify on `/board/archive?relevance_score_min=6&relevance_score_max=6` that clicking Promote on a real score-6 stage='scored' row returns 200 and bumps the score

🤖 Generated with [Claude Code](https://claude.com/claude-code)