### PR TITLE
feat(fetchers): drop jobs-api14 Indeed slot (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Changed
+
+- **Dropped the jobs-api14 Indeed slot from daily triage (#274).** Lifetime data showed 0.08% application rate (3 of 3,584 ingested) and 0.77% LLM-precision at score≥7 — vs 4.2% LLM-precision for Greenhouse on the same scorer. Root cause is upstream: jobs-api14's Indeed endpoint accepts no recency, level, or employment-type filter, so its keyword matching returns large volumes of off-target rows ("Patient Engagement *Center* QA Analyst" for `query=data center operations manager`, etc.). The LinkedIn slot in the same fetcher remains — it accepts `datePosted` + `experienceLevels` filters and is producing useful signal. Indeed coverage continues via `gmail_indeed` (LinkedIn / Indeed alert emails parsed from Gmail). Cuts ~$4/month of pure-noise LLM scoring spend and removes ~120 daily off-target rows from triage. The historical 3,584 rows remain in the DB and are still filterable via the `source` column on the board's Archive tab. See the issue thread for the diagnostic + market-survey writeup of replacement candidates (JSearch, Adzuna) — tracked as separate follow-up issues.
+
 ### Fixed
 
 - **probability_score column visible by default + canonical score-column order on Dashboard and Waitlist (#302).** The `probability_score` column had `default_visible=False` in the per-column filter framework's registry (`src/findajob/web/filters/registry.py`), so the operator never saw the briefing-derived probability average on triage views. The column declarations also had `interview_likelihood` after `probability_score`, so even when toggled on via `?cols=`, the rendered order didn't match expectations. Both fixed: `probability_score` is now `default_visible=True`, and the four score columns now render in the canonical order `relevance_score → interview_likelihood → fit_score → probability_score` — putting compositional/relative signals on the left and derived briefing scores on the right. Two parametrized regression tests in `tests/test_filter_score_columns.py` pin both invariants for every tab declaring all four scores.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ file. If you're refactoring an old hardcoded section, add a note to `docs/GENERA
 | `fit_analyst` | `openrouter:perplexity/sonar-reasoning-pro` — appended to company briefing |
 | `resume_change_reviewer` / `network_analyst` | `openrouter:google/gemini-3-flash-preview` |
 | `recruiter_critic` | `openrouter:anthropic/claude-opus-4.7`, `max_tokens: 1024` — sees company, title, JD, tailored resume, cover; NOT profile/briefing/fit |
-| Job ingestion | jobs-api14 (RapidAPI) — LinkedIn (`datePosted: 'day'`) + Indeed; Gmail OAuth2 |
+| Job ingestion | jobs-api14 (RapidAPI) — LinkedIn only (`datePosted: 'day'`; Indeed slot dropped #274 due to 0.08% application rate); direct Greenhouse/Ashby/Lever JSON; Gmail OAuth2 (LinkedIn + Indeed alerts) |
 | Package manager | `uv sync` for dev deps; `uv run` prefix for pytest/ruff/mypy/uvicorn |
 | Path resolution | `src/findajob/paths.py` — reads `config/paths.env`; BASE derived from `__file__` |
 | Roles dir | `config/roles/` |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Live status of every issue and milestone is on the **[project board](https://git
 
 ## How it works
 
-**1. Daily triage** (00:00, scheduler-driven) — fetches 100–500 listings from RapidAPI (LinkedIn + Indeed), Greenhouse, and Gmail job alerts; cleans + deduplicates; enriches with JD text; scores each against your `profile.md` using an LLM. Results land in SQLite.
+**1. Daily triage** (00:00, scheduler-driven) — fetches 100–500 listings from RapidAPI (LinkedIn), direct ATS feeds (Greenhouse, Ashby, Lever), and Gmail job alerts (LinkedIn + Indeed); cleans + deduplicates; enriches with JD text; scores each against your `profile.md` using an LLM. Results land in SQLite.
 
 **2. Dashboard triage** — the web UI shows every scored job that cleared the threshold, with relevance/fit/probability scores, known contacts, and AI notes. You flag the ones worth prepping.
 

--- a/src/findajob/fetchers.py
+++ b/src/findajob/fetchers.py
@@ -408,16 +408,9 @@ def fetch_jobsapi_jobs(queries_path):
             },
             "url_field": "linkedinUrl",
         },
-        {
-            "name": "indeed",
-            "url": "https://jobs-api14.p.rapidapi.com/v2/indeed/search",
-            "params": lambda q: {
-                "query": q,
-                "countryCode": "us",
-                "sortType": "date",
-            },
-            "url_field": "applyUrl",
-        },
+        # No Indeed slot: jobs-api14's Indeed endpoint accepts no recency,
+        # level, or employment-type filter, so its keyword matching returns
+        # ~89% off-target rows. Indeed coverage continues via gmail_indeed.
     ]
 
     jobs = []


### PR DESCRIPTION
## Summary
Remove the Indeed entry from `fetch_jobsapi_jobs()`'s `sources` list. Lifetime: 3,584 ingested → 3 applied (0.08%), 23 at score≥7 (0.77% LLM-precision; Greenhouse is 4.2× on the same scorer). The LinkedIn slot in the same fetcher is preserved.

Closes #274.

## Why drop instead of fix
The jobs-api14 Indeed endpoint accepts no recency / level / employment-type filter — its keyword matching returned "Patient Engagement Center QA Analyst" for `query=data center operations manager`. The relevance is unfixable client-side. Full diagnostic + decision tree is on the issue: https://github.com/brockamer/findajob/issues/274#issuecomment-4331539677

## What stays
- `gmail_indeed` (LinkedIn / Indeed alert emails parsed from Gmail) — separate source, separate signal, not in scope.
- `fetch_jd()`'s `jobsapi_indeed` branch — historical rows still need it via `backfill_jd.py`.
- 3,584 historical rows in the DB — still filterable via the `source` column on Archive.
- Board filter dropdown values in `web/filters/registry.py` — preserved so historical rows remain queryable.

## Effect
- ~$4/month LLM-scoring spend reclaimed.
- ~120 daily off-target rows removed from triage queues.
- Daily triage runs ~10s faster (one fewer RapidAPI batch per query).

## Test plan
- [x] `uv run ruff check src/findajob/fetchers.py` — all checks passed
- [x] `uv run ruff format --check src/findajob/fetchers.py` — already formatted
- [x] `uv run mypy src/findajob/fetchers.py` — no issues
- [x] `uv run pytest -k 'fetch or jobsapi or board_filters'` — 25 passed
- [ ] Post-merge: confirm next overnight triage logs show no `jobsapi_fetched source=indeed` events; expect lower total `jobs_fetched` count.

## Follow-ups (not in this PR)
- Pilot JSearch + Adzuna as replacement / supplement sources — market-survey writeup posted as the second comment on #274. Will track as a separate issue.
- Crusoe Ashby slug 25% read-timeout rate observed during this work — also separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)