### PR TITLE
fix(web/board): reserve scrollbar gutter so Archive doesn't shift right (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Archive tab no longer shifts horizontally relative to other board tabs (#280).** Root cause: the `html` element didn't reserve the vertical-scrollbar gutter, so tabs whose content overflowed vertically (Archive with thousands of historical jobs) rendered ~15px narrower than tabs that fit on screen (Dashboard with a handful of pre-application rows). Switching between them via hx-boost made the content area "shift right" because the scrollbar appeared on Archive but not on Dashboard. Fix: one CSS rule, `html { scrollbar-gutter: stable; }`, in `static/app.css`. Reserves the gutter on every page regardless of content height; layout is now consistent across all six board tabs and all other routes that extend `base.html`.
+
 ### Added
 
 - **In-app feedback widget files a GitHub issue per submission (#227).** Floating "Feedback" button in the bottom-right corner of every page opens a small modal with a textarea; submission posts to `/feedback/submit` which calls the GitHub Issues API server-side and labels the issue `feedback` (plus an optional per-stack identifier label). New env vars in `state/data/.env`: `GITHUB_FEEDBACK_PAT` (fine-grained PAT scoped to Issues:read+write on the target repo, required), `FEEDBACK_STACK_LABEL` (optional second label, e.g. `from:operator` / `from:alice-doe`), `FEEDBACK_REPO` (defaults to `brockamer/findajob`). The PAT is held server-side and never reaches the browser. No PII guard, no rate limit — testers see what they're typing and the feedback path is internal to the Wireguard perimeter.

--- a/src/findajob/web/static/app.css
+++ b/src/findajob/web/static/app.css
@@ -1,3 +1,11 @@
+/* Reserve the vertical-scrollbar gutter on every page (#280). Without this,
+   tabs that don't overflow vertically (e.g. Dashboard with few rows) render
+   ~15px wider than tabs that do (Archive with thousands of rows), so
+   switching between them shifts the content area horizontally. */
+html {
+  scrollbar-gutter: stable;
+}
+
 /* Design tokens matching the Google Sheet's conditional formatting palette. */
 :root {
   --color-applied-fresh: #c6e6b9;  /* 0–6 days, green */

--- a/tests/test_web_scrollbar_gutter.py
+++ b/tests/test_web_scrollbar_gutter.py
@@ -1,0 +1,46 @@
+"""Regression test for the global scrollbar-gutter rule (#280).
+
+The rule lives in static/app.css and reserves the vertical-scrollbar gutter
+on every page. Without it, tabs whose content overflows vertically (Archive
+with thousands of jobs) render ~15px narrower than tabs that don't, and
+switching between them via hx-boost causes a horizontal layout shift.
+
+Asserting on the served CSS catches the case where the rule is moved out
+of `html { ... }` or otherwise lost in a future refactor; the bug only
+reproduces visually so a unit test on the asset is the cheapest proxy.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> TestClient:
+    db_path = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE jobs (id TEXT PRIMARY KEY)")
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    return TestClient(create_app(companies_root=companies, db_path=db_path, base_root=tmp_path))
+
+
+def test_app_css_reserves_scrollbar_gutter(client: TestClient) -> None:
+    r = client.get("/static/app.css")
+    assert r.status_code == 200
+    # The rule must apply to <html>, not just <body> — applying it to <body>
+    # leaves the document scroller (the html element) free to shift the
+    # viewport when content overflows.
+    assert re.search(
+        r"html\s*\{[^}]*scrollbar-gutter:\s*stable",
+        r.text,
+        re.DOTALL,
+    ), "html { scrollbar-gutter: stable } missing from app.css"


### PR DESCRIPTION
## Summary

- Root cause was **not** in the templates — all six board tabs already declare identical `{% block main_classes %}w-full px-4 py-6{% endblock %}` and every element inside `<main>` measured at the same `left=16` / `width=fullViewport-32` on every tab. Confirmed via Playwright at 1400px and 1920px viewports.
- The "shift" was the **body element's clientWidth changing by ~15px** depending on whether the current page's content overflowed vertically. Dashboard with ~12 pre-application rows fits → no vertical scrollbar → body uses the full viewport. Archive with thousands of historical rows overflows → vertical scrollbar appears → body shrinks by ~15px. hx-boost navigation between them made the visible content area appear to "shift right".
- Fix: one CSS rule on the `html` element — `html { scrollbar-gutter: stable; }`. Reserves the scrollbar gutter on every page, so layout is identical regardless of whether content overflows. Applies to every route that extends `base.html` (not just the board), eliminating any future cross-route layout shift.

## Test plan

- [x] `uv run pytest tests/test_web_scrollbar_gutter.py` — new regression test asserting the rule is present in the served CSS, fails if a future refactor drops it from `html` scope.
- [x] `uv run pytest -q` — full suite, 1064 tests pass.
- [x] `uv run ruff check`, `ruff format --check`, `mypy` clean.
- [x] **Manual reproduce + verify** at 1920×1080 with a seeded local DB:
  - Before: Dashboard `body.clientWidth=1920`, Archive `body.clientWidth=1905` → 15px discrepancy.
  - After: both pages `body.clientWidth=1905` → identical layout.
- [ ] Manual: `docker compose pull && up -d` on operator stack, click between Dashboard and Archive, confirm no horizontal shift.

## Notes

`scrollbar-gutter: stable` is supported in all evergreen browsers. Older browsers fall back gracefully (the property is unknown and ignored — the original "shift sometimes" behavior remains, no regression beyond what already existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)