### PR TITLE
fix(interview_prep): treat orphaned sentinels as stale (closes #312)

### DIFF
--- a/scripts/interview_prep.py
+++ b/scripts/interview_prep.py
@@ -18,6 +18,7 @@ import re
 import sqlite3
 import subprocess
 import sys
+import time
 from datetime import datetime
 
 from findajob.paths import AICHAT, BASE, PANDOC
@@ -33,6 +34,40 @@ PROFILE_PATH = f"{BASE}/candidate_context/profile.md"
 MASTER_RESUME_PATH = f"{BASE}/candidate_context/master_resume.md"
 
 SENTINEL_NAME = ".interview_prep_in_progress"
+# Treat any sentinel older than this as orphaned from a killed run.
+# Well above typical Opus 4.7 generation time (~2 min observed) but well below
+# the operator-noticing threshold for a stuck Interviewing button.
+SENTINEL_STALE_AFTER_SECONDS = 600
+
+
+def _sentinel_blocks_run(sentinel_path: str, *, log_kwargs: dict[str, object]) -> bool:
+    """Return True iff a fresh in-flight sentinel exists at ``sentinel_path``.
+
+    A sentinel older than ``SENTINEL_STALE_AFTER_SECONDS`` is treated as
+    orphaned from a killed run: removed in place and a
+    ``interview_prep_sentinel_stale_removed`` event logged so the recovery
+    is auditable in pipeline.jsonl. Returns False after removal so the
+    caller proceeds.
+    """
+    if not os.path.exists(sentinel_path):
+        return False
+    try:
+        age = time.time() - os.path.getmtime(sentinel_path)
+    except OSError:
+        return False
+    if age < SENTINEL_STALE_AFTER_SECONDS:
+        return True
+    log_event(
+        "interview_prep_sentinel_stale_removed",
+        age_seconds=int(age),
+        **log_kwargs,
+    )
+    try:
+        os.remove(sentinel_path)
+    except OSError:
+        pass
+    return False
+
 
 load_env()
 
@@ -141,16 +176,16 @@ def main() -> None:
         notify(f"INTERVIEW PREP SKIPPED: {company} — {title}\nNo prep folder; apply was likely manual.")
         return
 
-    # ── Concurrency guard: refuse if a run is already in flight for this folder ──
+    # ── Concurrency guard: refuse if a fresh run is already in flight for this folder ──
     sentinel = os.path.join(prep_folder, SENTINEL_NAME)
-    if os.path.exists(sentinel):
-        log_event(
-            "interview_prep_skipped_in_flight",
-            job_id=job_id,
-            company=company,
-            title=title,
-            folder=prep_folder,
-        )
+    log_kwargs: dict[str, object] = {
+        "job_id": job_id,
+        "company": company,
+        "title": title,
+        "folder": prep_folder,
+    }
+    if _sentinel_blocks_run(sentinel, log_kwargs=log_kwargs):
+        log_event("interview_prep_skipped_in_flight", **log_kwargs)
         return
 
     # Touch sentinel; remove on exit.

--- a/tests/test_interview_prep_sentinel.py
+++ b/tests/test_interview_prep_sentinel.py
@@ -1,0 +1,53 @@
+"""Stale-sentinel handling for scripts/interview_prep.py (#312)."""
+
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+# scripts/ isn't on sys.path by default; tests need interview_prep importable.
+SCRIPTS = Path(__file__).parent.parent / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import interview_prep  # noqa: E402
+
+
+def test_sentinel_missing_does_not_block(tmp_path: Path) -> None:
+    sentinel = tmp_path / interview_prep.SENTINEL_NAME
+    assert interview_prep._sentinel_blocks_run(str(sentinel), log_kwargs={"job_id": "j1"}) is False
+
+
+def test_fresh_sentinel_blocks(tmp_path: Path) -> None:
+    sentinel = tmp_path / interview_prep.SENTINEL_NAME
+    sentinel.write_text("just started")
+    # mtime is `now` from the write — well under STALE_AFTER_SECONDS.
+    assert interview_prep._sentinel_blocks_run(str(sentinel), log_kwargs={"job_id": "j1"}) is True
+    assert sentinel.exists()  # fresh sentinel must NOT be removed
+
+
+def test_stale_sentinel_removed_and_does_not_block(tmp_path: Path) -> None:
+    sentinel = tmp_path / interview_prep.SENTINEL_NAME
+    sentinel.write_text("orphaned by kill -9 long ago")
+    # Backdate mtime to STALE_AFTER_SECONDS + 1 minute ago.
+    stale_mtime = time.time() - (interview_prep.SENTINEL_STALE_AFTER_SECONDS + 60)
+    os.utime(sentinel, (stale_mtime, stale_mtime))
+
+    with patch.object(interview_prep, "log_event") as mock_log:
+        result = interview_prep._sentinel_blocks_run(
+            str(sentinel),
+            log_kwargs={"job_id": "j1", "company": "Anthropic", "title": "Director"},
+        )
+
+    assert result is False
+    assert not sentinel.exists()  # stale sentinel must be removed in place
+    # Audit event must fire so pipeline.jsonl shows the recovery.
+    assert mock_log.called
+    event_name = mock_log.call_args[0][0]
+    assert event_name == "interview_prep_sentinel_stale_removed"
+    kwargs = mock_log.call_args[1]
+    assert kwargs.get("job_id") == "j1"
+    assert kwargs.get("company") == "Anthropic"
+    assert isinstance(kwargs.get("age_seconds"), int)
+    assert kwargs["age_seconds"] >= interview_prep.SENTINEL_STALE_AFTER_SECONDS


### PR DESCRIPTION
## Summary

- `scripts/interview_prep.py` wrote `.interview_prep_in_progress` at start and removed it in `finally`. A process killed before cleanup (OOM, kill -9, container restart) left the sentinel in place forever — every future Interviewing click for that job became a silent no-op.
- Existence-check now reads mtime; anything older than `SENTINEL_STALE_AFTER_SECONDS` (600s) is treated as orphaned, removed in place, and emits `interview_prep_sentinel_stale_removed` to `pipeline.jsonl` so the recovery is auditable. Fresh sentinels still short-circuit as before.
- Logic factored into `_sentinel_blocks_run()` for isolated unit testing. 3 new tests in `tests/test_interview_prep_sentinel.py` cover missing / fresh / stale paths.

Closes #312.

## Test plan

- [ ] `uv run pytest tests/test_interview_prep_sentinel.py -v` — 3 new tests pass.
- [ ] Full suite (`uv run pytest`) green.
- [ ] On docker.lan: drop a stale sentinel into a real prep folder (`touch -d "20 minutes ago" companies/<folder>/.interview_prep_in_progress`), click Interviewing on the board, confirm the run proceeds and `pipeline.jsonl` shows the `interview_prep_sentinel_stale_removed` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)