### PR TITLE
fix(web): SPEC title link + ENUM/DATE filter Apply + materials fallback

### DIFF
--- a/src/findajob/web/routes/materials.py
+++ b/src/findajob/web/routes/materials.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse
+from fastapi.responses import FileResponse, HTMLResponse, PlainTextResponse, RedirectResponse
 
 from findajob.web.folder_resolver import resolve_folder
 from findajob.web.markdown import render_markdown
@@ -64,6 +64,11 @@ def folder_view(
     root: Path = request.app.state.companies_root
     folder = resolve_folder(fingerprint, db, root)
     if folder is None:
+        # Synthetic rows have no prep folder until flag-for-prep — surface the
+        # role-card description (raw_jd_text) instead of dead-ending.
+        synth_row = db.execute("SELECT synthetic FROM jobs WHERE fingerprint = ?", (fingerprint,)).fetchone()
+        if synth_row is not None and synth_row["synthetic"]:
+            return RedirectResponse(url=f"/jobs/{fingerprint}/jd", status_code=303)
         raise HTTPException(status_code=404, detail="folder not found")
     row = db.execute("SELECT title, company, stage FROM jobs WHERE fingerprint = ?", (fingerprint,)).fetchone()
     files = sorted(p.name for p in folder.iterdir() if p.is_file())
@@ -79,6 +84,30 @@ def folder_view(
             "stage": row["stage"] if row else "",
             "files": files,
         },
+    )
+
+
+@router.get("/jobs/{fingerprint}/jd", response_class=HTMLResponse)
+def jd_view(
+    fingerprint: str,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    row = db.execute(
+        "SELECT title, company, raw_jd_text FROM jobs WHERE fingerprint = ?",
+        (fingerprint,),
+    ).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    body = (row["raw_jd_text"] or "").strip()
+    header = f"# {row['title']}\n\n_{row['company']}_\n\n---\n\n"
+    md = header + (body if body else "_No JD text on file._")
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="base.html",
+        context={"_rendered_md": render_markdown(md)},
+        headers={"content-type": "text/html; charset=utf-8"},
     )
 
 

--- a/src/findajob/web/routes/materials.py
+++ b/src/findajob/web/routes/materials.py
@@ -55,12 +55,12 @@ def materials_index(request: Request, db: sqlite3.Connection = Depends(get_db)) 
     )
 
 
-@router.get("/materials/{fingerprint}", response_class=HTMLResponse)
+@router.get("/materials/{fingerprint}", response_class=HTMLResponse, response_model=None)
 def folder_view(
     fingerprint: str,
     request: Request,
     db: sqlite3.Connection = Depends(get_db),  # noqa: B008
-) -> HTMLResponse:
+) -> HTMLResponse | RedirectResponse:
     root: Path = request.app.state.companies_root
     folder = resolve_folder(fingerprint, db, root)
     if folder is None:

--- a/src/findajob/web/templates/_job_row.html
+++ b/src/findajob/web/templates/_job_row.html
@@ -36,10 +36,10 @@
                {% if field == 'known_contacts' and row[field] %}cell-contact-amber{% endif %}
                {% if field == 'remote_status' %}{{ remote_cell_class(row[field]) }}{% endif %}">
       <div class="cell-text-wrap" title="{{ row[field] if row[field] is not none else '' }}">
-      {% if field == 'title' and row.url %}
-        {% if row[field] and row[field].startswith('[SPEC]') %}
-          <span class="inline-block mr-1 px-1.5 py-0.5 text-[10px] font-bold uppercase bg-purple-100 text-purple-800 rounded align-middle">SPEC</span>
-        {% endif %}
+      {% if field == 'title' and row[field] and row[field].startswith('[SPEC]') %}
+        <span class="inline-block mr-1 px-1.5 py-0.5 text-[10px] font-bold uppercase bg-purple-100 text-purple-800 rounded align-middle">SPEC</span>
+        <a class="underline" href="/jobs/{{ row.fingerprint }}/jd">{{ row[field] }}</a>
+      {% elif field == 'title' and row.url %}
         <a class="underline" href="{{ row.url }}" target="_blank" rel="noopener noreferrer">{{ row[field] }}</a>
       {% elif field == 'company' and row.fingerprint and row.stage in folder_stages and materials_base_url %}
         <a class="underline" href="{{ materials_base_url }}/materials/{{ row.fingerprint }}">{{ row[field] }}</a>

