### PR TITLE
feat(speculative): briefing + role-synth pipeline runner (B2 of #131)

### DIFF
--- a/config/roles/candidate_led_briefing.md
+++ b/config/roles/candidate_led_briefing.md
@@ -1,0 +1,55 @@
+---
+model: openrouter:perplexity/sonar-deep-research
+temperature: 0.3
+---
+You are a research analyst producing a hiring-posture briefing on a target company for a candidate considering speculative cold outreach. The candidate's profile and master resume are provided as context. There is no job description — you are inferring likely role surfaces from the company's apparent hiring direction, recent announcements, leadership communications, and operational footprint.
+
+# Output
+
+Return well-formed Markdown with these sections, in this order:
+
+## 🏢 Company Snapshot
+2–4 sentences. What they do, scale (employees, revenue, recent funding), industry position.
+
+## 📈 Hiring Signals
+Bullet list. Specific signals you found: open recs by category, recent leadership hires, public statements about expansion, geographic moves, organizational changes. Cite sources inline.
+
+## 🎯 Likely Role Surfaces for This Candidate
+Bullet list of 3–6 plausible role types this company would hire that align with the candidate's background. Each bullet: role title or function + 1-sentence why-this-fits drawing on candidate's specific experience. Be concrete; do not list every role they hire.
+
+## 🤝 Suggested Angle of Approach
+2–3 sentences. Recommended framing for cold outreach: which team or function to target, what posture (recruiter, hiring manager, senior IC), what to lead with from the candidate's background.
+
+## 👥 Known Contacts (if any)
+If the candidate's profile or visible LinkedIn graph reveals any direct or 2nd-degree contacts at the target, list them. If none, write "None identified — outreach should be cold."
+
+## ❓ Likely Interview Questions
+List 5–8 questions the candidate should expect, drawn from the role surfaces you identified.
+
+## 💡 Stories from Your Background
+For each likely interview question, point to a specific story from the candidate's master resume that maps best.
+
+# Constraints
+
+- Ground every claim in a citation. Do not infer hiring signals from generic web copy.
+- Do not invent roles the company isn't plausibly hiring for.
+- Do not recommend an angle the candidate's resume doesn't actually support.
+- The briefing is consumed by a downstream synthesizer; structure matters.
+
+# Candidate context
+
+{{candidate_profile}}
+
+---
+
+{{master_resume}}
+
+---
+
+# Target
+
+Company: {{company}}
+
+Optional operator hint: {{hint}}
+
+Optional connection notes: {{personal_notes}}

--- a/config/roles/speculative_roles_synth.md
+++ b/config/roles/speculative_roles_synth.md
@@ -1,0 +1,42 @@
+---
+model: openrouter:anthropic/claude-sonnet-4-6
+max_tokens: 4096
+temperature: 0.4
+---
+You synthesize 1–5 plausible job roles a target company might hire that align with this candidate's background, given a researcher's hiring-posture briefing. Output is consumed by an approver that writes one `jobs` row per role you return.
+
+# Output
+
+Return ONLY a JSON array. No prose, no markdown fences. Schema for each element:
+
+```json
+{
+  "title": "string — concrete job title; will be prefixed with [SPEC] downstream",
+  "description": "string — 4-8 sentence synthesized job description, framed as if posted; pulls from the briefing's hiring signals and likely role surfaces",
+  "why_this_fits_candidate": "string — 2-4 sentence specific match between candidate's resume and this role; cite specific resume bullets",
+  "likely_team_or_org": "string — best guess at internal team / function / org",
+  "suggested_contact_type": "recruiter | hiring_manager | senior_ic"
+}
+```
+
+# Constraints
+
+- Return between 1 and 5 cards. Quality over quantity. If the briefing only supports 1 strong match, return 1; do not pad.
+- Do NOT return cards for roles the briefing's "Likely Role Surfaces" section does not list.
+- Each card's `description` must read like a real posting — responsibilities, qualifications, scope. Anchor in the briefing.
+- Each card's `why_this_fits_candidate` must reference specific entries from the candidate's master resume below.
+- Do not fabricate technical details, internal program names, or seniority levels not supported by the briefing.
+
+# Candidate context
+
+{{candidate_profile}}
+
+---
+
+{{master_resume}}
+
+---
+
+# Briefing (from candidate_led_briefing role)
+
+{{briefing}}

--- a/scripts/run_speculative_research.py
+++ b/scripts/run_speculative_research.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Detached subprocess entry: run speculative research for a request_id.
+
+Spawned from POST /ingest/speculative as a background process. Reads the
+DB, runs run_research(), exits. Idempotent on re-spawn (e.g. for
+regeneration) because run_research caches briefing_md across retries.
+
+Usage:
+    python scripts/run_speculative_research.py <request_id>
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+from findajob.paths import BASE
+from findajob.speculative.runner import run_research
+from findajob.utils import log_event
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or not argv[1].isdigit():
+        print("usage: run_speculative_research.py <request_id>", file=sys.stderr)
+        return 2
+    request_id = int(argv[1])
+
+    db_path = Path(BASE) / "data" / "pipeline.db"
+    profile = Path(BASE) / "candidate_context" / "profile.md"
+    master_resume = Path(BASE) / "candidate_context" / "master_resume.md"
+    companies_dir = Path(BASE) / "companies"
+
+    conn = sqlite3.connect(str(db_path), timeout=30)
+    conn.row_factory = sqlite3.Row
+    try:
+        run_research(
+            conn=conn,
+            request_id=request_id,
+            profile_path=profile,
+            master_resume_path=master_resume,
+            companies_dir=companies_dir,
+        )
+    except Exception as e:
+        log_event("speculative_research_uncaught_exception", request_id=request_id, error=str(e))
+        # run_research best-efforts a status='failed' write on known errors;
+        # this catches truly unexpected (e.g. DB connection errors) so the
+        # process never exits without recording state.
+        try:
+            conn.execute(
+                "UPDATE speculative_requests SET status='failed', error_message=? WHERE id=?",
+                (f"unexpected: {e}", request_id),
+            )
+            conn.commit()
+        except Exception:
+            pass
+        return 1
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/findajob/speculative/__init__.py
+++ b/src/findajob/speculative/__init__.py
@@ -1,0 +1,8 @@
+"""Speculative ingest pipeline — see docs/superpowers/specs/2026-04-28-speculative-ingest-131-design.md.
+
+Modules:
+- runner.py    : orchestrates the briefing + role-synth call sequence
+- parser.py    : validates LLM output into role-card dicts
+- approver.py  : on operator approve, writes jobs rows from kept role cards
+- storage.py   : creates speculative briefing folder + writes briefing.md
+"""

--- a/src/findajob/speculative/approver.py
+++ b/src/findajob/speculative/approver.py
@@ -47,7 +47,8 @@ def approve_request(
 
     if not kept_indices:
         conn.execute(
-            "UPDATE speculative_requests SET status='trashed' WHERE id=?", (request_id,),
+            "UPDATE speculative_requests SET status='trashed' WHERE id=?",
+            (request_id,),
         )
         conn.commit()
         log_event("speculative_request_trashed", request_id=request_id, company=row["company"])

--- a/src/findajob/speculative/approver.py
+++ b/src/findajob/speculative/approver.py
@@ -1,0 +1,102 @@
+"""Approver: on operator approve, write 1 jobs row per kept role card.
+
+Synthetic rows ship with:
+- synthetic=1
+- source='web_speculative'
+- title prefixed with [SPEC]
+- stage='scored'
+- ai_notes populated from the card's why_this_fits + team
+
+Approving with kept_indices=[] is equivalent to trash — sets status='trashed'.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import UTC, datetime
+
+from findajob.cleaning import fingerprint
+from findajob.speculative.parser import parse_role_cards
+from findajob.utils import log_event, write_audit
+
+
+def approve_request(
+    conn: sqlite3.Connection,
+    *,
+    request_id: int,
+    kept_indices: list[int],
+) -> list[str]:
+    """Approve a ready_for_review request, writing one jobs row per kept card.
+
+    Returns the list of fingerprints written. Empty list when kept_indices is empty
+    (status='trashed' instead of 'approved').
+
+    Raises ValueError if the request is not in 'ready_for_review' status.
+    """
+    row = conn.execute(
+        "SELECT id, company, status, role_cards_json, briefing_folder FROM speculative_requests WHERE id=?",
+        (request_id,),
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"speculative_requests id={request_id} not found")
+    if row["status"] != "ready_for_review":
+        raise ValueError(
+            f"cannot approve request id={request_id}: status is {row['status']!r}, expected 'ready_for_review'"
+        )
+
+    if not kept_indices:
+        conn.execute(
+            "UPDATE speculative_requests SET status='trashed' WHERE id=?", (request_id,),
+        )
+        conn.commit()
+        log_event("speculative_request_trashed", request_id=request_id, company=row["company"])
+        return []
+
+    cards = parse_role_cards(row["role_cards_json"])
+    company = row["company"]
+    now = datetime.now(UTC).isoformat()
+    fingerprints: list[str] = []
+
+    for idx in kept_indices:
+        if idx < 0 or idx >= len(cards):
+            raise ValueError(f"kept_indices contains out-of-range index {idx} (have {len(cards)} cards)")
+        card = cards[idx]
+        title = f"[SPEC] {card.title}"
+        ai_notes = (
+            f"WHY THIS FITS: {card.why_this_fits_candidate}\n\n"
+            f"LIKELY TEAM: {card.likely_team_or_org}\n\n"
+            f"SUGGESTED CONTACT: {card.suggested_contact_type}"
+        )
+        # Speculative rows have no URL — synthesize a sentinel that's distinct.
+        url = f"speculative://{company}/{idx}/{request_id}"
+        # Using fingerprint() of (title, company, '') — same hashing as real rows.
+        fp = fingerprint(title, company, "")
+        job_id = str(uuid.uuid4())
+        conn.execute(
+            """INSERT INTO jobs (id, fingerprint, url, title, company, location, source,
+                                  raw_jd_text, relevance_score, score_status,
+                                  ai_notes, stage, stage_updated, synthetic,
+                                  created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, '', 'web_speculative', ?, 7, 'scored',
+                       ?, 'scored', ?, 1, ?, ?)""",
+            (job_id, fp, url, title, company, card.description, ai_notes, now, now, now),
+        )
+        write_audit(conn, job_id, "stage", "", "scored")
+        fingerprints.append(fp)
+
+    conn.execute(
+        """UPDATE speculative_requests
+           SET status='approved', approved_at=?, approved_role_count=?
+           WHERE id=?""",
+        (now, len(kept_indices), request_id),
+    )
+    conn.commit()
+    log_event(
+        "speculative_request_approved",
+        request_id=request_id,
+        company=company,
+        approved_count=len(kept_indices),
+        fingerprints=fingerprints,
+    )
+    return fingerprints

--- a/src/findajob/speculative/parser.py
+++ b/src/findajob/speculative/parser.py
@@ -45,8 +45,13 @@ def parse_role_cards(raw: str) -> list[RoleCard]:
     for i, item in enumerate(data[:_MAX_CARDS]):
         if not isinstance(item, dict):
             raise ValueError(f"role card {i} is not a JSON object")
-        for required in ("title", "description", "why_this_fits_candidate",
-                         "likely_team_or_org", "suggested_contact_type"):
+        for required in (
+            "title",
+            "description",
+            "why_this_fits_candidate",
+            "likely_team_or_org",
+            "suggested_contact_type",
+        ):
             if required not in item or not item[required]:
                 raise ValueError(f"role card {i} missing required field: {required}")
         contact_type = item["suggested_contact_type"]
@@ -55,13 +60,15 @@ def parse_role_cards(raw: str) -> list[RoleCard]:
                 f"role card {i} has invalid suggested_contact_type "
                 f"{contact_type!r}; expected one of {sorted(_VALID_CONTACT_TYPES)}"
             )
-        cards.append(RoleCard(
-            title=str(item["title"]).strip(),
-            description=str(item["description"]).strip(),
-            why_this_fits_candidate=str(item["why_this_fits_candidate"]).strip(),
-            likely_team_or_org=str(item["likely_team_or_org"]).strip(),
-            suggested_contact_type=contact_type,
-        ))
+        cards.append(
+            RoleCard(
+                title=str(item["title"]).strip(),
+                description=str(item["description"]).strip(),
+                why_this_fits_candidate=str(item["why_this_fits_candidate"]).strip(),
+                likely_team_or_org=str(item["likely_team_or_org"]).strip(),
+                suggested_contact_type=contact_type,
+            )
+        )
     return cards
 
 

--- a/src/findajob/speculative/parser.py
+++ b/src/findajob/speculative/parser.py
@@ -1,0 +1,73 @@
+"""Validates LLM output from speculative_roles_synth into RoleCard objects.
+
+Defensive against LLMs that wrap JSON in markdown fences despite instructions,
+return more than 5 cards, omit required fields, or use invalid enums.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+ContactType = Literal["recruiter", "hiring_manager", "senior_ic"]
+_VALID_CONTACT_TYPES: set[str] = {"recruiter", "hiring_manager", "senior_ic"}
+_MAX_CARDS = 5
+
+
+@dataclass(frozen=True)
+class RoleCard:
+    title: str
+    description: str
+    why_this_fits_candidate: str
+    likely_team_or_org: str
+    suggested_contact_type: ContactType
+
+
+def parse_role_cards(raw: str) -> list[RoleCard]:
+    """Parse a speculative_roles_synth output into validated RoleCard objects.
+
+    Raises ValueError on any structural problem. Caps at 5 cards.
+    """
+    cleaned = _strip_markdown_fence(raw).strip()
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"role-cards output is not valid JSON: {e}") from e
+
+    if not isinstance(data, list):
+        raise ValueError("role-cards output must be a JSON array, got: " + type(data).__name__)
+    if not data:
+        raise ValueError("role-cards output is empty — synthesis must produce at least one card")
+
+    cards: list[RoleCard] = []
+    for i, item in enumerate(data[:_MAX_CARDS]):
+        if not isinstance(item, dict):
+            raise ValueError(f"role card {i} is not a JSON object")
+        for required in ("title", "description", "why_this_fits_candidate",
+                         "likely_team_or_org", "suggested_contact_type"):
+            if required not in item or not item[required]:
+                raise ValueError(f"role card {i} missing required field: {required}")
+        contact_type = item["suggested_contact_type"]
+        if contact_type not in _VALID_CONTACT_TYPES:
+            raise ValueError(
+                f"role card {i} has invalid suggested_contact_type "
+                f"{contact_type!r}; expected one of {sorted(_VALID_CONTACT_TYPES)}"
+            )
+        cards.append(RoleCard(
+            title=str(item["title"]).strip(),
+            description=str(item["description"]).strip(),
+            why_this_fits_candidate=str(item["why_this_fits_candidate"]).strip(),
+            likely_team_or_org=str(item["likely_team_or_org"]).strip(),
+            suggested_contact_type=contact_type,
+        ))
+    return cards
+
+
+def _strip_markdown_fence(s: str) -> str:
+    """Remove ```json ... ``` or ``` ... ``` fence wrapping if present."""
+    fence_match = re.match(r"^```(?:json)?\s*\n(.+?)\n```\s*$", s.strip(), re.S)
+    if fence_match:
+        return fence_match.group(1)
+    return s

--- a/src/findajob/speculative/runner.py
+++ b/src/findajob/speculative/runner.py
@@ -1,0 +1,152 @@
+"""Speculative research runner.
+
+Invoked as a detached subprocess via scripts/run_speculative_research.py
+(itself spawned from POST /ingest/speculative). Single entry point:
+``run_research(conn, request_id, profile_path, master_resume_path, companies_dir)``.
+
+Lifecycle:
+    status='researching'  ->  call briefing role  ->  call synth role  ->
+    write briefing folder + briefing.md  ->  status='ready_for_review'
+
+On any failure: status='failed' + error_message, partial state
+(briefing_md if briefing call succeeded) preserved for retry.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from findajob.paths import AICHAT
+from findajob.speculative.parser import parse_role_cards
+from findajob.speculative.storage import write_briefing
+from findajob.utils import log_event
+
+_BRIEFING_ROLE = "candidate_led_briefing"
+_SYNTH_ROLE = "speculative_roles_synth"
+_BRIEFING_PROMPT_VERSION = f"{_BRIEFING_ROLE}@v1"
+_SYNTH_PROMPT_VERSION = f"{_SYNTH_ROLE}@v1"
+
+
+def run_research(
+    *,
+    conn: sqlite3.Connection,
+    request_id: int,
+    profile_path: Path,
+    master_resume_path: Path,
+    companies_dir: Path,
+) -> None:
+    """Run briefing + role-synth for the given speculative_requests row.
+
+    Idempotency: caller is responsible for ensuring the row exists with
+    status='researching'. This function updates it to 'ready_for_review'
+    or 'failed'.
+    """
+    row = conn.execute(
+        "SELECT id, company, hint, personal_notes, briefing_md FROM speculative_requests WHERE id=?",
+        (request_id,),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"speculative_requests id={request_id} not found")
+
+    company = row["company"]
+    hint = row["hint"] or ""
+    personal_notes = row["personal_notes"] or ""
+
+    profile = profile_path.read_text() if profile_path.exists() else ""
+    master_resume = master_resume_path.read_text() if master_resume_path.exists() else ""
+
+    log_event("speculative_research_started", request_id=request_id, company=company)
+
+    # Step 1: briefing (skip if already cached on retry)
+    briefing_md = row["briefing_md"]
+    if not briefing_md:
+        try:
+            briefing_md = _call_aichat(
+                _BRIEFING_ROLE,
+                vars_={
+                    "company": company,
+                    "hint": hint,
+                    "personal_notes": personal_notes,
+                    "candidate_profile": profile,
+                    "master_resume": master_resume,
+                },
+            )
+        except Exception as e:
+            _mark_failed(conn, request_id, f"briefing failed: {e}")
+            log_event("speculative_research_failed", request_id=request_id, stage="briefing", error=str(e))
+            return
+        conn.execute(
+            "UPDATE speculative_requests SET briefing_md=?, briefing_prompt_version=? WHERE id=?",
+            (briefing_md, _BRIEFING_PROMPT_VERSION, request_id),
+        )
+        conn.commit()
+
+    # Step 2: role synth
+    try:
+        synth_raw = _call_aichat(
+            _SYNTH_ROLE,
+            vars_={
+                "candidate_profile": profile,
+                "master_resume": master_resume,
+                "briefing": briefing_md,
+            },
+        )
+        # Validate parses cleanly so the review page never sees garbage.
+        _ = parse_role_cards(synth_raw)
+    except Exception as e:
+        _mark_failed(conn, request_id, f"synth failed: {e}")
+        log_event("speculative_research_failed", request_id=request_id, stage="synth", error=str(e))
+        return
+
+    # Step 3: write briefing folder
+    folder = write_briefing(base_dir=companies_dir, company=company, briefing_md=briefing_md)
+    folder_name = folder.name
+
+    # Step 4: finalize
+    now = datetime.now(UTC).isoformat()
+    conn.execute(
+        """UPDATE speculative_requests
+           SET role_cards_json=?, synth_prompt_version=?, briefing_folder=?,
+               status='ready_for_review', research_completed_at=?
+           WHERE id=?""",
+        (synth_raw, _SYNTH_PROMPT_VERSION, folder_name, now, request_id),
+    )
+    conn.commit()
+    log_event("speculative_research_complete", request_id=request_id, company=company, folder=folder_name)
+
+
+def _mark_failed(conn: sqlite3.Connection, request_id: int, msg: str) -> None:
+    conn.execute(
+        "UPDATE speculative_requests SET status='failed', error_message=? WHERE id=?",
+        (msg, request_id),
+    )
+    conn.commit()
+
+
+def _call_aichat(role: str, *, vars_: dict[str, str]) -> str:
+    """Invoke aichat-ng with the named role, passing template vars as a single prompt string.
+
+    Convention matches prep_application.py and interview_prep.py:
+    ``aichat-ng --role <role> -S <prompt_body>``
+
+    The prompt body is a concatenation of all template variables as labeled
+    sections, matching the pattern used elsewhere in the pipeline for direct
+    context injection.
+    """
+    body = "\n\n".join(f"# {k}\n{v}" for k, v in vars_.items())
+    proc = subprocess.run(
+        [AICHAT, "--role", role, "-S", body],
+        capture_output=True,
+        text=True,
+        timeout=600,  # 10 min: deep-research can take 1-5 min, plus margin
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"aichat-ng exit {proc.returncode}: {proc.stderr.strip()[-500:]}")
+    output = proc.stdout.strip()
+    # Strip <think>...</think> blocks that leak from reasoning models
+    output = re.sub(r"<think>.*?</think>", "", output, flags=re.DOTALL).strip()
+    return output

--- a/src/findajob/speculative/storage.py
+++ b/src/findajob/speculative/storage.py
@@ -1,0 +1,34 @@
+"""Filesystem layout for speculative submissions:
+
+    {BASE}/companies/{Company}_SPECULATIVE_{YYYY-MM-DD}_{HHMMSS}/briefing.md
+
+The folder name is referenced by `speculative_requests.briefing_folder` so
+the approver and prep paths can locate the briefing on read.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+def speculative_folder_name(company: str, when_iso: str | None = None) -> str:
+    """Return the canonical folder name (no parent path) for a speculative briefing."""
+    safe_company = re.sub(r"[^A-Za-z0-9_]+", "_", company).strip("_") or "Unknown"
+    when = datetime.fromisoformat(when_iso) if when_iso else datetime.now()
+    stamp = when.strftime("%Y-%m-%d_%H%M%S")
+    return f"{safe_company}_SPECULATIVE_{stamp}"
+
+
+def write_briefing(
+    base_dir: Path,
+    company: str,
+    briefing_md: str,
+    when_iso: str | None = None,
+) -> Path:
+    """Create the speculative folder under base_dir and write briefing.md."""
+    folder = Path(base_dir) / speculative_folder_name(company, when_iso=when_iso)
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "briefing.md").write_text(briefing_md)
+    return folder

