### PR TITLE
feat(web/feedback): in-app widget files GitHub issue per submission (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **In-app feedback widget files a GitHub issue per submission (#227).** Floating "Feedback" button in the bottom-right corner of every page opens a small modal with a textarea; submission posts to `/feedback/submit` which calls the GitHub Issues API server-side and labels the issue `feedback` (plus an optional per-stack identifier label). New env vars in `state/data/.env`: `GITHUB_FEEDBACK_PAT` (fine-grained PAT scoped to Issues:read+write on the target repo, required), `FEEDBACK_STACK_LABEL` (optional second label, e.g. `from:operator` / `from:alice-doe`), `FEEDBACK_REPO` (defaults to `brockamer/findajob`). The PAT is held server-side and never reaches the browser. No PII guard, no rate limit — testers see what they're typing and the feedback path is internal to the Wireguard perimeter.
+
+### Migration required
+
+- Set `GITHUB_FEEDBACK_PAT` in each stack's `state/data/.env` before the next `docker compose up -d`. Without it, the widget renders but submissions return a 503 with a friendly "feedback isn't configured on this stack" message — i.e. the app stays up; only the feedback path is degraded. Generate a fine-grained PAT at github.com/settings/personal-access-tokens/new with `Issues: read+write` scoped to the target repo only. Optionally set `FEEDBACK_STACK_LABEL=from:<stack>` per stack so triage can tell operator-stack and tester-stack reports apart.
+
 ## [0.5.1] — 2026-04-26
 
 Patch bump. Two bug fixes that surfaced after v0.5.0 deployed: the discoverer's atomic-replace writer was creating files at mode 0o600 (the `tempfile.mkstemp` default), which made them unreadable by the FastAPI process when written by a different user, and the scorer's JSON parser was failing on prose-prefixed LLM responses (~5–10/triage cycle on the operator stack). Rolling `docker compose pull && up -d` picks both up.

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -8,6 +8,7 @@ from findajob.web.routes import (
     board_actions,
     config,
     docs,
+    feedback,
     healthz,
     ingest,
     landing,
@@ -31,3 +32,4 @@ router.include_router(config.router)
 router.include_router(tools.router)
 router.include_router(onboarding.router)
 router.include_router(docs.router)
+router.include_router(feedback.router)

--- a/src/findajob/web/routes/feedback.py
+++ b/src/findajob/web/routes/feedback.py
@@ -1,0 +1,132 @@
+"""In-app feedback widget that files a GitHub issue per submission (#227).
+
+Reads three env vars at request time (so per-stack `state/data/.env` edits
+take effect on container restart with no rebuild):
+
+- ``GITHUB_FEEDBACK_PAT`` — fine-grained PAT scoped to ``Issues: read+write``
+  on the target repo. Held server-side; never reaches the browser.
+- ``FEEDBACK_STACK_LABEL`` — single label identifying which stack the
+  report came from (e.g. ``from:operator`` / ``from:alice-doe``). Optional;
+  defaults to no second label.
+- ``FEEDBACK_REPO`` — ``owner/repo`` to file into. Defaults to
+  ``brockamer/findajob``.
+
+The PAT is intentionally not pre-validated at app startup; a missing PAT
+surfaces as a 503 on the first submit attempt with a user-friendly message.
+That keeps the widget out of the way on dev stacks that don't have it set.
+"""
+
+from __future__ import annotations
+
+import os
+
+import requests
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+_GITHUB_API = "https://api.github.com"
+_DEFAULT_REPO = "brockamer/findajob"
+_TITLE_MAX = 70
+_BODY_MAX = 4000
+
+
+@router.post("/feedback/submit", response_class=HTMLResponse)
+def submit_feedback(
+    request: Request,
+    text: str = Form(...),
+    page_url: str = Form(""),
+) -> HTMLResponse:
+    """Accept a feedback submission, file a GitHub issue, return a result partial."""
+    text = text.strip()
+    if not text:
+        return _result_partial(request, ok=False, message="Please write something before submitting.", status=400)
+    if len(text) > _BODY_MAX:
+        return _result_partial(
+            request,
+            ok=False,
+            message=f"Too long ({len(text)} chars). Please trim to under {_BODY_MAX}.",
+            status=400,
+        )
+
+    pat = os.environ.get("GITHUB_FEEDBACK_PAT", "").strip()
+    if not pat:
+        return _result_partial(
+            request,
+            ok=False,
+            message="Feedback isn't configured on this stack. Tell the operator.",
+            status=503,
+        )
+
+    repo = os.environ.get("FEEDBACK_REPO", _DEFAULT_REPO).strip() or _DEFAULT_REPO
+    stack_label = os.environ.get("FEEDBACK_STACK_LABEL", "").strip()
+    labels = ["feedback"]
+    if stack_label:
+        labels.append(stack_label)
+
+    title = _build_title(text)
+    body = _build_body(text=text, page_url=page_url.strip(), stack_label=stack_label)
+
+    try:
+        resp = requests.post(
+            f"{_GITHUB_API}/repos/{repo}/issues",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {pat}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            json={"title": title, "body": body, "labels": labels},
+            timeout=10,
+        )
+    except requests.RequestException:
+        return _result_partial(
+            request,
+            ok=False,
+            message="Couldn't reach GitHub. Try again in a moment.",
+            status=502,
+        )
+
+    if resp.status_code >= 300:
+        return _result_partial(
+            request,
+            ok=False,
+            message=f"GitHub rejected the submission (HTTP {resp.status_code}). Tell the operator.",
+            status=502,
+        )
+
+    issue_url = (resp.json() or {}).get("html_url", "")
+    return _result_partial(request, ok=True, message="Thanks — feedback filed.", issue_url=issue_url)
+
+
+def _build_title(text: str) -> str:
+    first_line = text.splitlines()[0].strip() if text else "feedback"
+    if len(first_line) > _TITLE_MAX:
+        first_line = first_line[: _TITLE_MAX - 1].rstrip() + "…"
+    return first_line or "feedback"
+
+
+def _build_body(*, text: str, page_url: str, stack_label: str) -> str:
+    parts = [text, "", "---", "_Filed via in-app feedback widget._"]
+    if page_url:
+        parts.append(f"- Page: {page_url}")
+    if stack_label:
+        parts.append(f"- Stack: `{stack_label}`")
+    return "\n".join(parts)
+
+
+def _result_partial(
+    request: Request,
+    *,
+    ok: bool,
+    message: str,
+    status: int = 200,
+    issue_url: str = "",
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="_feedback_result.html",
+        context={"ok": ok, "message": message, "issue_url": issue_url},
+        status_code=status,
+    )

--- a/src/findajob/web/templates/_feedback_result.html
+++ b/src/findajob/web/templates/_feedback_result.html
@@ -1,0 +1,13 @@
+{# Result partial swapped into #feedback-result by the feedback form (#227). #}
+{% if ok %}
+  <div class="rounded border border-emerald-300 bg-emerald-50 text-emerald-900 px-3 py-2">
+    {{ message }}
+    {% if issue_url %}
+      <a href="{{ issue_url }}" target="_blank" rel="noopener noreferrer" class="underline ml-1">View issue</a>
+    {% endif %}
+  </div>
+{% else %}
+  <div class="rounded border border-rose-300 bg-rose-50 text-rose-900 px-3 py-2">
+    {{ message }}
+  </div>
+{% endif %}

--- a/src/findajob/web/templates/_feedback_widget.html
+++ b/src/findajob/web/templates/_feedback_widget.html
@@ -1,0 +1,52 @@
+{# In-app feedback widget (#227). Floating button + modal. PAT is held
+   server-side; this template only collects user text and the current URL. #}
+<div x-data="{ open: false }" class="fixed bottom-4 right-4 z-50">
+  <button type="button"
+          @click="open = true"
+          class="bg-slate-800 text-slate-100 hover:bg-slate-700 rounded-full shadow-lg px-4 py-2 text-sm font-medium"
+          aria-label="Send feedback">
+    Feedback
+  </button>
+
+  <div x-show="open"
+       x-cloak
+       x-transition.opacity
+       @keydown.escape.window="open = false"
+       class="fixed inset-0 bg-slate-900/40 flex items-end sm:items-center justify-end sm:justify-center"
+       @click.self="open = false">
+    <div class="bg-white rounded-t-lg sm:rounded-lg shadow-xl w-full sm:w-[28rem] m-0 sm:m-4 p-4">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-semibold">Send feedback</h2>
+        <button type="button" @click="open = false" class="text-slate-500 hover:text-slate-800" aria-label="Close">✕</button>
+      </div>
+
+      <form hx-post="/feedback/submit"
+            hx-target="#feedback-result"
+            hx-swap="innerHTML"
+            hx-disabled-elt="find button[type=submit]">
+        <textarea name="text"
+                  rows="5"
+                  required
+                  maxlength="4000"
+                  placeholder="What's broken, confusing, or missing? Files a GitHub issue."
+                  class="w-full border border-slate-300 rounded p-2 text-sm focus:outline-none focus:ring-2 focus:ring-slate-500"></textarea>
+        <input type="hidden" name="page_url" x-bind:value="window.location.href">
+
+        <div class="mt-2 flex items-center justify-between">
+          <p class="text-xs text-slate-500">Goes to GitHub. No PII guard — please don't include passwords or anything you wouldn't post in a public bug report.</p>
+        </div>
+
+        <div class="mt-3 flex items-center justify-end gap-2">
+          <button type="button" @click="open = false"
+                  class="px-3 py-1.5 text-sm rounded border border-slate-300 hover:bg-slate-100">Cancel</button>
+          <button type="submit"
+                  class="px-3 py-1.5 text-sm rounded bg-slate-800 text-slate-100 hover:bg-slate-700 disabled:opacity-50">
+            Send
+          </button>
+        </div>
+      </form>
+
+      <div id="feedback-result" class="mt-3 text-sm"></div>
+    </div>
+  </div>
+</div>

--- a/src/findajob/web/templates/base.html
+++ b/src/findajob/web/templates/base.html
@@ -18,5 +18,6 @@
     {% block content %}{% endblock %}
     {% block body %}{% endblock %}
   </main>
+  {% include "_feedback_widget.html" %}
 </body>
 </html>

--- a/tests/test_web_feedback.py
+++ b/tests/test_web_feedback.py
@@ -1,0 +1,149 @@
+"""Tests for the in-app feedback widget endpoint (#227).
+
+Validates the POST /feedback/submit route under four scenarios:
+empty text, missing PAT, GitHub API success, GitHub API failure. The
+GitHub HTTP call is mocked at the ``requests.post`` boundary so tests
+never hit a live API.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+_SCHEMA = """
+CREATE TABLE jobs (id TEXT PRIMARY KEY);
+"""
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    db_path = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_SCHEMA)
+    conn.close()
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+
+    # Onboarding guard — synthesize the sentinel so /feedback/ isn't gated.
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / ".onboarding-complete").write_text("ok")
+
+    monkeypatch.setenv("JSP_BASE", str(tmp_path))
+    monkeypatch.delenv("GITHUB_FEEDBACK_PAT", raising=False)
+    monkeypatch.delenv("FEEDBACK_STACK_LABEL", raising=False)
+    monkeypatch.delenv("FEEDBACK_REPO", raising=False)
+
+    app = create_app(companies_root=companies, db_path=db_path, base_root=tmp_path)
+    return TestClient(app)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, json_body: dict | None = None) -> None:
+        self.status_code = status_code
+        self._json = json_body or {}
+
+    def json(self) -> dict:
+        return self._json
+
+
+def test_empty_text_returns_400(client: TestClient) -> None:
+    r = client.post("/feedback/submit", data={"text": "   ", "page_url": "/"})
+    assert r.status_code == 400
+    assert "write something" in r.text.lower()
+
+
+def test_missing_pat_returns_503(client: TestClient) -> None:
+    # No GITHUB_FEEDBACK_PAT in env — fixture explicitly clears it.
+    r = client.post("/feedback/submit", data={"text": "thing is broken", "page_url": "/board/"})
+    assert r.status_code == 503
+    assert "isn't configured" in r.text.lower() or "operator" in r.text.lower()
+
+
+def test_success_path_files_issue(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_FEEDBACK_PAT", "github_pat_dummy")
+    monkeypatch.setenv("FEEDBACK_STACK_LABEL", "from:operator")
+
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: A002 — match requests signature
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        return _FakeResponse(201, {"html_url": "https://github.com/brockamer/findajob/issues/999"})
+
+    with patch("findajob.web.routes.feedback.requests.post", side_effect=fake_post):
+        r = client.post(
+            "/feedback/submit",
+            data={"text": "Promote button hidden under filter\nrepro: ...", "page_url": "/board/archive"},
+        )
+
+    assert r.status_code == 200
+    assert "thanks" in r.text.lower()
+    assert "issues/999" in r.text
+
+    assert captured["url"] == "https://api.github.com/repos/brockamer/findajob/issues"
+    assert captured["headers"]["Authorization"] == "Bearer github_pat_dummy"
+    payload = captured["json"]
+    assert payload["title"] == "Promote button hidden under filter"
+    assert payload["labels"] == ["feedback", "from:operator"]
+    assert "repro: ..." in payload["body"]
+    assert "/board/archive" in payload["body"]
+    assert "from:operator" in payload["body"]
+
+
+def test_success_without_stack_label_files_only_feedback_label(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GITHUB_FEEDBACK_PAT", "github_pat_dummy")
+    # FEEDBACK_STACK_LABEL not set.
+
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: A002
+        captured["json"] = json
+        return _FakeResponse(201, {"html_url": "https://github.com/brockamer/findajob/issues/1000"})
+
+    with patch("findajob.web.routes.feedback.requests.post", side_effect=fake_post):
+        r = client.post("/feedback/submit", data={"text": "small bug", "page_url": ""})
+
+    assert r.status_code == 200
+    assert captured["json"]["labels"] == ["feedback"]
+
+
+def test_github_api_failure_returns_502(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_FEEDBACK_PAT", "github_pat_dummy")
+
+    with patch(
+        "findajob.web.routes.feedback.requests.post",
+        return_value=_FakeResponse(401, {"message": "Bad credentials"}),
+    ):
+        r = client.post("/feedback/submit", data={"text": "x", "page_url": "/"})
+
+    assert r.status_code == 502
+    assert "github" in r.text.lower()
+
+
+def test_long_first_line_truncates_title(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_FEEDBACK_PAT", "github_pat_dummy")
+    long_line = "x" * 200
+    captured: dict = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: A002
+        captured["title"] = json["title"]
+        return _FakeResponse(201, {"html_url": "https://example.test/1"})
+
+    with patch("findajob.web.routes.feedback.requests.post", side_effect=fake_post):
+        r = client.post("/feedback/submit", data={"text": long_line, "page_url": "/"})
+
+    assert r.status_code == 200
+    assert captured["title"].endswith("…")
+    assert len(captured["title"]) <= 70


### PR DESCRIPTION
## Summary

- Floating "Feedback" button (Alpine modal) on every page; submission POSTs to `/feedback/submit` which calls the GitHub Issues API server-side using a fine-grained PAT held in `state/data/.env`.
- Rescoped from the original 8-criterion spec on #227 to a minimal MVP: one global affordance, single shared fine-grained PAT for both stacks, per-stack identifier via `FEEDBACK_STACK_LABEL` env var (not a UI selector), no PII regex, no rate limit. The Wireguard perimeter and single-tester scope justify the cuts; the original heavier scope is preserved as crossed-out criteria in the issue body for posterity.
- Failure modes render inline result partials, never a stack trace: `400` empty text, `503` no PAT configured, `502` GitHub unreachable or non-2xx.

## Migration required

Set `GITHUB_FEEDBACK_PAT` in each stack's `state/data/.env` before the next `docker compose up -d`. Without it, the widget renders but submissions return a friendly 503 — the app stays up; only the feedback path is degraded. Optionally set `FEEDBACK_STACK_LABEL=from:<stack>` per stack so triage can tell stacks apart. Operator already deployed the shared fine-grained PAT to both stacks during this session.

## Test plan

- [x] `uv run pytest tests/test_web_feedback.py` — 6 new tests, all green
- [x] `uv run pytest -q` — full suite (1063 prior tests) still green
- [x] `uv run ruff check src/findajob/web/ tests/test_web_feedback.py` clean
- [x] `uv run ruff format --check` clean
- [x] `uv run mypy src/findajob/web/routes/feedback.py` clean
- [ ] Manual: `docker compose pull && up -d` on operator stack, click "Feedback" in bottom-right, submit a test note, confirm a real GitHub issue is filed with `feedback` + `from:operator` labels and the page URL is in the body
- [ ] Manual: same on amy stack with `FEEDBACK_STACK_LABEL=from:alice-doe`
- [ ] Manual: temporarily unset `GITHUB_FEEDBACK_PAT` on a stack and confirm the widget renders and submissions show the friendly 503 partial

🤖 Generated with [Claude Code](https://claude.com/claude-code)