--- a/src/findajob/web/templates/_table_header.html
+++ b/src/findajob/web/templates/_table_header.html
@@ -98,7 +98,13 @@
                    name="{{ s.name }}"
                    data-filter-input
                    value="{{ picks | join(',') }}"
-                   data-popover-target="{{ s.name }}">
+                   data-popover-target="{{ s.name }}"
+                   hx-get="{{ rows_url }}"
+                   hx-trigger="change"
+                   hx-target="#rows"
+                   hx-swap="innerHTML"
+                   hx-include="[data-filter-input]"
+                   hx-push-url="true">
             <div x-show="open"
                  x-cloak
                  @click.outside="open = false"
@@ -140,7 +146,13 @@
                    name="{{ s.name }}_from"
                    data-filter-input
                    value="{{ d_from or '' }}"
-                   data-popover-target="{{ s.name }}_from">
+                   data-popover-target="{{ s.name }}_from"
+                   hx-get="{{ rows_url }}"
+                   hx-trigger="change"
+                   hx-target="#rows"
+                   hx-swap="innerHTML"
+                   hx-include="[data-filter-input]"
+                   hx-push-url="true">
             <input type="hidden"
                    name="{{ s.name }}_to"
                    data-filter-input

--- a/tests/test_table_header_render.py
+++ b/tests/test_table_header_render.py
@@ -57,3 +57,41 @@ def test_table_header_renders_filter_row(tmp_path) -> None:
     # HTMX wiring present.
     assert 'hx-get="/board/dashboard/rows"' in rendered
     assert 'hx-push-url="true"' in rendered
+
+
+def test_enum_hidden_input_has_htmx_change_trigger(tmp_path) -> None:
+    """ENUM popover Apply commits to a hidden input via htmx.trigger(_, 'change');
+    that hidden input must carry hx-trigger='change' or the request never fires.
+    Regression for the ENUM filter no-op bug."""
+    from findajob.web.app import create_app
+
+    app = create_app(
+        companies_root=tmp_path / "companies",
+        db_path=tmp_path / "pipeline.db",
+    )
+    templates = app.state.templates
+    specs = (
+        ColumnSpec(
+            name="stage",
+            label="Stage",
+            kind=Kind.ENUM,
+            enum_values=("applied", "interview", "offer"),
+        ),
+    )
+    parsed = ParsedFilters()
+
+    class _StubReq:
+        class url:
+            path = "/board/applied"
+
+    rendered = templates.get_template("_table_header.html").render(
+        request=_StubReq, specs=specs, parsed=parsed, visible={"stage"}, leading_cols=[]
+    )
+    # Find the hidden input for stage and assert it carries htmx attrs.
+    hidden_marker = 'data-popover-target="stage"'
+    assert hidden_marker in rendered
+    # Slice the input element and check inside it.
+    start = rendered.index(hidden_marker)
+    chunk = rendered[max(0, start - 400) : start + 400]
+    assert 'hx-trigger="change"' in chunk
+    assert 'hx-get="/board/applied/rows"' in chunk

--- a/tests/test_web_board_dashboard.py
+++ b/tests/test_web_board_dashboard.py
@@ -93,3 +93,121 @@ def test_dashboard_title_links_to_job_url(client: TestClient) -> None:
     assert 'href="https://example.com/meta-dc-ops"' in r.text
     assert 'target="_blank"' in r.text
     assert 'rel="noopener noreferrer"' in r.text