--- a/tests/test_speculative_approver.py
+++ b/tests/test_speculative_approver.py
@@ -76,8 +76,13 @@ CREATE TABLE audit_log (
 
 def _seed_ready(conn: sqlite3.Connection, n_cards: int = 3) -> int:
     cards = [
-        {"title": f"Role {i}", "description": "D", "why_this_fits_candidate": "W",
-         "likely_team_or_org": "T", "suggested_contact_type": "recruiter"}
+        {
+            "title": f"Role {i}",
+            "description": "D",
+            "why_this_fits_candidate": "W",
+            "likely_team_or_org": "T",
+            "suggested_contact_type": "recruiter",
+        }
         for i in range(n_cards)
     ]
     cur = conn.execute(

--- a/tests/test_speculative_approver.py
+++ b/tests/test_speculative_approver.py
@@ -1,0 +1,148 @@
+"""Tests for findajob.speculative.approver — writes jobs rows on Approve."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from findajob.speculative.approver import approve_request
+
+JOBS_SCHEMA = """
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    location TEXT DEFAULT '',
+    source TEXT NOT NULL,
+    raw_jd_text TEXT,
+    relevance_score INTEGER,
+    interview_likelihood INTEGER,
+    strengths_alignment TEXT,
+    industry_sector TEXT,
+    comp_estimate TEXT DEFAULT '',
+    ai_notes TEXT,
+    score_status TEXT,
+    score_flag_reason TEXT,
+    remote_status TEXT DEFAULT 'Unknown',
+    network_depth INTEGER DEFAULT 0,
+    known_contacts TEXT DEFAULT '',
+    stage TEXT DEFAULT 'discovered',
+    stage_updated TEXT,
+    status TEXT DEFAULT 'active',
+    apply_flag INTEGER DEFAULT 0,
+    reject_reason TEXT DEFAULT '',
+    prep_folder_path TEXT,
+    gdrive_folder_url TEXT,
+    fit_score REAL,
+    probability_score REAL,
+    user_notes TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    dupe_of TEXT DEFAULT '',
+    synthetic INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE speculative_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company TEXT NOT NULL,
+    hint TEXT,
+    personal_notes TEXT,
+    status TEXT NOT NULL DEFAULT 'researching',
+    error_message TEXT,
+    briefing_md TEXT,
+    role_cards_json TEXT,
+    briefing_folder TEXT,
+    submitted_at TEXT NOT NULL DEFAULT (datetime('now')),
+    research_completed_at TEXT,
+    approved_at TEXT,
+    approved_role_count INTEGER,
+    briefing_prompt_version TEXT,
+    synth_prompt_version TEXT
+);
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    field_changed TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_at TEXT DEFAULT (datetime('now')),
+    changed_by TEXT DEFAULT 'system'
+);
+"""
+
+
+def _seed_ready(conn: sqlite3.Connection, n_cards: int = 3) -> int:
+    cards = [
+        {"title": f"Role {i}", "description": "D", "why_this_fits_candidate": "W",
+         "likely_team_or_org": "T", "suggested_contact_type": "recruiter"}
+        for i in range(n_cards)
+    ]
+    cur = conn.execute(
+        """INSERT INTO speculative_requests
+           (company, status, briefing_md, role_cards_json, briefing_folder)
+           VALUES (?, 'ready_for_review', ?, ?, ?)""",
+        ("PSIQuantum", "# briefing\n", json.dumps(cards), "PSIQuantum_SPECULATIVE_2026-04-28_140000"),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def test_approve_writes_one_job_per_kept_card():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(JOBS_SCHEMA)
+    req_id = _seed_ready(conn, n_cards=3)
+
+    approve_request(conn, request_id=req_id, kept_indices=[0, 2])
+
+    jobs = conn.execute("SELECT * FROM jobs ORDER BY title").fetchall()
+    assert len(jobs) == 2
+    assert all(j["synthetic"] == 1 for j in jobs)
+    assert all(j["source"] == "web_speculative" for j in jobs)
+    assert all(j["title"].startswith("[SPEC] ") for j in jobs)
+    assert all(j["stage"] == "scored" for j in jobs)
+    titles = sorted(j["title"] for j in jobs)
+    assert titles == ["[SPEC] Role 0", "[SPEC] Role 2"]
+
+
+def test_approve_updates_request_status_and_count():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(JOBS_SCHEMA)
+    req_id = _seed_ready(conn, n_cards=4)
+
+    approve_request(conn, request_id=req_id, kept_indices=[1, 3])
+
+    row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (req_id,)).fetchone()
+    assert row["status"] == "approved"
+    assert row["approved_role_count"] == 2
+    assert row["approved_at"] is not None
+
+
+def test_approve_with_zero_kept_indices_marks_trashed():
+    """Approving with all cards dropped means 'I changed my mind' — equivalent to trash."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(JOBS_SCHEMA)
+    req_id = _seed_ready(conn, n_cards=3)
+
+    approve_request(conn, request_id=req_id, kept_indices=[])
+
+    row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (req_id,)).fetchone()
+    assert row["status"] == "trashed"
+    job_count = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+    assert job_count == 0
+
+
+def test_approve_rejects_non_ready_status():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(JOBS_SCHEMA)
+    cur = conn.execute("INSERT INTO speculative_requests (company, status) VALUES (?, 'researching')", ("X",))
+    req_id = cur.lastrowid
+
+    with pytest.raises(ValueError, match="status"):
+        approve_request(conn, request_id=req_id, kept_indices=[0])

