### PR TITLE
fix(security): CI-side PII scan + diagnostic on pre-commit hook (#314)

### DIFF
--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -1,0 +1,79 @@
+name: PII Scan
+
+# Defense-in-depth complement to the local pre-commit hook (#314). The local
+# hook can fail silently — wrong git env, --no-verify, malformed patterns
+# array. This workflow scans the PR diff against patterns from a GitHub
+# Secret, so a defect in the local hook doesn't leave us unprotected.
+#
+# The secret PII_PATTERNS_REGEX holds one regex per line — same format as
+# the local hook's PATTERNS array (sans bash quoting). When unset (e.g. on
+# fork PRs that don't get repo secrets), the workflow logs a warning and
+# passes — failing closed on missing secrets would block external
+# contributions, and external contributors shouldn't have operator PII
+# anyway.
+#
+# Security note: the only ${{ }} interpolation in this file is
+# `${{ secrets.PII_PATTERNS_REGEX }}` which is passed via `env:` to the
+# shell rather than substituted into a run: command directly. No untrusted
+# input from event payloads (PR title/body/etc.) is used in any shell
+# command.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Diff PR against main
+        id: diff
+        run: |
+          set -euo pipefail
+          git fetch origin main:main 2>/dev/null || true
+          git diff origin/main...HEAD --diff-filter=ACMR -U0 \
+            | grep '^+' \
+            | grep -v '^+++' \
+            > /tmp/pr_added_lines.txt || true
+          line_count=$(wc -l < /tmp/pr_added_lines.txt)
+          echo "Scanning $line_count added lines"
+
+      - name: Scan against PII patterns
+        env:
+          PATTERNS: ${{ secrets.PII_PATTERNS_REGEX }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PATTERNS:-}" ]; then
+            echo "::warning::PII_PATTERNS_REGEX secret not set — skipping scan."
+            echo "::warning::Install per docs/setup/configure.md or this guard is inert."
+            exit 0
+          fi
+
+          if [ ! -s /tmp/pr_added_lines.txt ]; then
+            echo "No added lines in PR diff — nothing to scan."
+            exit 0
+          fi
+
+          found=0
+          while IFS= read -r pattern; do
+            [ -z "$pattern" ] && continue
+            case "$pattern" in '#'*) continue ;; esac
+
+            if grep -qiE "$pattern" /tmp/pr_added_lines.txt; then
+              echo "::error::PR diff matches PII pattern: $pattern"
+              found=1
+            fi
+          done <<< "$PATTERNS"
+
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "::error::One or more PII patterns matched. Find and remove the matching content."
+            echo "::error::To audit your branch locally: bash .git/hooks/pre-commit (after staging)."
+            exit 1
+          fi
+
+          echo "Clean — no PII matches in $(wc -l < /tmp/pr_added_lines.txt) added lines."

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -244,6 +244,39 @@ The hook should block it. Then unstage and delete the file.
 redact) and retry the commit. Do NOT use `--no-verify` to bypass except in emergencies —
 it defeats the whole purpose.
 
