### PR TITLE
fix(scorer): recover from prose/fence-wrapped LLM JSON output (#278)

### DIFF
--- a/src/findajob/scoring.py
+++ b/src/findajob/scoring.py
@@ -9,7 +9,7 @@ import time
 
 from findajob.paths import AICHAT, BASE
 from findajob.scorer_prefilter import _hard_reject_match, prefilter_score
-from findajob.utils import jd_is_usable, log_event, validate_llm_json
+from findajob.utils import extract_json_payload, jd_is_usable, log_event, validate_llm_json
 
 DB_PATH: str = f"{BASE}/data/pipeline.db"
 SCHEMA_PATH: str = f"{BASE}/config/scoring_schema.json"
@@ -30,12 +30,7 @@ def _normalize_llm_output(raw: str) -> str:
     Fixes: remote_status variants ("Remote-Friendly" → "Remote"),
            score values outside 1-10 range.
     """
-    text = raw.strip()
-    if text.startswith("```"):
-        text = "\n".join(text.split("\n")[1:])
-    if text.endswith("```"):
-        text = text[: text.rfind("```")]
-    text = text.strip()
+    text = extract_json_payload(raw)
     try:
         d = json.loads(text)
     except (json.JSONDecodeError, ValueError):
@@ -194,7 +189,17 @@ JD:
     parsed, error = validate_llm_json(_normalize_llm_output(result.stdout), SCHEMA_PATH)
 
     if error:
-        log_event("score_validation_failed", error=error, title=title, company=company)
+        # Capture the first 500 chars of the raw response so future parse
+        # failures can be diagnosed from pipeline.jsonl alone (the extractor
+        # already handles known fenced/prose-prefixed shapes; anything that
+        # still fails is a new failure mode).
+        log_event(
+            "score_validation_failed",
+            error=error,
+            title=title,
+            company=company,
+            raw_excerpt=(result.stdout or "").strip()[:500],
+        )
         # Stage 1.5: if LLM failed AND title matches a hard reject pattern, auto-reject
         # instead of cluttering the manual_review queue with obvious mismatches
         if _hard_reject_match(title):

--- a/src/findajob/utils.py
+++ b/src/findajob/utils.py
@@ -129,15 +129,62 @@ def load_env(path: str | None = None) -> dict[str, str]:
 # ── LLM JSON validation ─────────────────────────────────────────────────────
 
 
+def extract_json_payload(raw_output: str) -> str:
+    """Pull the JSON payload out of an LLM response that may wrap it in
+    markdown fences, prose, or both.
+
+    Handles, in order:
+    1. Whole response is a fenced block (```...```, possibly with a
+       language tag like ```json). Strip the fences.
+    2. Response contains a fenced ```json…``` block somewhere inside
+       prose. Return the contents of the first such block.
+    3. Response has prose before the JSON. Find the first '{' or '[',
+       return the substring from there onward (the parser will reject
+       trailing prose only if it's also non-JSON, which is fine — we
+       optimize for prose-before-JSON, the observed failure mode).
+    4. Otherwise return the input unchanged.
+
+    This is best-effort recovery for scorer responses that drift from
+    "JSON only" in the prompt despite explicit instructions; the parser
+    that consumes the output still gates on `json.loads` + schema
+    validation.
+    """
+    text = raw_output.strip()
+
+    # Case 1: whole-response fenced block
+    if text.startswith("```"):
+        # Drop the opening fence line (which may carry a language tag
+        # like "```json"), then strip a trailing fence if present.
+        first_newline = text.find("\n")
+        if first_newline != -1:
+            inner = text[first_newline + 1 :]
+            if inner.rstrip().endswith("```"):
+                inner = inner.rstrip()[: -len("```")]
+            return inner.strip()
+
+    # Case 2: fenced block embedded in prose. Match the first ```json
+    # or ``` (with optional lang tag) ... ``` block.
+    fence_match = _FENCED_JSON_RE.search(text)
+    if fence_match:
+        return fence_match.group(1).strip()
+
+    # Case 3: bare JSON preceded by prose. Anchor at the first { or [
+    # that opens a JSON value.
+    for opener in ("{", "["):
+        idx = text.find(opener)
+        if idx > 0:  # strictly prose-before; idx == 0 already parses
+            return text[idx:].strip()
+
+    return text
+
+
+_FENCED_JSON_RE = re.compile(r"```(?:json|JSON)?\s*\n(.*?)\n```", re.DOTALL)
+
+
 def validate_llm_json(raw_output: str, schema_path: str) -> tuple[dict | None, str | None]:
     import jsonschema
 
-    text = raw_output.strip()
-    if text.startswith("```"):
-        text = "\n".join(text.split("\n")[1:])
-    if text.endswith("```"):
-        text = text[: text.rfind("```")]
-    text = text.strip()
+    text = extract_json_payload(raw_output)
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError as e:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ from findajob.utils import (
     _clean_profile_field,
     build_outreach_filename,
     build_prep_filenames,
+    extract_json_payload,
     is_aggregator_company,
     is_ingest_noise_title,
     is_valid_company,
@@ -515,3 +516,62 @@ class TestLoadVoiceSamples:
     def test_under_cap_unchanged(self, tmp_path):
         (tmp_path / "a.md").write_text("short content")
         assert load_voice_samples(samples_dir=str(tmp_path), max_chars=1000) == "short content"
+
+
+# ── extract_json_payload ───────────────────────────────────────────────────
+
+
+class TestExtractJsonPayload:
+    """Recovery shapes for LLM scorer responses (#278). The scorer prompt
+    asks for JSON only; reality is sometimes prose, sometimes fenced,
+    sometimes both. The extractor handles each known shape so the parser
+    that runs after it sees clean JSON.
+    """
+
+    def test_plain_json_unchanged(self):
+        text = '{"relevance_score": 7}'
+        assert extract_json_payload(text) == text
+
+    def test_strips_whole_response_fence_with_json_lang(self):
+        text = '```json\n{"relevance_score": 7}\n```'
+        assert extract_json_payload(text) == '{"relevance_score": 7}'
+
+    def test_strips_whole_response_fence_no_lang(self):
+        text = '```\n{"relevance_score": 7}\n```'
+        assert extract_json_payload(text) == '{"relevance_score": 7}'
+
+    def test_extracts_fenced_json_block_inside_prose(self):
+        text = (
+            "Looking at this role, here's the analysis:\n\n"
+            "```json\n"
+            '{"relevance_score": 5}\n'
+            "```\n\n"
+            "Notes: the fit is moderate."
+        )
+        assert json.loads(extract_json_payload(text)) == {"relevance_score": 5}
+
+    def test_extracts_bare_json_after_prose(self):
+        # The exact failure mode reported in #278: prose at lines 1–2,
+        # then JSON starting on line 3. Original parser saw "Looking..."
+        # on char 0 and bombed at "char 50".
+        text = (
+            'Looking at this job posting,\n\nthe scoring output is:\n{"relevance_score": 6, "interview_likelihood": 4}'
+        )
+        assert json.loads(extract_json_payload(text)) == {
+            "relevance_score": 6,
+            "interview_likelihood": 4,
+        }
+
+    def test_extracts_bare_json_array_after_prose(self):
+        text = "Here are the results:\n[1, 2, 3]"
+        assert json.loads(extract_json_payload(text)) == [1, 2, 3]
+
+    def test_falls_through_to_input_when_no_json_present(self):
+        # Pure prose — extractor returns the input unchanged so the
+        # downstream parser surfaces a meaningful JSONDecodeError.
+        text = "I cannot evaluate this role without more information."
+        assert extract_json_payload(text) == text
+
+    def test_handles_leading_whitespace(self):
+        text = '   \n  {"relevance_score": 7}'
+        assert json.loads(extract_json_payload(text)) == {"relevance_score": 7}


### PR DESCRIPTION
## Summary
Closes #278. The scorer was emitting ~5–10 `score_validation_failed` events per triage cycle (43 in pipeline.jsonl over ~36h on the operator stack), all with identical parser error `JSON parse: Expecting value: line 3 column 21 (char 50)` — classic prose-before-JSON shape that the existing fence-stripper didn't handle.

New `extract_json_payload` helper covers four shapes:
1. Whole-response fence (`````json...```` `` or just `` ```...``` ``)
2. Fenced JSON block embedded in prose
3. Bare JSON after prose (the observed #278 failure mode)
4. Pure prose / no JSON — falls through unchanged

Both `validate_llm_json` and `_normalize_llm_output` route through the helper; duplicated fence-strip logic removed.

Defense-in-depth: `score_validation_failed` events now carry `raw_excerpt` (first 500 chars of the LLM response) so any remaining failure modes are diagnosable from pipeline.jsonl without redeploying a debug branch.

## Test plan
- [x] `uv run pytest tests/test_utils.py::TestExtractJsonPayload -v` — 8 new tests pass (plain, fenced w/ + w/o lang tag, fenced-in-prose, bare-after-prose, array, no-JSON fallthrough, leading whitespace)
- [x] `uv run pytest` — 1057 pass
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy src/findajob/utils.py src/findajob/scoring.py` — all green
- [ ] Post-merge: monitor `score_validation_failed` count in pipeline.jsonl over the next triage cycle (00:00 PT, target = 0). If non-zero, the new `raw_excerpt` field will reveal the next failure shape to handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)