--- a/tests/test_speculative_parser.py
+++ b/tests/test_speculative_parser.py
@@ -1,0 +1,76 @@
+"""Tests for findajob.speculative.parser — validates LLM-output role cards."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from findajob.speculative.parser import RoleCard, parse_role_cards
+
+
+def test_parses_valid_array():
+    raw = json.dumps([
+        {
+            "title": "Critical Infrastructure Engineer",
+            "description": "Own deployment of GPU clusters at new sites.",
+            "why_this_fits_candidate": "Candidate landed FTW Lab in a single half.",
+            "likely_team_or_org": "Site Operations",
+            "suggested_contact_type": "hiring_manager",
+        }
+    ])
+    cards = parse_role_cards(raw)
+    assert len(cards) == 1
+    assert cards[0].title == "Critical Infrastructure Engineer"
+    assert cards[0].suggested_contact_type == "hiring_manager"
+
+
+def test_strips_leading_markdown_fence():
+    """LLMs sometimes wrap JSON in ```json fences despite instructions."""
+    raw = "```json\n" + json.dumps([{
+        "title": "X",
+        "description": "Y",
+        "why_this_fits_candidate": "Z",
+        "likely_team_or_org": "T",
+        "suggested_contact_type": "recruiter",
+    }]) + "\n```"
+    cards = parse_role_cards(raw)
+    assert len(cards) == 1
+
+
+def test_caps_at_five_cards():
+    raw = json.dumps([
+        {"title": f"Role {i}", "description": "D", "why_this_fits_candidate": "W",
+         "likely_team_or_org": "T", "suggested_contact_type": "recruiter"}
+        for i in range(8)
+    ])
+    cards = parse_role_cards(raw)
+    assert len(cards) == 5  # surplus dropped
+
+
+def test_rejects_invalid_contact_type():
+    raw = json.dumps([{
+        "title": "X", "description": "Y", "why_this_fits_candidate": "Z",
+        "likely_team_or_org": "T", "suggested_contact_type": "ceo",  # invalid
+    }])
+    with pytest.raises(ValueError, match="suggested_contact_type"):
+        parse_role_cards(raw)
+
+
+def test_rejects_missing_required_field():
+    raw = json.dumps([{"title": "X"}])
+    with pytest.raises(ValueError, match="missing"):
+        parse_role_cards(raw)
+
+
+def test_rejects_non_array():
+    raw = json.dumps({"title": "X"})  # object, not array
+    with pytest.raises(ValueError, match="array"):
+        parse_role_cards(raw)
+
+
+def test_rejects_empty_array():
+    """Spec requires 1-5 cards — empty is a synthesis failure, not silent success."""
+    raw = json.dumps([])
+    with pytest.raises(ValueError, match="empty|at least one"):
+        parse_role_cards(raw)