+**Diagnostic output:** As of #314, every hook run prints a one-line stderr summary
+(`pre-commit: PII scan: N patterns × M added lines`). If a commit lands without that
+line appearing — check `git config core.hooksPath`, that the hook is executable, and
+whether `--no-verify` was passed. The line is the canary for silent-fail conditions.
+
+### CI-side defense (defense-in-depth, #314)
+
+The local hook can fail silently (wrong git env, `--no-verify` slip, malformed
+PATTERNS). The `.github/workflows/pii-scan.yml` workflow scans every PR diff against
+the same patterns from a GitHub Secret, so a defect in the local hook doesn't leave
+the repo unprotected.
+
+**Install (one-time):** copy your local PATTERNS array into a GitHub Secret named
+`PII_PATTERNS_REGEX`. One regex per line, no quotes, no shell escaping:
+
+```bash
+# Extract just the pattern strings from your local hook (skip blank/comment lines):
+grep -E '^\s*"' .git/hooks/pre-commit | sed -E 's/^\s*"//;s/"\s*$//' > /tmp/pii-patterns.txt
+gh secret set PII_PATTERNS_REGEX < /tmp/pii-patterns.txt
+rm /tmp/pii-patterns.txt
+```
+
+**When unset:** the workflow logs a warning and passes (so external/fork PRs that
+can't access secrets aren't blocked — they shouldn't have operator PII anyway).
+
+**When set and any pattern matches:** the workflow fails the PR check; the matched
+pattern is printed in the run log (the matched line itself is NOT printed to avoid
+leaking the PII to public CI logs). Find the line locally, fix, push.
+
+**Updating patterns:** when you add a new beta tester or a new personal service
+handle to the local hook, re-run the install command above to push the updated
+list to the secret.
+
 See also `docs/GENERALIZATION.md` for the broader tracking of domain-specific content that
 should not land in tracked files.
 

--- a/docs/setup/pre-commit-hook.example.sh
+++ b/docs/setup/pre-commit-hook.example.sh
@@ -52,6 +52,13 @@ PATTERNS=(
 # ── Check staged content ──────────────────────────────────────────────────────
 STAGED=$(git diff --cached --diff-filter=ACMR -U0 | grep '^+' | grep -v '^+++' || true)
 
+# Diagnostic line — makes silent failures visible (#314). If a commit with PII
+# ever slips through, check whether this line printed at all in your terminal
+# (or whether --no-verify was used). The line is the canary for silent-fail
+# conditions.
+ADDED_LINE_COUNT=$(echo -n "$STAGED" | grep -c '^+' || true)
+echo "pre-commit: PII scan: ${#PATTERNS[@]} patterns × ${ADDED_LINE_COUNT:-0} added lines" >&2
+
 FOUND=0
 for pattern in "${PATTERNS[@]}"; do
     # Skip empty patterns (all commented out is fine)


### PR DESCRIPTION
## Summary

Closes #314. Three layers of defense to address the original observation that two CHANGELOG additions containing operator's first name committed cleanly during #258 release prep despite the hook's PATTERNS array including `\bBrock\b`.

**Repro result:** the hook fires correctly in current testing (direct invocation + `git commit` both blocked when staging tracked-file content with "Brock"). The original silent-fail conditions remain unidentified — most likely candidates are `--no-verify` slip or a one-time env quirk. Defense-in-depth is the right response either way.

### What's added

1. **CI-side PR-diff scan** — new `.github/workflows/pii-scan.yml`. Runs on every PR, reads patterns from GitHub Secret `PII_PATTERNS_REGEX`, scans the PR diff. When the secret is unset (fork PRs), warns and passes. When set and any pattern matches, fails the check; the matched pattern is printed but NOT the matched line itself (no leaking PII to public CI logs).

2. **Diagnostic stderr line on the local hook** — every run now prints `pre-commit: PII scan: N patterns × M added lines`. Silent-fail conditions are now observable: if a commit lands without that line, `core.hooksPath` / executable-bit / `--no-verify` are the suspects.

3. **Setup docs** — `docs/setup/configure.md` gets the secret-install recipe + explains the diagnostic line. The example hook (`docs/setup/pre-commit-hook.example.sh`) gains the diagnostic line so fresh installs inherit it.

### Operator action required after merge

Set the GitHub Secret so the workflow has patterns to scan:

```bash
grep -E '^\s*"' .git/hooks/pre-commit | sed -E 's/^\s*"//;s/"\s*$//' > /tmp/pii-patterns.txt
gh secret set PII_PATTERNS_REGEX < /tmp/pii-patterns.txt
rm /tmp/pii-patterns.txt
```

Until the secret is set, the workflow logs a warning on every PR but doesn't block — by design, so this PR itself merges cleanly.

### Test plan

- [x] `uv run pytest -x` — 1108 passed
- [x] `uv run ruff format --check . && ruff check .` — clean
- [x] Direct hook invocation with staged "Brock" content blocks correctly + diagnostic line prints
- [ ] Post-merge: set the secret per recipe above; verify the workflow runs (and passes) on a clean PR; verify it fails on a deliberately PII-containing test PR (then close the test PR without merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)