### PR TITLE
fix(smoke): refuse to run as root, fail fast with PUID/PGID diagnostic

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -123,6 +123,13 @@ FINDAJOB_TEST_IMAGE=findajob:local \
 The script takes 2–5 minutes (dominated by ~20 LLM scoring calls over the real
 network) and costs ≤$0.10 of API budget per run.
 
+**Run as your normal docker-group user — do not `sudo` this script.** The
+compose snippet embeds `$(id -u):$(id -g)` as PUID/PGID; running under sudo
+collapses both to 0, collides with the container's root GID, and prevents
+the unprivileged `lad` user from being created. The script now fails fast
+with a clear diagnostic if it detects uid=0 or gid=0, so this is a
+one-line correction rather than a 60s startup timeout to debug.
+
 **If the smoke is green on the commit you intend to tag, the gate is cleared
 and Claude may propose the cut.** No time window, no 24h/48h observation. A
 binary signal tied to what a fresh tester actually exercises.

--- a/scripts/test_container_integration.sh
+++ b/scripts/test_container_integration.sh
@@ -33,6 +33,35 @@
 set -euo pipefail
 
 # ────────────────────────────────────────────────────────────────────────────
+# 0. PUID/PGID guard — refuse to run as root
+# ────────────────────────────────────────────────────────────────────────────
+#
+# The compose snippet below shells out $(id -u):$(id -g) at script-run time.
+# Under `sudo` (or `sudo -E`), those resolve to 0:0, the container entrypoint
+# tries `groupadd -g 0 lad`, collides with the existing root GID, and
+# supercronic never starts (manifests as a 60s startup timeout downstream).
+# Fail fast here with a clear diagnostic instead.
+
+if [ "$(id -u)" -eq 0 ] || [ "$(id -g)" -eq 0 ]; then
+    cat >&2 <<'EOM'
+ERROR: this smoke script must NOT be run as root (uid=0 / gid=0).
+
+The compose file embeds $(id -u):$(id -g) as PUID/PGID. Running under sudo
+collapses both to 0, which collides with the container's root GID and
+prevents the entrypoint from creating the unprivileged 'lad' user.
+
+Re-invoke as your normal docker-group user, without sudo:
+
+    FINDAJOB_SMOKE_SHEET_ID=<sheet-id> \
+      scripts/test_container_integration.sh
+
+If your account is not in the 'docker' group, add it once with
+`sudo usermod -aG docker $USER` and re-login — don't sudo this script.
+EOM
+    exit 2
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
 # 1. Resolve repo root + fixture paths
 # ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Top-of-script guard in `scripts/test_container_integration.sh` exits 2 with a clear diagnostic when invoked as root (uid=0 or gid=0), naming PUID/PGID as the cause and pointing at the non-sudo invocation as the fix.
- `docs/release-process.md` §"Pre-tag smoke check" now states "do not sudo this script" inline, so the expected invocation is on the gate page itself.

Closes #292.

## Why this approach
Issue body offered two paths: (a) auto-recover via `$SUDO_UID`/`$SUDO_GID`, or (b) fail fast with a clear diagnostic. Went with (b) — script complexity stays minimal, surfaces the user's invocation as the actual fix, and matches the issue body's preferred outcome. Auto-recover would have invited quiet behavior change.

## Test plan
- [x] `bash -n scripts/test_container_integration.sh` — syntax OK
- [x] `sudo bash scripts/test_container_integration.sh` — exits 2 with diagnostic naming PUID=0/PGID=0 (verified)
- [x] `bash scripts/test_container_integration.sh` (no sudo) — guard does NOT fire; lands on existing env-var check as before (verified — no regression on the green path)
- [ ] Optional: full end-to-end smoke run on docker.lan with real env vars (existing pre-tag gate procedure — unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)