--- a/tests/test_speculative_parser.py
+++ b/tests/test_speculative_parser.py
@@ -6,19 +6,21 @@ import json
 
 import pytest
 
-from findajob.speculative.parser import RoleCard, parse_role_cards
+from findajob.speculative.parser import parse_role_cards
 
 
 def test_parses_valid_array():
-    raw = json.dumps([
-        {
-            "title": "Critical Infrastructure Engineer",
-            "description": "Own deployment of GPU clusters at new sites.",
-            "why_this_fits_candidate": "Candidate landed FTW Lab in a single half.",
-            "likely_team_or_org": "Site Operations",
-            "suggested_contact_type": "hiring_manager",
-        }
-    ])
+    raw = json.dumps(
+        [
+            {
+                "title": "Critical Infrastructure Engineer",
+                "description": "Own deployment of GPU clusters at new sites.",
+                "why_this_fits_candidate": "Candidate landed FTW Lab in a single half.",
+                "likely_team_or_org": "Site Operations",
+                "suggested_contact_type": "hiring_manager",
+            }
+        ]
+    )
     cards = parse_role_cards(raw)
     assert len(cards) == 1
     assert cards[0].title == "Critical Infrastructure Engineer"
@@ -27,32 +29,54 @@ def test_parses_valid_array():
 
 def test_strips_leading_markdown_fence():
     """LLMs sometimes wrap JSON in ```json fences despite instructions."""
