### PR TITLE
feat(speculative): /ingest/ form + status/review/approve UX (B3 of #131)

### DIFF
--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -14,6 +14,7 @@ from findajob.web.routes import (
     landing,
     materials,
     onboarding,
+    speculative,
     stats,
     tools,
 )
@@ -27,6 +28,7 @@ router.include_router(landing.router)
 router.include_router(board.router, dependencies=_guard)
 router.include_router(board_actions.router, dependencies=_guard)
 router.include_router(ingest.router)
+router.include_router(speculative.router, dependencies=_guard)
 router.include_router(stats.router, dependencies=_guard)
 router.include_router(config.router)
 router.include_router(tools.router)

--- a/src/findajob/web/routes/ingest.py
+++ b/src/findajob/web/routes/ingest.py
@@ -32,13 +32,24 @@ twenty postings in a row with the checkbox on.
 
 
 @router.get("/ingest/", response_class=HTMLResponse)
-def ingest_page(request: Request) -> HTMLResponse:
+def ingest_page(
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
     """Render the manual-JD form."""
     templates = request.app.state.templates
+    try:
+        today_speculative_count = db.execute(
+            "SELECT COUNT(*) FROM speculative_requests WHERE date(submitted_at)=date('now', 'localtime')"
+        ).fetchone()[0]
+    except sqlite3.OperationalError:
+        # Table absent in legacy/test fixtures that haven't run init_db.py.
+        # Falls back to no soft-warn — pipeline-correct default.
+        today_speculative_count = 0
     return templates.TemplateResponse(
         request=request,
         name="ingest/form.html",
-        context={},
+        context={"today_speculative_count": today_speculative_count},
     )
 
 

--- a/src/findajob/web/routes/speculative.py
+++ b/src/findajob/web/routes/speculative.py
@@ -1,0 +1,36 @@
+"""Web routes for speculative ingest (#131 B3).
+
+Endpoints:
+    POST /ingest/speculative              — form submit (kicks subprocess)
+    GET  /speculative/status/{id}         — async status page (HTMX poll)
+    GET  /speculative/status/{id}/poll    — HTMX poll fragment
+    GET  /speculative/review/{id}         — review page (briefing + role cards)
+    POST /speculative/approve/{id}        — write jobs rows from kept cards
+    POST /speculative/regenerate/{id}     — re-run research (resets status to researching)
+    POST /speculative/trash/{id}          — drop submission, no jobs rows written
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from findajob.paths import BASE
+from findajob.speculative.approver import approve_request
+
+router = APIRouter()
+templates = Jinja2Templates(directory=str(Path(BASE) / "src" / "findajob" / "web" / "templates"))
+
+DB_PATH = Path(BASE) / "data" / "pipeline.db"
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(DB_PATH), timeout=30)
+    conn.row_factory = sqlite3.Row
+    return conn

--- a/src/findajob/web/routes/speculative.py
+++ b/src/findajob/web/routes/speculative.py
@@ -16,6 +16,7 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -23,6 +24,8 @@ from fastapi.templating import Jinja2Templates
 
 from findajob.paths import BASE
 from findajob.speculative.approver import approve_request
+from findajob.speculative.parser import parse_role_cards
+from findajob.web.markdown import render_markdown
 
 router = APIRouter()
 templates = Jinja2Templates(directory=str(Path(BASE) / "src" / "findajob" / "web" / "templates"))
@@ -34,3 +37,149 @@ def _conn() -> sqlite3.Connection:
     conn = sqlite3.connect(str(DB_PATH), timeout=30)
     conn.row_factory = sqlite3.Row
     return conn
+
+
+# ── T21: POST /ingest/speculative ────────────────────────────────────────
+
+
+@router.post("/ingest/speculative")
+def post_speculative(
+    company: str = Form(default=""),
+    hint: str = Form(default=""),
+    personal_notes: str = Form(default=""),
+) -> RedirectResponse:
+    company = company.strip()
+    if not company:
+        raise HTTPException(status_code=400, detail="company is required")
+    conn = _conn()
+    try:
+        cur = conn.execute(
+            """INSERT INTO speculative_requests (company, hint, personal_notes, status)
+               VALUES (?, ?, ?, 'researching')""",
+            (company, hint.strip() or None, personal_notes.strip() or None),
+        )
+        conn.commit()
+        request_id = cur.lastrowid
+    finally:
+        conn.close()
+
+    script_path = Path(BASE) / "scripts" / "run_speculative_research.py"
+    subprocess.Popen(
+        [sys.executable, str(script_path), str(request_id)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return RedirectResponse(url=f"/speculative/status/{request_id}", status_code=303)
+
+
+# ── T22: status page + HTMX poll fragment ────────────────────────────────
+
+
+@router.get("/speculative/status/{request_id}", response_class=HTMLResponse)
+def get_status(request: Request, request_id: int):
+    conn = _conn()
+    try:
+        row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (request_id,)).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        raise HTTPException(status_code=404, detail="speculative request not found")
+    return templates.TemplateResponse(request=request, name="speculative/status.html", context={"row": dict(row)})
+
+
+@router.get("/speculative/status/{request_id}/poll", response_class=HTMLResponse)
+def poll_status(request: Request, request_id: int):
+    conn = _conn()
+    try:
+        row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (request_id,)).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        raise HTTPException(status_code=404)
+    return templates.TemplateResponse(
+        request=request,
+        name="speculative/_status_fragment.html",
+        context={"row": dict(row)},
+    )
+
+
+# ── T23: review page ─────────────────────────────────────────────────────
+
+
+@router.get("/speculative/review/{request_id}", response_class=HTMLResponse)
+def get_review(request: Request, request_id: int):
+    conn = _conn()
+    try:
+        row = conn.execute("SELECT * FROM speculative_requests WHERE id=?", (request_id,)).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        raise HTTPException(status_code=404, detail="speculative request not found")
+    if row["status"] != "ready_for_review":
+        return RedirectResponse(url=f"/speculative/status/{request_id}", status_code=303)
+    cards = parse_role_cards(row["role_cards_json"])
+    briefing_html = render_markdown(row["briefing_md"] or "")
+    return templates.TemplateResponse(
+        request=request,
+        name="speculative/review.html",
+        context={"row": dict(row), "cards": cards, "briefing_html": briefing_html},
+    )
+
+
+# ── T24: approve / regenerate / trash ────────────────────────────────────
+
+
+@router.post("/speculative/approve/{request_id}")
+def post_approve(request_id: int, keep: Annotated[list[int] | None, Form()] = None) -> RedirectResponse:
+    conn = _conn()
+    try:
+        approve_request(conn, request_id=request_id, kept_indices=keep or [])
+    finally:
+        conn.close()
+    return RedirectResponse(url="/board/", status_code=303)
+
+
+@router.post("/speculative/regenerate/{request_id}")
+def post_regenerate(request_id: int) -> RedirectResponse:
+    conn = _conn()
+    try:
+        row = conn.execute("SELECT status FROM speculative_requests WHERE id=?", (request_id,)).fetchone()
+        if row is None:
+            raise HTTPException(status_code=404)
+        if row["status"] == "researching":
+            raise HTTPException(status_code=409, detail="research already in flight")
+        conn.execute(
+            """UPDATE speculative_requests
+               SET status='researching', error_message=NULL,
+                   role_cards_json=NULL, briefing_folder=NULL,
+                   research_completed_at=NULL
+               WHERE id=?""",
+            (request_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    script_path = Path(BASE) / "scripts" / "run_speculative_research.py"
+    subprocess.Popen(
+        [sys.executable, str(script_path), str(request_id)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return RedirectResponse(url=f"/speculative/status/{request_id}", status_code=303)
+
+
+@router.post("/speculative/trash/{request_id}")
+def post_trash(request_id: int) -> RedirectResponse:
+    conn = _conn()
+    try:
+        conn.execute(
+            "UPDATE speculative_requests SET status='trashed' WHERE id=?",
+            (request_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return RedirectResponse(url="/ingest/", status_code=303)

--- a/src/findajob/web/templates/ingest/form.html
+++ b/src/findajob/web/templates/ingest/form.html
@@ -9,20 +9,24 @@
   the same as the old Google Form.
 </p>
 
-{# Mode toggle. Speculative (#131) slots in here later. #}
+{# Mode toggle (#131). Switches between real-JD form and speculative form. #}
+<div x-data="{ mode: 'real' }">
 <div class="flex gap-2 mb-6 border-b border-slate-200">
   <button type="button"
-          class="px-3 py-2 text-sm font-medium border-b-2 border-slate-800 text-slate-900"
-          aria-current="page">
+          @click="mode = 'real'"
+          :class="mode === 'real' ? 'border-slate-800 text-slate-900' : 'border-transparent text-slate-500 hover:text-slate-700'"
+          class="px-3 py-2 text-sm font-medium border-b-2">
     Real posting
   </button>
   <button type="button"
-          class="px-3 py-2 text-sm font-medium border-b-2 border-transparent text-slate-400 cursor-not-allowed"
-          disabled
-          title="Speculative company briefing — coming in #131">
-    Speculative &middot; <span class="text-xs">#131</span>
+          @click="mode = 'speculative'"
+          :class="mode === 'speculative' ? 'border-slate-800 text-slate-900' : 'border-transparent text-slate-500 hover:text-slate-700'"
+          class="px-3 py-2 text-sm font-medium border-b-2">
+    Speculative
   </button>
 </div>
+
+<div x-show="mode === 'real'">
 
 <form id="manual-ingest-form"
       hx-post="/ingest/manual"
@@ -107,4 +111,49 @@
 </form>
 
 <div id="ingest-result" class="mt-6 max-w-3xl"></div>
+
+</div>{# /x-show real #}
+
+<div x-show="mode === 'speculative'" x-cloak>
+  <p class="text-sm text-slate-600 mb-4">
+    No JD? Submit a company name and the pipeline will research them via Perplexity Deep Research,
+    synthesize 1–5 plausible roles, and let you approve a cold-outreach package.
+    <strong>Takes 1–5 minutes.</strong>
+  </p>
+  {% if today_speculative_count and today_speculative_count > 0 %}
+    <div class="rounded bg-yellow-50 border border-yellow-300 p-3 mb-4 text-sm">
+      You've already submitted {{ today_speculative_count }} speculative request(s) today
+      (~${{ "%.2f"|format(today_speculative_count * 0.50) }} of Perplexity Deep Research).
+      No hard cap — submit if it's worth it.
+    </div>
+  {% endif %}
+  <form method="post" action="/ingest/speculative" class="space-y-4 max-w-3xl">
+    <label class="block">
+      <span class="text-sm font-medium text-slate-700">Company <span class="text-red-600">*</span></span>
+      <input type="text" name="company" required autocomplete="off"
+             class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+    </label>
+    <label class="block">
+      <span class="text-sm font-medium text-slate-700">Hint (optional)</span>
+      <input type="text" name="hint" placeholder="data center team / ML platform org / …" autocomplete="off"
+             class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
+      <span class="text-xs text-slate-500 mt-1 block">Helps focus the research on a specific function/team.</span>
+    </label>
+    <label class="block">
+      <span class="text-sm font-medium text-slate-700">Connection notes (optional)</span>
+      <textarea name="personal_notes" rows="2"
+                placeholder="Any prior contacts, mutual connections, or context worth surfacing in outreach"
+                class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm"></textarea>
+    </label>
+    <div class="flex items-center gap-3 pt-2">
+      <button type="submit"
+              class="bg-slate-800 text-white text-sm font-medium rounded px-4 py-2 hover:bg-slate-700">
+        Submit speculative
+      </button>
+      <span class="text-xs text-slate-500">Redirects to a status page that polls until research completes.</span>
+    </div>
+  </form>
+</div>{# /x-show speculative #}
+
+</div>{# /x-data mode toggle #}
 {% endblock %}

--- a/src/findajob/web/templates/speculative/_status_fragment.html
+++ b/src/findajob/web/templates/speculative/_status_fragment.html
@@ -1,0 +1,24 @@
+{% if row.status == 'researching' %}
+  <div class="rounded border p-4 bg-blue-50">
+    <div class="font-semibold">Researching — Perplexity Deep Research takes 1–5 minutes.</div>
+    <div class="text-sm text-gray-600 mt-2">This page auto-refreshes every 5 seconds.</div>
+  </div>
+{% elif row.status == 'ready_for_review' %}
+  <div class="rounded border p-4 bg-green-50">
+    Research complete — redirecting to review page…
+  </div>
+  <script>window.location = "/speculative/review/{{ row.id }}";</script>
+{% elif row.status == 'failed' %}
+  <div class="rounded border p-4 bg-red-50">
+    <div class="font-semibold">Research failed</div>
+    <div class="mt-2 text-sm">{{ row.error_message or "(no error message recorded)" }}</div>
+    <form method="post" action="/speculative/regenerate/{{ row.id }}" class="mt-4">
+      <button type="submit" class="btn btn-primary">Retry</button>
+    </form>
+    <form method="post" action="/speculative/trash/{{ row.id }}" class="mt-2">
+      <button type="submit" class="btn btn-secondary">Trash</button>
+    </form>
+  </div>
+{% else %}
+  <div class="rounded border p-4 bg-gray-50">Status: {{ row.status }}</div>
+{% endif %}

--- a/src/findajob/web/templates/speculative/review.html
+++ b/src/findajob/web/templates/speculative/review.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="max-w-4xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-2">Review — {{ row.company }}</h1>
+  <div class="text-sm text-gray-600 mb-4">Submitted {{ row.submitted_at }} · Research completed {{ row.research_completed_at }}</div>
+
+  <details class="mb-6 border rounded p-4">
+    <summary class="font-semibold cursor-pointer">Briefing ({{ row.briefing_md|length }} chars)</summary>
+    <div class="prose mt-4">{{ briefing_html|safe }}</div>
+  </details>
+
+  <h2 class="text-xl font-semibold mb-3">Role cards ({{ cards|length }})</h2>
+  <form method="post" action="/speculative/approve/{{ row.id }}" class="space-y-4">
+    {% for card in cards %}
+      <div class="border rounded p-4">
+        <label class="flex items-start gap-3">
+          <input type="checkbox" name="keep" value="{{ loop.index0 }}" checked class="mt-1">
+          <div class="flex-1">
+            <div class="font-bold text-lg">{{ card.title }}</div>
+            <div class="text-sm text-gray-600 mb-2">
+              {{ card.likely_team_or_org }} · suggested contact: {{ card.suggested_contact_type }}
+            </div>
+            <div class="mb-3 whitespace-pre-line">{{ card.description }}</div>
+            <div class="text-sm bg-gray-50 p-3 rounded">
+              <span class="font-semibold">Why this fits you:</span> {{ card.why_this_fits_candidate }}
+            </div>
+          </div>
+        </label>
+      </div>
+    {% endfor %}
+    <div class="flex gap-3 pt-4">
+      <button type="submit" class="btn btn-primary">Approve kept cards</button>
+      <button type="submit" formaction="/speculative/regenerate/{{ row.id }}" formmethod="post" class="btn btn-secondary">Regenerate</button>
+      <button type="submit" formaction="/speculative/trash/{{ row.id }}" formmethod="post" class="btn btn-warning">Trash</button>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/src/findajob/web/templates/speculative/status.html
+++ b/src/findajob/web/templates/speculative/status.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="max-w-3xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-4">Speculative submission for {{ row.company }}</h1>
+  <div id="status" hx-get="/speculative/status/{{ row.id }}/poll" hx-trigger="every 5s" hx-swap="outerHTML">
+    {% include "speculative/_status_fragment.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_speculative_routes.py
+++ b/tests/test_speculative_routes.py
@@ -1,0 +1,288 @@
+"""Routes tests for speculative ingest. FastAPI TestClient + in-memory DB."""
+
+from __future__ import annotations
+
+import json as _json
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from findajob.web.routes import speculative as spec_routes
+
+
+def _make_app(db_path: Path) -> FastAPI:
+    app = FastAPI()
+    app.include_router(spec_routes.router)
+    spec_routes.DB_PATH = db_path
+    return app
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db = tmp_path / "p.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript("""
+        CREATE TABLE speculative_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            company TEXT NOT NULL,
+            hint TEXT,
+            personal_notes TEXT,
+            status TEXT NOT NULL DEFAULT 'researching',
+            error_message TEXT,
+            briefing_md TEXT,
+            role_cards_json TEXT,
+            briefing_folder TEXT,
+            submitted_at TEXT NOT NULL DEFAULT (datetime('now')),
+            research_completed_at TEXT,
+            approved_at TEXT,
+            approved_role_count INTEGER,
+            briefing_prompt_version TEXT,
+            synth_prompt_version TEXT
+        );
+    """)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _make_db_with_jobs(tmp_path: Path) -> Path:
+    """Schema for tests that exercise the approve path (writes jobs rows)."""
+    db = tmp_path / "p.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript("""
+        CREATE TABLE jobs (
+            id TEXT PRIMARY KEY, fingerprint TEXT UNIQUE NOT NULL, url TEXT NOT NULL,
+            title TEXT NOT NULL, company TEXT NOT NULL, location TEXT DEFAULT '',
+            source TEXT NOT NULL, raw_jd_text TEXT, relevance_score INTEGER,
+            score_status TEXT, ai_notes TEXT, stage TEXT, stage_updated TEXT,
+            created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now')),
+            synthetic INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, job_id TEXT NOT NULL, field_changed TEXT NOT NULL,
+            old_value TEXT, new_value TEXT, changed_at TEXT DEFAULT (datetime('now')), changed_by TEXT DEFAULT 'system'
+        );
+        CREATE TABLE speculative_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            company TEXT NOT NULL,
+            hint TEXT,
+            personal_notes TEXT,
+            status TEXT NOT NULL DEFAULT 'researching',
+            error_message TEXT,
+            briefing_md TEXT,
+            role_cards_json TEXT,
+            briefing_folder TEXT,
+            submitted_at TEXT NOT NULL DEFAULT (datetime('now')),
+            research_completed_at TEXT,
+            approved_at TEXT,
+            approved_role_count INTEGER,
+            briefing_prompt_version TEXT,
+            synth_prompt_version TEXT
+        );
+    """)
+    conn.commit()
+    conn.close()
+    return db
+
+
+# ── T21: POST /ingest/speculative ────────────────────────────────────────
+
+
+def test_post_speculative_inserts_row_and_spawns_subprocess(tmp_path):
+    db = _make_db(tmp_path)
+    app = _make_app(db)
+    client = TestClient(app)
+
+    with patch("findajob.web.routes.speculative.subprocess.Popen") as mock_popen:
+        resp = client.post(
+            "/ingest/speculative",
+            data={"company": "PSIQuantum", "hint": "advanced computing", "personal_notes": ""},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 303
+    assert resp.headers["location"].startswith("/speculative/status/")
+    assert mock_popen.call_count == 1
+    args = mock_popen.call_args[0][0]
+    assert any("run_speculative_research.py" in str(a) for a in args)
+
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM speculative_requests").fetchone()
+    assert row is not None
+    assert row["company"] == "PSIQuantum"
+    assert row["status"] == "researching"
+
+
+def test_post_speculative_rejects_empty_company(tmp_path):
+    db = _make_db(tmp_path)
+    app = _make_app(db)
+    client = TestClient(app)
+    resp = client.post(
+        "/ingest/speculative",
+        data={"company": "", "hint": "", "personal_notes": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+# ── T22: status page + poll fragment ─────────────────────────────────────
+
+
+def test_get_status_renders_researching(tmp_path):
+    db = _make_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute("INSERT INTO speculative_requests (company, status) VALUES ('PSI', 'researching')")
+    conn.commit()
+    conn.close()
+
+    app = _make_app(db)
+    client = TestClient(app)
+    resp = client.get("/speculative/status/1")
+    assert resp.status_code == 200
+    assert "Researching" in resp.text
+
+
+def test_poll_returns_fragment(tmp_path):
+    db = _make_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO speculative_requests (company, status, error_message) VALUES ('PSI', 'failed', 'budget exceeded')"
+    )
+    conn.commit()
+    conn.close()
+
+    app = _make_app(db)
+    client = TestClient(app)
+    resp = client.get("/speculative/status/1/poll")
+    assert resp.status_code == 200
+    assert "Research failed" in resp.text
+    assert "budget exceeded" in resp.text
+
+
+# ── T23: review page ─────────────────────────────────────────────────────
+
+
+def test_get_review_renders_briefing_and_cards(tmp_path):
+    db = _make_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """INSERT INTO speculative_requests (company, status, briefing_md, role_cards_json)
+           VALUES ('PSI', 'ready_for_review', '# Briefing\nbody', ?)""",
+        (
+            _json.dumps(
+                [
+                    {
+                        "title": "Critical Infra Eng",
+                        "description": "Own GPU cluster bring-up.",
+                        "why_this_fits_candidate": "Resume bullet match.",
+                        "likely_team_or_org": "SiteOps",
+                        "suggested_contact_type": "hiring_manager",
+                    }
+                ]
+            ),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    app = _make_app(db)
+    client = TestClient(app)
+    resp = client.get("/speculative/review/1")
+    assert resp.status_code == 200
+    assert "Critical Infra Eng" in resp.text
+    assert "Own GPU cluster bring-up" in resp.text
+    assert "SiteOps" in resp.text
+    # All cards default-checked (keep on by default)
+    assert 'value="0" checked' in resp.text
+
+
+def test_get_review_redirects_when_not_ready(tmp_path):
+    db = _make_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute("INSERT INTO speculative_requests (company, status) VALUES ('PSI', 'researching')")
+    conn.commit()
+    conn.close()
+
+    app = _make_app(db)
+    client = TestClient(app)
+    resp = client.get("/speculative/review/1", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/speculative/status/1"
+
+
+# ── T24: approve / regenerate / trash ────────────────────────────────────
+
+
+def test_approve_writes_jobs_and_redirects_to_board(tmp_path):
+    db = _make_db_with_jobs(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """INSERT INTO speculative_requests (company, status, briefing_md, role_cards_json, briefing_folder)
+           VALUES ('PSI', 'ready_for_review', '# b', ?, 'PSI_SPECULATIVE_2026-04-28_140000')""",
+        (
+            _json.dumps(
+                [
+                    {
+                        "title": "Eng A",
+                        "description": "D",
+                        "why_this_fits_candidate": "W",
+                        "likely_team_or_org": "T",
+                        "suggested_contact_type": "recruiter",
+                    },
+                    {
+                        "title": "Eng B",
+                        "description": "D",
+                        "why_this_fits_candidate": "W",
+                        "likely_team_or_org": "T",
+                        "suggested_contact_type": "recruiter",
+                    },
+                ]
+            ),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    app = _make_app(db)
+    client = TestClient(app)
+    resp = client.post("/speculative/approve/1", data={"keep": ["1"]}, follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/board/"
+
+    conn = sqlite3.connect(str(db))
+    titles = [r[0] for r in conn.execute("SELECT title FROM jobs").fetchall()]
+    assert titles == ["[SPEC] Eng B"]
+
+
+def test_trash_marks_status_and_redirects_to_ingest(tmp_path):
+    db = _make_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute("INSERT INTO speculative_requests (company, status) VALUES ('PSI', 'ready_for_review')")
+    conn.commit()
+    conn.close()
+
+    app = _make_app(db)
+    client = TestClient(app)
+    resp = client.post("/speculative/trash/1", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/ingest/"
+    conn = sqlite3.connect(str(db))
+    assert conn.execute("SELECT status FROM speculative_requests").fetchone()[0] == "trashed"
+
+
+def test_regenerate_409_when_research_already_in_flight(tmp_path):
+    db = _make_db(tmp_path)
+    conn = sqlite3.connect(str(db))
+    conn.execute("INSERT INTO speculative_requests (company, status) VALUES ('PSI', 'researching')")
+    conn.commit()
+    conn.close()
+
+    app = _make_app(db)
+    client = TestClient(app)
+    with patch("findajob.web.routes.speculative.subprocess.Popen") as mock_popen:
+        resp = client.post("/speculative/regenerate/1", follow_redirects=False)
+    assert resp.status_code == 409
+    assert mock_popen.call_count == 0

--- a/tests/test_web_ingest.py
+++ b/tests/test_web_ingest.py
@@ -60,6 +60,17 @@ CREATE TABLE feedback_log (
     jd_excerpt TEXT DEFAULT '',
     created_at TEXT DEFAULT (datetime('now'))
 );
+
+CREATE TABLE speculative_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company TEXT NOT NULL,
+    hint TEXT,
+    personal_notes TEXT,
+    status TEXT NOT NULL DEFAULT 'researching',
+    submitted_at TEXT NOT NULL DEFAULT (datetime('now')),
+    research_completed_at TEXT,
+    approved_at TEXT
+);
 """
 
 _VALID_FORM: dict[str, str] = {
@@ -127,8 +138,9 @@ def test_get_renders_form(client: TestClient) -> None:
     html = resp.text
     assert 'id="manual-ingest-form"' in html
     assert 'hx-post="/ingest/manual"' in html
-    # Speculative mode stub must be present so #131 slots in cleanly.
-    assert "#131" in html
+    # Speculative mode (#131) is now wired — toggle and form should be present.
+    assert 'action="/ingest/speculative"' in html
+    assert "Submit speculative" in html
 
 
 def test_post_success_inserts_row(client: TestClient, popen_calls) -> None:


### PR DESCRIPTION
## Summary

- New routes module `src/findajob/web/routes/speculative.py` with 7 endpoints (POST /ingest/speculative, GET /speculative/status/{id} + /poll, GET /speculative/review/{id}, POST /speculative/{approve,regenerate,trash}/{id}).
- Status page polls every 5s via HTMX; on `ready_for_review` auto-redirects to review.
- Review page renders briefing markdown via the shared `render_markdown` helper + role cards with default-checked Keep boxes; one form, three submit buttons via `formaction`.
- `/ingest/` form gets an Alpine-driven Real-posting / Speculative mode toggle. Speculative form has soft-warn when today's submission count > 0 (no hard cap, per Decision R2).
- 9 new route tests with FastAPI TestClient + temp DB.

This is **B3 of 4** for #131. After merge, the operator can submit through the form, watch research progress, and approve/regenerate/trash. B4 ships speculative-aware prep variants + sent-outreach button + watchdog branch + docs.

## Test plan

- [x] `uv run pytest -x` — 1100 passed
- [x] `uv run ruff format --check . && uv run ruff check .` — clean
- [x] `uv run mypy src/findajob` — clean
- [ ] Post-merge browser smoke (PSIQuantum + ai&) — covered by B4's whole-feature verification gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)