### PR TITLE
fix(web/config + discoverer): readable output mode + visible /config/ errors (#289)

### DIFF
--- a/src/findajob/discoverer/writer.py
+++ b/src/findajob/discoverer/writer.py
@@ -19,6 +19,11 @@ from pathlib import Path
 _MD_RELPATH = "candidate_context/discovered_companies.md"
 _JSON_RELPATH = "candidate_context/discovered_companies.json"
 _BACKUP_ROOT = ".backups"
+# tempfile.mkstemp() defaults to 0o600 (owner-only). Outputs land in
+# bind-mounted candidate_context/ and must be readable by the web server
+# even when the writer ran as a different user (e.g., manual `docker exec`
+# as root vs. the FastAPI process running as `lad`).
+_OUTPUT_FILE_MODE = 0o644
 
 
 def _utc_stamp() -> str:
@@ -75,6 +80,7 @@ def commit_atomically(
         fd, tmp_md = tempfile.mkstemp(prefix=md_dest.name + ".", suffix=".tmp", dir=str(md_dest.parent))
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
             fh.write(markdown)
+        os.chmod(tmp_md, _OUTPUT_FILE_MODE)
         tempfiles.append((tmp_md, md_dest))
 
         # Stage JSON
@@ -82,6 +88,7 @@ def commit_atomically(
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
             json.dump(json_payload, fh, ensure_ascii=False, indent=2)
             fh.write("\n")
+        os.chmod(tmp_json, _OUTPUT_FILE_MODE)
         tempfiles.append((tmp_json, json_dest))
 
         # Commit

--- a/src/findajob/web/routes/config.py
+++ b/src/findajob/web/routes/config.py
@@ -44,14 +44,28 @@ def config_edit_form(relpath: str, request: Request) -> HTMLResponse:
 
     content = ""
     exists = resolved.is_file()
+    error: str | None = None
     if exists:
-        content = resolved.read_text(encoding="utf-8", errors="replace")
+        try:
+            content = resolved.read_text(encoding="utf-8", errors="replace")
+        except PermissionError:
+            # File exists but is unreadable by the web process (e.g., it was
+            # written by a different user via `docker exec` and has restrictive
+            # mode). Render an inline error rather than 500ing into HTMX.
+            error = (
+                f"Cannot read {relpath}: permission denied. The file exists but "
+                "is not readable by the web server. Check ownership and mode "
+                "on the host (e.g., `chown $(id -u):$(id -g) <file>`, "
+                "`chmod 644 <file>`)."
+            )
+        except OSError as exc:
+            error = f"Cannot read {relpath}: {exc.strerror or type(exc).__name__}."
 
     templates = request.app.state.templates
     return templates.TemplateResponse(
         request=request,
         name="config/editor.html",
-        context={"relpath": relpath, "content": content, "exists": exists},
+        context={"relpath": relpath, "content": content, "exists": exists, "error": error},
     )
 
 

--- a/src/findajob/web/templates/config/editor.html
+++ b/src/findajob/web/templates/config/editor.html
@@ -9,7 +9,11 @@
   </p>
   <h1 class="text-xl font-semibold font-mono mb-1">{{ relpath }}</h1>
 
-  {% if not exists %}
+  {% if error %}
+    <p class="text-sm text-red-800 bg-red-50 border border-red-300 rounded px-3 py-2 mb-4">
+      {{ error }}
+    </p>
+  {% elif not exists %}
     <p class="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2 mb-4">
       File does not exist yet — it will be created on save.
     </p>

--- a/tests/discoverer/test_writer.py
+++ b/tests/discoverer/test_writer.py
@@ -29,6 +29,12 @@ def test_commit_atomically_writes_both_files(tmp_path: Path) -> None:
     assert md_path.read_text() == "# md\n\nhello\n"
     json_path = tmp_path / "candidate_context" / "discovered_companies.json"
     assert json.loads(json_path.read_text())["companies"][0]["name"] == "Alpha"
+    # Files must be world-readable (0o644) so the FastAPI process running as
+    # `lad` can read files that the discoverer wrote as a different user
+    # (e.g., manual `docker exec` as root). tempfile.mkstemp's default 0o600
+    # would make /config/ silently 500 on the file-read path.
+    assert (md_path.stat().st_mode & 0o777) == 0o644
+    assert (json_path.stat().st_mode & 0o777) == 0o644
 
 
 def test_commit_atomically_creates_parent_dir(tmp_path: Path) -> None:

--- a/tests/test_web_config_editor.py
+++ b/tests/test_web_config_editor.py
@@ -105,6 +105,24 @@ def test_editor_rejects_unlisted_file(client: TestClient) -> None:
     assert resp.status_code == 403
 
 
+def test_editor_renders_inline_error_on_unreadable_file(client: TestClient, base_root: Path, monkeypatch) -> None:
+    """A 0o000-mode file (or one owned by another user) was 500ing into HTMX
+    silently. The route now catches PermissionError and renders an inline
+    error in the editor template (#289)."""
+    target = base_root / "candidate_context" / "profile.md"
+
+    def _raise_permission(*_a, **_kw):
+        raise PermissionError(13, "Permission denied", str(target))
+
+    monkeypatch.setattr(Path, "read_text", _raise_permission)
+
+    resp = client.get("/config/files/candidate_context/profile.md")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "permission denied" in html.lower()
+    assert "candidate_context/profile.md" in html
+
+
 def test_editor_rejects_path_traversal(client: TestClient) -> None:
     resp = client.get("/config/files/config/../../etc/passwd")
     assert resp.status_code in (403, 404)


### PR DESCRIPTION
## Summary
Closes #289. Two-part fix:

1. **Discoverer writer chmod 0o644.** `tempfile.mkstemp()` defaults to 0o600; outputs land in bind-mounted `candidate_context/` and must be readable by the FastAPI process running as `lad` regardless of which user wrote them.
2. **/config/ route catches PermissionError.** Renders an inline red error block in the editor template instead of letting the exception 500 silently into HTMX. Error text names the cause (permission denied) and the host-side fix (chown / chmod).

## Test plan
- [x] `uv run pytest tests/discoverer/test_writer.py tests/test_web_config_editor.py -v` — 18 pass; new `test_editor_renders_inline_error_on_unreadable_file`, extended `test_commit_atomically_writes_both_files` asserting mode 0o644 on both files
- [x] `uv run pytest` — 1049 pass
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy src/findajob/discoverer/writer.py src/findajob/web/routes/config.py` — all green
- [ ] Post-merge: chown + chmod existing root-owned `discovered_companies.{md,json}` on docker.lan to `lad:lad` mode 644 (one-shot ops command — done at deploy time)
- [ ] Post-deploy: re-trigger an existing-file repro on /config/ and confirm the inline error renders instead of HTMX-silent failure

## Note
Both bugs ship together because they form a defense-in-depth pair: even if the writer fix regresses (or another script writes files as root), the /config/ error rendering means the operator sees what's wrong instead of "nothing happens."

🤖 Generated with [Claude Code](https://claude.com/claude-code)