-    raw = "```json\n" + json.dumps([{
-        "title": "X",
-        "description": "Y",
-        "why_this_fits_candidate": "Z",
-        "likely_team_or_org": "T",
-        "suggested_contact_type": "recruiter",
-    }]) + "\n```"
+    raw = (
+        "```json\n"
+        + json.dumps(
+            [
+                {
+                    "title": "X",
+                    "description": "Y",
+                    "why_this_fits_candidate": "Z",
+                    "likely_team_or_org": "T",
+                    "suggested_contact_type": "recruiter",
+                }
+            ]
+        )
+        + "\n```"
+    )
     cards = parse_role_cards(raw)
     assert len(cards) == 1
 
 
 def test_caps_at_five_cards():
-    raw = json.dumps([
-        {"title": f"Role {i}", "description": "D", "why_this_fits_candidate": "W",
-         "likely_team_or_org": "T", "suggested_contact_type": "recruiter"}
-        for i in range(8)
-    ])
+    raw = json.dumps(
+        [
+            {
+                "title": f"Role {i}",
+                "description": "D",
+                "why_this_fits_candidate": "W",
+                "likely_team_or_org": "T",
+                "suggested_contact_type": "recruiter",
+            }
+            for i in range(8)
+        ]
+    )
     cards = parse_role_cards(raw)
     assert len(cards) == 5  # surplus dropped
 
 
 def test_rejects_invalid_contact_type():
