### PR TITLE
fix(speculative): opt forms out of hx-boost so 303 redirects navigate (#319)

### DIFF
--- a/src/findajob/web/templates/speculative/_status_fragment.html
+++ b/src/findajob/web/templates/speculative/_status_fragment.html
@@ -12,10 +12,10 @@
   <div class="rounded border p-4 bg-red-50">
     <div class="font-semibold">Research failed</div>
     <div class="mt-2 text-sm">{{ row.error_message or "(no error message recorded)" }}</div>
-    <form method="post" action="/speculative/regenerate/{{ row.id }}" class="mt-4">
+    <form method="post" action="/speculative/regenerate/{{ row.id }}" class="mt-4" hx-boost="false">
       <button type="submit" class="btn btn-primary">Retry</button>
     </form>
-    <form method="post" action="/speculative/trash/{{ row.id }}" class="mt-2">
+    <form method="post" action="/speculative/trash/{{ row.id }}" class="mt-2" hx-boost="false">
       <button type="submit" class="btn btn-secondary">Trash</button>
     </form>
   </div>

--- a/src/findajob/web/templates/speculative/review.html
+++ b/src/findajob/web/templates/speculative/review.html
@@ -10,7 +10,7 @@
   </details>
 
   <h2 class="text-xl font-semibold mb-3">Role cards ({{ cards|length }})</h2>
-  <form method="post" action="/speculative/approve/{{ row.id }}" class="space-y-4">
+  <form method="post" action="/speculative/approve/{{ row.id }}" class="space-y-4" hx-boost="false">
     {% for card in cards %}
       <div class="border rounded p-4">
         <label class="flex items-start gap-3">

--- a/tests/test_speculative_routes.py
+++ b/tests/test_speculative_routes.py
@@ -160,6 +160,9 @@ def test_poll_returns_fragment(tmp_path):
     assert resp.status_code == 200
     assert "Research failed" in resp.text
     assert "budget exceeded" in resp.text
+    # The retry/trash forms on the failed-status fragment must opt out of
+    # hx-boost so the 303 redirect navigates the browser (#319).
+    assert 'hx-boost="false"' in resp.text
 
 
 # ── T23: review page ─────────────────────────────────────────────────────
@@ -197,6 +200,9 @@ def test_get_review_renders_briefing_and_cards(tmp_path):
     assert "SiteOps" in resp.text
     # All cards default-checked (keep on by default)
     assert 'value="0" checked' in resp.text
+    # The form must opt out of hx-boost so the 303 redirect from approve/regenerate/trash
+    # is followed by the browser, not swallowed by HTMX (#319).
+    assert 'hx-boost="false"' in resp.text
 
 
 def test_get_review_redirects_when_not_ready(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #319. The `base.html` body has `hx-boost="true"` globally, so the speculative `<form method="post">` elements were getting intercepted by HTMX, which doesn't follow `Location` headers from a 303 the way a normal browser does. The redirect was swallowed; operator's browser stayed on the review page after Approve/Trash/Regenerate.

Three forms get `hx-boost="false"`:
- `review.html` — the approve/regenerate/trash form (one form, three submit buttons via `formaction`)
- `_status_fragment.html` — the retry + trash forms shown on the `failed` status

Status page's outer HTMX poll div is unchanged — that's `hx-get` on a `<div>`, not affected.

## Test plan

- [x] Two regression assertions added: review page must contain `hx-boost="false"`; failed-status fragment must contain `hx-boost="false"`
- [x] `uv run pytest tests/test_speculative_routes.py -v` — 9/9 green
- [x] `uv run ruff check . && ruff format --check . && mypy src/findajob` — clean
- [ ] Post-merge verification: submit any speculative request through `/ingest/` Speculative tab → click each of Approve / Trash / Regenerate / Retry-on-failed → confirm browser navigates to expected destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)