+
+
+def test_speculative_title_links_to_internal_jd_viewer(tmp_path: Path) -> None:
+    """[SPEC]-prefixed rows must NOT render the speculative:// sentinel as an href.
+    Regression for the title-click-goes-nowhere bug."""
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, interview_likelihood INTEGER, "
+        "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
+        "ai_notes TEXT, raw_jd_text TEXT, created_at TEXT, stage_updated TEXT, url TEXT, "
+        "prep_folder_path TEXT, synthetic INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, title, company, stage, relevance_score, url, raw_jd_text, synthetic) "
+        "VALUES ('spec1','[SPEC] Director of Capacity','Anthropic','scored',7,"
+        "'speculative://Anthropic/0/42','Lead capacity planning for clusters.', 1)"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    client = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = client.get("/board/dashboard")
+    assert r.status_code == 200
+    assert "speculative://" not in r.text  # sentinel must not leak as href
+    assert 'href="/jobs/spec1/jd"' in r.text
+
+
+def test_jd_viewer_renders_raw_jd_text(tmp_path: Path) -> None:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, interview_likelihood INTEGER, "
+        "location TEXT, remote_status TEXT, known_contacts TEXT, comp_estimate TEXT, "
+        "ai_notes TEXT, raw_jd_text TEXT, created_at TEXT, stage_updated TEXT, url TEXT, "
+        "prep_folder_path TEXT, synthetic INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, title, company, stage, raw_jd_text, synthetic) "
+        "VALUES ('spec1','[SPEC] Director of Capacity','Anthropic','scored',"
+        "'Lead capacity planning for clusters.', 1)"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    client = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = client.get("/jobs/spec1/jd")
+    assert r.status_code == 200
+    assert "Director of Capacity" in r.text
+    assert "Anthropic" in r.text
+    assert "Lead capacity planning for clusters." in r.text
+
+
+def test_materials_redirects_synthetic_row_to_jd_viewer(tmp_path: Path) -> None:
+    """Synthetic rows have no prep_folder_path until flag-for-prep; /materials/{fp}
+    must redirect to the JD viewer instead of 404ing."""
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "raw_jd_text TEXT, prep_folder_path TEXT, synthetic INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, title, company, stage, raw_jd_text, synthetic) "
+        "VALUES ('spec1','[SPEC] Director','Anthropic','scored','Lead capacity.', 1)"
+    )
+    # Real job with no prep folder — must still 404, not redirect.
+    conn.execute(
+        "INSERT INTO jobs (fingerprint, title, company, stage, raw_jd_text, synthetic) "
+        "VALUES ('real1','Director','Acme','scored','Real JD.', 0)"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    client = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = client.get("/materials/spec1", follow_redirects=False)
+    assert r.status_code == 303
+    assert r.headers["location"] == "/jobs/spec1/jd"
+
+    r = client.get("/materials/real1", follow_redirects=False)
+    assert r.status_code == 404
+
+
+def test_jd_viewer_404_for_unknown_fingerprint(tmp_path: Path) -> None:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "raw_jd_text TEXT, synthetic INTEGER DEFAULT 0)"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    client = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = client.get("/jobs/nope/jd")
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

Three small UI bugs surfaced while exploring the board:

- **SPEC title click went nowhere.** Speculative jobs ship with a sentinel `url='speculative://…'` from the approver, but `_job_row.html` rendered it as an `<a href>`. Browser couldn't navigate the scheme. Now `[SPEC]`-prefixed titles link to a new tiny viewer **`GET /jobs/{fp}/jd`** that renders `raw_jd_text` (the role-card description) as Markdown.
- **ENUM/DATE filter Apply was a silent no-op.** `filters.js` fires `htmx.trigger(hidden, 'change')` after Apply, but the hidden inputs had no `hx-*` attrs, so htmx ignored the event. Mirrored the text/number-input HTMX contract on the hidden ENUM input and the date `_from` input.
- **`/materials/{fp}` 404'd for in-flight speculative rows.** Synthetic jobs have no `prep_folder_path` until flag-for-prep. Now 303-redirects synthetic rows to `/jobs/{fp}/jd`. Real-job 404 path unchanged.

4 new regression tests across `test_table_header_render.py` and `test_web_board_dashboard.py`. 1113 tests pass; ruff clean.

## Test plan

- [ ] On `/board/dashboard` (or wherever a `[SPEC]` row lives), click the title — expect `/jobs/{fp}/jd` with the role description rendered as Markdown.
- [ ] On `/board/applied`, open the Stage column filter popover, check a box, click Apply — expect URL to gain `?stage=…` and rows to refresh.
- [ ] Same on a DATE filter — pick a from date, Apply — expect URL gains `?<col>_from=…` and rows refresh.
- [ ] Hit `/materials/{fp}` for an in-flight `[SPEC]` job — expect 303 to `/jobs/{fp}/jd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)