-    raw = json.dumps([{
-        "title": "X", "description": "Y", "why_this_fits_candidate": "Z",
-        "likely_team_or_org": "T", "suggested_contact_type": "ceo",  # invalid
-    }])
+    raw = json.dumps(
+        [
+            {
+                "title": "X",
+                "description": "Y",
+                "why_this_fits_candidate": "Z",
+                "likely_team_or_org": "T",
+                "suggested_contact_type": "ceo",  # invalid
+            }
+        ]
+    )
     with pytest.raises(ValueError, match="suggested_contact_type"):
         parse_role_cards(raw)
 

--- a/tests/test_speculative_runner.py
+++ b/tests/test_speculative_runner.py
@@ -15,8 +15,6 @@ import json
 import sqlite3
 from unittest.mock import patch
 
-import pytest
-
 from findajob.speculative.runner import run_research
 
 SCHEMA = """
@@ -54,15 +52,17 @@ def _ok_briefing() -> str:
 
 
 def _ok_role_cards() -> str:
-    return json.dumps([
-        {
-            "title": "Critical Infrastructure Engineer",
-            "description": "Own GPU cluster bring-up.",
-            "why_this_fits_candidate": "FTW Lab analog.",
-            "likely_team_or_org": "Site Operations",
-            "suggested_contact_type": "hiring_manager",
-        }
-    ])
+    return json.dumps(
+        [
+            {
+                "title": "Critical Infrastructure Engineer",
+                "description": "Own GPU cluster bring-up.",
+                "why_this_fits_candidate": "FTW Lab analog.",
+                "likely_team_or_org": "Site Operations",
+                "suggested_contact_type": "hiring_manager",
+            }
+        ]
+    )
 
 
 def test_run_research_happy_path(tmp_path):
@@ -113,8 +113,10 @@ def test_run_research_briefing_failure_sets_status_failed(tmp_path):
     conn.executescript(SCHEMA)
     req_id = _seed(conn)
 
-    profile = tmp_path / "profile.md"; profile.write_text("p")
-    resume = tmp_path / "master_resume.md"; resume.write_text("r")
+    profile = tmp_path / "profile.md"
+    profile.write_text("p")
+    resume = tmp_path / "master_resume.md"
+    resume.write_text("r")
 
     with patch("findajob.speculative.runner._call_aichat") as mock_call:
         mock_call.side_effect = RuntimeError("aichat-ng exit 1: rate limited")
@@ -141,8 +143,10 @@ def test_run_research_synth_failure_preserves_briefing(tmp_path):
     conn.executescript(SCHEMA)
     req_id = _seed(conn)
 
-    profile = tmp_path / "profile.md"; profile.write_text("p")
-    resume = tmp_path / "master_resume.md"; resume.write_text("r")
+    profile = tmp_path / "profile.md"
+    profile.write_text("p")
+    resume = tmp_path / "master_resume.md"
+    resume.write_text("r")
 
     with patch("findajob.speculative.runner._call_aichat") as mock_call:
         mock_call.side_effect = [_ok_briefing(), RuntimeError("synth failed: invalid JSON")]

--- a/tests/test_speculative_runner.py
+++ b/tests/test_speculative_runner.py
@@ -1,0 +1,161 @@
+"""Tests for findajob.speculative.runner — orchestrates briefing + role-synth.
+
+aichat-ng subprocess is mocked. We assert the runner:
+1. Reads the speculative_requests row and candidate context files
+2. Calls the briefing role, then the synth role with the briefing as input
+3. Writes briefing.md to a freshly-created folder
+4. Updates the request row to status='ready_for_review' with briefing_md +
+   role_cards_json + briefing_folder + research_completed_at populated
+5. On any failure, sets status='failed' + error_message
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from findajob.speculative.runner import run_research
+
+SCHEMA = """
+CREATE TABLE speculative_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company TEXT NOT NULL,
+    hint TEXT,
+    personal_notes TEXT,
+    status TEXT NOT NULL DEFAULT 'researching',
+    error_message TEXT,
+    briefing_md TEXT,
+    role_cards_json TEXT,
+    briefing_folder TEXT,
+    submitted_at TEXT NOT NULL DEFAULT (datetime('now')),
+    research_completed_at TEXT,
+    approved_at TEXT,
+    approved_role_count INTEGER,
+    briefing_prompt_version TEXT,
+    synth_prompt_version TEXT
+);
+"""
+
+
+def _seed(conn: sqlite3.Connection) -> int:
+    cur = conn.execute(
+        "INSERT INTO speculative_requests (company, hint, personal_notes, status) VALUES (?, ?, ?, 'researching')",
+        ("PSIQuantum", "advanced computing infrastructure", None),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _ok_briefing() -> str:
+    return "# briefing\n\n## 🏢 Company Snapshot\nbody\n"
+
+
+def _ok_role_cards() -> str:
+    return json.dumps([
+        {
+            "title": "Critical Infrastructure Engineer",
+            "description": "Own GPU cluster bring-up.",
+            "why_this_fits_candidate": "FTW Lab analog.",
+            "likely_team_or_org": "Site Operations",
+            "suggested_contact_type": "hiring_manager",
+        }
+    ])
+
+
+def test_run_research_happy_path(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    req_id = _seed(conn)
+
+    profile = tmp_path / "profile.md"
+    profile.write_text("candidate profile body")
+    resume = tmp_path / "master_resume.md"
+    resume.write_text("master resume body")
+
+    with patch("findajob.speculative.runner._call_aichat") as mock_call:
+        mock_call.side_effect = [_ok_briefing(), _ok_role_cards()]
+        run_research(
+            conn=conn,
+            request_id=req_id,
+            profile_path=profile,
+            master_resume_path=resume,
+            companies_dir=tmp_path / "companies",
+        )
+
+    assert mock_call.call_count == 2
+    # First call is candidate_led_briefing, second is speculative_roles_synth
+    first_role = mock_call.call_args_list[0][0][0]
+    second_role = mock_call.call_args_list[1][0][0]
+    assert first_role == "candidate_led_briefing"
+    assert second_role == "speculative_roles_synth"
+
+    # Row updated
+    row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (req_id,)).fetchone()
+    assert row["status"] == "ready_for_review"
+    assert row["briefing_md"] == _ok_briefing()
+    assert row["role_cards_json"] == _ok_role_cards()
+    assert row["briefing_folder"] is not None
+    assert row["research_completed_at"] is not None
+
+    # Folder + briefing.md exist on disk
+    folder = tmp_path / "companies" / row["briefing_folder"]
+    assert folder.exists()
+    assert (folder / "briefing.md").read_text() == _ok_briefing()
+
+
+def test_run_research_briefing_failure_sets_status_failed(tmp_path):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    req_id = _seed(conn)
+
+    profile = tmp_path / "profile.md"; profile.write_text("p")
+    resume = tmp_path / "master_resume.md"; resume.write_text("r")
+
+    with patch("findajob.speculative.runner._call_aichat") as mock_call:
+        mock_call.side_effect = RuntimeError("aichat-ng exit 1: rate limited")
+        run_research(
+            conn=conn,
+            request_id=req_id,
+            profile_path=profile,
+            master_resume_path=resume,
+            companies_dir=tmp_path / "companies",
+        )
+
+    row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (req_id,)).fetchone()
+    assert row["status"] == "failed"
+    assert "rate limited" in (row["error_message"] or "")
+    assert row["briefing_md"] is None
+    assert row["role_cards_json"] is None
+
+
+def test_run_research_synth_failure_preserves_briefing(tmp_path):
+    """If briefing succeeds but role-synth fails, briefing_md is preserved
+    in the row so a retry only re-runs the synth step."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    req_id = _seed(conn)
+
+    profile = tmp_path / "profile.md"; profile.write_text("p")
+    resume = tmp_path / "master_resume.md"; resume.write_text("r")
+
+    with patch("findajob.speculative.runner._call_aichat") as mock_call:
+        mock_call.side_effect = [_ok_briefing(), RuntimeError("synth failed: invalid JSON")]
+        run_research(
+            conn=conn,
+            request_id=req_id,
+            profile_path=profile,
+            master_resume_path=resume,
+            companies_dir=tmp_path / "companies",
+        )
+
+    row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (req_id,)).fetchone()
+    assert row["status"] == "failed"
+    assert row["briefing_md"] == _ok_briefing()
+    assert row["role_cards_json"] is None
+    assert "synth failed" in (row["error_message"] or "")

--- a/tests/test_speculative_storage.py
+++ b/tests/test_speculative_storage.py
@@ -2,10 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
-
 from findajob.speculative.storage import speculative_folder_name, write_briefing
 
 

--- a/tests/test_speculative_storage.py
+++ b/tests/test_speculative_storage.py
@@ -1,0 +1,36 @@
+"""Tests for findajob.speculative.storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from findajob.speculative.storage import speculative_folder_name, write_briefing
+
+
+def test_folder_name_includes_company_date_time():
+    name = speculative_folder_name("PSIQuantum", when_iso="2026-04-28T14:30:00")
+    assert name == "PSIQuantum_SPECULATIVE_2026-04-28_143000"
+
+
+def test_folder_name_strips_company_unsafe_chars():
+    # Slashes, colons, etc. must not appear in folder names.
+    name = speculative_folder_name("ai/&:Co", when_iso="2026-04-28T09:00:00")
+    assert "/" not in name
+    assert ":" not in name
+    assert name.startswith("ai_Co_SPECULATIVE_") or name.startswith("ai__Co_SPECULATIVE_")
+
+
+def test_write_briefing_creates_folder_and_md(tmp_path):
+    folder = write_briefing(
+        base_dir=tmp_path,
+        company="PSIQuantum",
+        briefing_md="# briefing\n\nbody\n",
+        when_iso="2026-04-28T14:30:00",
+    )
+    assert folder.exists()
+    assert folder.is_dir()
+    md = folder / "briefing.md"
+    assert md.read_text() == "# briefing\n\nbody\n"
+    assert folder.name == "PSIQuantum_SPECULATIVE_2026-04-28_143000"


### PR DESCRIPTION
## Summary

- New `src/findajob/speculative/` package: `parser.py` (RoleCard + parse_role_cards with fence-stripping, enum guard, 5-card cap), `storage.py` (briefing folder + write_briefing), `runner.py` (orchestrates briefing + synth + writes results), `approver.py` (writes one jobs row per kept card on operator approve).
- New role files: `config/roles/candidate_led_briefing.md` (Perplexity Sonar Deep Research) and `config/roles/speculative_roles_synth.md` (Claude Sonnet 4.6, JSON-array output).
- `scripts/run_speculative_research.py` is the detached-subprocess entry — POST handler in B3 will spawn it.
- 14 new tests across 4 test files; 1091/1091 total green.

This is **B2 of 4** for #131. After merge, speculative research can be invoked headless against a pre-INSERTed `speculative_requests` row.

## Test plan

- [x] `uv run pytest -x` — 1091 passed
- [x] `uv run ruff format --check . && uv run ruff check .` — clean
- [x] `uv run mypy src/findajob` — 0 errors
- [ ] Post-merge manual smoke (with B3 wiring): submit through `/ingest/speculative` → verify status transitions and briefing folder created

🤖 Generated with [Claude Code](https://claude.com/claude-code)