### PR TITLE
Optional HTTP Basic Auth middleware for internet-exposed findajob instances (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **Optional HTTP Basic Auth on the findajob web UI for internet-exposed instances (#327).** Per-tester instances reachable at `https://findajob-{tester}.example.com` no longer have to rely on the Wireguard perimeter alone. New FastAPI middleware (`findajob.web.auth.BasicAuthMiddleware`) gates every request to the web UI behind HTTP Basic Auth when `FINDAJOB_AUTH_USER` and `FINDAJOB_AUTH_PASS` env vars are both set; allowlist for `/healthz`, `/static/*`, and `/favicon.ico` so health checks and the auth-prompt page itself still render. Constant-time credential compare via `hmac.compare_digest`. When env vars are unset the middleware is not installed at all — Wireguard-only deployments and local-dev loops are unchanged. Threat model is drive-by scanning of the open internet (TLS terminates upstream, Firewalla/equivalent restricts geography); per-user identity / RBAC remains intentionally out of scope. New pattern doc at `docs/setup/internet-exposure.md` (also reachable at `/docs/setup/internet-exposure` in-app). Roadmap Decision 16 supersedes Decision 3 for the public-exposure case. 14-test canary suite at `tests/test_web_basic_auth.py` — including a check that the gate fires for protected routes — guards against accidental middleware-order regressions in `app.py`.
+
 ## [0.6.1] — 2026-04-28
 
 Patch bump. Two small bugfix PRs against board interactions. Bugfix-only — operators pinned to `:v0.6` pick this up automatically on `docker compose pull && up -d`. No migration required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,12 @@ Foundational decisions (from `docs/superpowers/specs/2026-04-21-web-frontend-14b
 
 `/config/` is the in-browser editor for the pipeline's editable config files (profile,
 master resume, prefilter rules, search queries, feed URLs, role prompts) with an
-explicit allowlist; no auth, consistent with the Wireguard perimeter model. See
-`findajob.web.config_files` for the allowlist definition (#149).
+explicit allowlist. There is no per-user authorization inside findajob — anyone the
+perimeter lets in can edit pipeline config. The default perimeter is Wireguard-only;
+internet-exposed per-tester instances additionally gate the entire web UI behind HTTP
+Basic Auth via the `FINDAJOB_AUTH_USER` / `FINDAJOB_AUTH_PASS` env vars (see
+`findajob.web.auth` and `docs/setup/internet-exposure.md` (#327)). See
+`findajob.web.config_files` for the `/config/` allowlist definition (#149).
 
 `/onboarding/` is the first-run NUX + paste-back injector for the interview
 emitted by `config/roles/onboarding_interviewer.md`. A FastAPI dependency on

--- a/data/.env.example
+++ b/data/.env.example
@@ -20,3 +20,11 @@ NTFY_TOPIC=your-ntfy-topic             # Create a topic at ntfy.sh (or self-host
 # ── Google Sheets ─────────────────────────────────────────────────────────────
 # Service account credentials go in config/gsheets_creds.json (gitignored)
 # Sheet ID goes in config/sheet_id.txt (gitignored)
+
+# ── Optional: HTTP Basic Auth for internet-exposed instances (#327) ──────────
+# Set both to gate the findajob web UI behind HTTP Basic Auth. Intended for
+# per-tester instances reachable on the public internet. When either is unset
+# (or empty), no authentication is enforced — fine for Wireguard-only or
+# loopback deployments. See docs/setup/internet-exposure.md.
+FINDAJOB_AUTH_USER=                    # leave empty to disable auth
+FINDAJOB_AUTH_PASS=                    # leave empty to disable auth

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,10 +56,11 @@ Append-only. Numbers are stable references. Amend an entry in place only for fac
 13. **User-facing documentation — split planned.** The umbrella scope is too broad for one issue. Plan: three focused issues, each paired with the shipping work that makes the doc concrete — (a) day-1 Dashboard usage guide paired with Phase 4 tester deploy, (b) tuning guide paired with first feedback-calibration cycle, (c) troubleshooting guide paired with first real tester failure.
 14. **Post-GA milestone split (2026-04-24).** Post-GA Hardening grab-bag replaced with four dated release milestones (v1.1 / v1.2 / v1.3 / v1.4 — see "Post-GA horizon" below). Driven by a structural review: the single grab-bag milestone couldn't pass the one-sentence-deliverable test, and the Roadmap view showed no visible arc past GA. v1.4 (Funnel + Triage UX) precedes v1.2/v1.3 because active-operator triage friction is the binding constraint on the daily job-search loop.
 15. **Umbrella-epic convention (2026-04-24).** GitHub's native sub-issue field is the canonical parent-child relationship for grouping related work (example: #228 tuning loop → #229/#230/#231; #239 credentials hygiene → #67/#225; #240 cost observability → #48/#87). Epics are `enhancement`-labeled, Medium priority, and live on the board like any other issue — not labels, not milestones. Milestones are release boundaries; epics are thematic groupings that may span milestones.
+16. **Optional HTTP Basic Auth for internet-exposed instances (2026-04-28, supersedes #3 for the public-exposure case).** A FastAPI middleware (`findajob.web.auth`) gates the entire web UI behind shared-secret HTTP Basic Auth when `FINDAJOB_AUTH_USER` / `FINDAJOB_AUTH_PASS` env vars are both set, with `/healthz`, `/static/*`, and `/favicon.ico` allowlisted. When env vars are unset the middleware is a no-op — Wireguard-only deployments are unchanged. Intended for per-tester instances at `findajob-{tester}.example.com`; defends against drive-by scanning, not against a determined adversary. Real per-user identity / RBAC remains out of scope (still a future change). See `docs/setup/internet-exposure.md` (#327).
 
 ### Scope out (explicit)
 
-- Public web access / app-level auth (follow-up if demand materializes).
+- Per-user identity / RBAC inside findajob — Decision 16 added shared-secret auth, not identity.
 - Separate rclone-replacement project.
 - Manual RAG source document editing.
 - Alternative LLM provider exploration.

--- a/docs/setup/internet-exposure.md
+++ b/docs/setup/internet-exposure.md
@@ -1,0 +1,96 @@
+# Exposing findajob to the public internet
+
+By default findajob has no authentication. That is fine when access is restricted by the network perimeter (Wireguard, loopback, lab network). To expose a per-tester instance to the public internet — for example at `https://findajob-{tester}.example.com` — turn on HTTP Basic Auth via two env vars.
+
+## Threat model
+
+This is **shared-secret authentication**, not an identity system. It defends against:
+
+- Drive-by scanning of the open internet
+- Indexing by search engines and archive crawlers
+- Casual probing by anyone who happens to learn the URL
+
+It does **not** defend against:
+
+- A determined attacker who learns the credential
+- A compromised tester endpoint (the password lives in `compose.yaml` plaintext)
+- Anything your reverse proxy + TLS layer don't already handle
+
+For real per-user identity (RBAC, 2FA, OIDC), a dedicated auth layer is needed. That is intentionally out of scope here — it is a separate, future change.
+
+## Topology
+
+```
+https://findajob-{tester}.example.com
+        ↓
+   Geo-IP filter (e.g. Firewalla, restrict to expected regions)
+        ↓
+   Reverse proxy (TLS termination — e.g. Synology DSM)
+        ↓
+   docker.lan:<per-tester-port>
+        ↓
+   FastAPI BasicAuthMiddleware  ← this layer
+        ↓
+   findajob route handlers
+```
+
+The middleware sits inside the findajob FastAPI app. There is no separate auth LXC — auth ships with the app, gated on env vars.
+
+## Setup
+
+1. **Generate a strong password per tester** (≥24 chars):
+
+       openssl rand -base64 32
+
+2. **Set the env vars in that tester's `compose.yaml`**:
+
+       services:
+         scheduler:
+           environment:
+             FINDAJOB_AUTH_USER: alice
+             FINDAJOB_AUTH_PASS: <long-random-string>
+
+3. **Apply**:
+
+       docker compose up -d
+
+4. **Verify the gate is on**:
+
+       curl -I https://findajob-alice.example.com/
+
+   Expected: `401 Unauthorized` with `WWW-Authenticate: Basic realm="findajob"`.
+
+5. **Verify the credential works**:
+
+       curl -I -u alice:<password> https://findajob-alice.example.com/
+
+   Expected: `200 OK`.
+
+6. **Wire the reverse proxy**: in your reverse-proxy UI (Synology DSM, etc.) point `findajob-alice.example.com` at `docker.lan:<port>`.
+
+## Allowlist
+
+Three paths bypass the auth gate even when the env vars are set:
+
+- `/healthz` — health checks; no PII; needed by the reverse proxy and any monitoring.
+- `/static/*` — CSS/JS the browser must fetch *before* it can render the auth-prompt page. Contains no PII.
+- `/favicon.ico` — same rationale as `/static/`.
+
+Every other path requires the credential.
+
+## Rotation
+
+To rotate a tester's credential:
+
+1. Edit `FINDAJOB_AUTH_PASS` in their `compose.yaml`.
+2. `docker compose up -d` on that stack — the container restarts with the new credential.
+3. Notify the tester out-of-band.
+
+## Disabling
+
+Remove (or empty) `FINDAJOB_AUTH_USER` / `FINDAJOB_AUTH_PASS` and `docker compose up -d`. The middleware becomes a no-op and all requests pass through.
+
+## What this does not change
+
+- **Wireguard access still works** for stacks that don't set the env vars (the operator's own deployment, for instance). The middleware is opt-in per stack.
+- **`/config/` is still un-rate-limited and trusts whoever the gate let in.** This is per-instance auth, not per-user authorization. Anyone holding the credential can edit pipeline config.

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -12,6 +12,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from findajob.web.auth import install_basic_auth
 from findajob.web.constants import FOLDER_STAGES
 from findajob.web.helpers import (
     applied_age_bucket,
@@ -68,6 +69,7 @@ def create_app(
 
     app.dependency_overrides.setdefault(_materials_routes.get_db, get_db)
     app.include_router(_aggregated_router)
+    install_basic_auth(app)
     return app
 
 

--- a/src/findajob/web/auth.py
+++ b/src/findajob/web/auth.py
@@ -1,0 +1,95 @@
+"""HTTP Basic Auth middleware for internet-exposed findajob instances (#327).
+
+Installed iff `FINDAJOB_AUTH_USER` and `FINDAJOB_AUTH_PASS` env vars are both
+set and non-empty. When unset, the middleware is not added at all and every
+request passes through. When set, every request to a non-allowlisted path
+must present matching HTTP Basic Auth credentials or gets 401.
+
+Threat model: drive-by scanning of internet-exposed per-tester instances
+(`findajob-{tester}.example.com`). Defense layers upstream are TLS
+termination + geo-IP restriction. This is shared-secret auth, not identity.
+"""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import os
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+_ALLOWLIST_PREFIXES: tuple[str, ...] = ("/static/",)
+_ALLOWLIST_EXACT: frozenset[str] = frozenset({"/healthz", "/favicon.ico"})
+
+
+class BasicAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        username: str,
+        password: str,
+        realm: str = "findajob",
+    ) -> None:
+        super().__init__(app)
+        self._username = username.encode("utf-8")
+        self._password = password.encode("utf-8")
+        self._challenge = f'Basic realm="{realm}"'
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if _is_allowlisted(request.url.path):
+            return await call_next(request)
+        if not self._authorized(request):
+            return Response(
+                content="Unauthorized",
+                status_code=401,
+                headers={"WWW-Authenticate": self._challenge},
+                media_type="text/plain",
+            )
+        return await call_next(request)
+
+    def _authorized(self, request: Request) -> bool:
+        header = request.headers.get("authorization", "")
+        if not header.lower().startswith("basic "):
+            return False
+        try:
+            decoded = base64.b64decode(header[6:].strip(), validate=True)
+        except ValueError:
+            return False
+        if b":" not in decoded:
+            return False
+        user, _, pw = decoded.partition(b":")
+        return hmac.compare_digest(user, self._username) and hmac.compare_digest(pw, self._password)
+
+
+def _is_allowlisted(path: str) -> bool:
+    if path in _ALLOWLIST_EXACT:
+        return True
+    return any(path.startswith(p) for p in _ALLOWLIST_PREFIXES)
+
+
+def install_basic_auth(
+    app: ASGIApp,
+    *,
+    username: str | None = None,
+    password: str | None = None,
+) -> bool:
+    """Add `BasicAuthMiddleware` to `app` iff credentials are present.
+
+    With no kwargs, reads `FINDAJOB_AUTH_USER` / `FINDAJOB_AUTH_PASS` from the
+    environment. Returns True when middleware was installed, False otherwise.
+    """
+    user = username if username is not None else os.environ.get("FINDAJOB_AUTH_USER", "")
+    pw = password if password is not None else os.environ.get("FINDAJOB_AUTH_PASS", "")
+    if not user or not pw:
+        return False
+    app.add_middleware(BasicAuthMiddleware, username=user, password=pw)  # type: ignore[attr-defined]
+    return True

--- a/src/findajob/web/auth.py
+++ b/src/findajob/web/auth.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import base64
 import hmac
+import logging
 import os
 from collections.abc import Awaitable, Callable
 
@@ -21,6 +22,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
 
 _ALLOWLIST_PREFIXES: tuple[str, ...] = ("/static/",)
 _ALLOWLIST_EXACT: frozenset[str] = frozenset({"/healthz", "/favicon.ico"})
@@ -86,10 +89,27 @@ def install_basic_auth(
 
     With no kwargs, reads `FINDAJOB_AUTH_USER` / `FINDAJOB_AUTH_PASS` from the
     environment. Returns True when middleware was installed, False otherwise.
+
+    Always emits one log line so the operator can grep startup logs to confirm
+    the auth state. Partial misconfiguration (only one var set) emits a
+    WARNING — silent fail-open on a typo'd compose.yaml is a real foot-gun for
+    internet-exposed instances and observability is the cheap defense.
     """
     user = username if username is not None else os.environ.get("FINDAJOB_AUTH_USER", "")
     pw = password if password is not None else os.environ.get("FINDAJOB_AUTH_PASS", "")
-    if not user or not pw:
+    if user and pw:
+        app.add_middleware(BasicAuthMiddleware, username=user, password=pw)  # type: ignore[attr-defined]
+        logger.info("basic auth: ENABLED (FINDAJOB_AUTH_USER + FINDAJOB_AUTH_PASS both set)")
+        return True
+    if user or pw:
+        which_set = "FINDAJOB_AUTH_USER" if user else "FINDAJOB_AUTH_PASS"
+        which_missing = "FINDAJOB_AUTH_PASS" if user else "FINDAJOB_AUTH_USER"
+        logger.warning(
+            "basic auth: DISABLED — %s is set but %s is empty. Set both to enable, "
+            "or unset both to silence this warning.",
+            which_set,
+            which_missing,
+        )
         return False
-    app.add_middleware(BasicAuthMiddleware, username=user, password=pw)  # type: ignore[attr-defined]
-    return True
+    logger.info("basic auth: DISABLED (no env vars set)")
+    return False

--- a/src/findajob/web/routes/docs.py
+++ b/src/findajob/web/routes/docs.py
@@ -25,6 +25,7 @@ _PAGES: dict[str, str] = {
     "setup/install-linux": "setup/install-linux.md",
     "setup/configure": "setup/configure.md",
     "setup/state-migration": "setup/state-migration.md",
+    "setup/internet-exposure": "setup/internet-exposure.md",
 }
 
 _INDEX_GUIDES = [

--- a/tests/test_web_basic_auth.py
+++ b/tests/test_web_basic_auth.py
@@ -8,6 +8,7 @@ these tests requires a deliberate review.
 from __future__ import annotations
 
 import base64
+import logging
 import sqlite3
 from pathlib import Path
 
@@ -110,22 +111,66 @@ def test_no_env_vars_means_no_auth(open_client: TestClient) -> None:
     assert r.status_code == 200
 
 
-def test_only_user_env_set_means_no_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_only_user_env_set_means_no_auth_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Partial config fail-opens but MUST emit a WARNING (silent fail-open is the foot-gun)."""
     monkeypatch.setenv("FINDAJOB_AUTH_USER", "tester")
     monkeypatch.delenv("FINDAJOB_AUTH_PASS", raising=False)
-    app = _make_app(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="findajob.web.auth"):
+        app = _make_app(tmp_path)
     client = TestClient(app)
     r = client.get("/", follow_redirects=False)
     assert r.status_code == 200
+    assert any(
+        rec.levelno == logging.WARNING
+        and "DISABLED" in rec.message
+        and "FINDAJOB_AUTH_USER" in rec.message
+        and "FINDAJOB_AUTH_PASS" in rec.message
+        for rec in caplog.records
+    ), f"expected partial-config WARNING; got {[(r.levelname, r.message) for r in caplog.records]}"
 
 
-def test_only_pass_env_set_means_no_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_only_pass_env_set_means_no_auth_with_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.delenv("FINDAJOB_AUTH_USER", raising=False)
     monkeypatch.setenv("FINDAJOB_AUTH_PASS", "lonely")
-    app = _make_app(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="findajob.web.auth"):
+        app = _make_app(tmp_path)
     client = TestClient(app)
     r = client.get("/", follow_redirects=False)
     assert r.status_code == 200
+    assert any(rec.levelno == logging.WARNING and "DISABLED" in rec.message for rec in caplog.records)
+
+
+def test_install_logs_enabled_when_both_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Operator should be able to grep startup logs for the actual auth state."""
+    monkeypatch.setenv("FINDAJOB_AUTH_USER", "tester")
+    monkeypatch.setenv("FINDAJOB_AUTH_PASS", "s3cret-token-xyz")
+    with caplog.at_level(logging.INFO, logger="findajob.web.auth"):
+        _make_app(tmp_path)
+    assert any("ENABLED" in rec.message and rec.levelno == logging.INFO for rec in caplog.records)
+
+
+def test_install_logs_disabled_when_unset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("FINDAJOB_AUTH_USER", raising=False)
+    monkeypatch.delenv("FINDAJOB_AUTH_PASS", raising=False)
+    with caplog.at_level(logging.INFO, logger="findajob.web.auth"):
+        _make_app(tmp_path)
+    assert any("DISABLED (no env vars set)" in rec.message and rec.levelno == logging.INFO for rec in caplog.records)
 
 
 def test_empty_string_env_vars_mean_no_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_web_basic_auth.py
+++ b/tests/test_web_basic_auth.py
@@ -1,0 +1,157 @@
+"""HTTP Basic Auth middleware on the findajob web UI (#327).
+
+Canary tests: if anyone reorders middleware in `app.py` and the auth gate
+stops firing, the no-creds → 401 assertions fail. Removing or weakening
+these tests requires a deliberate review.
+"""
+
+from __future__ import annotations
+
+import base64
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+
+
+def _make_app(tmp_path: Path):
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, "
+        "stage TEXT, fit_score REAL, created_at TEXT, stage_updated TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    return create_app(companies_root=companies, db_path=db, base_root=tmp_path)
+
+
+def _basic(user: str, pw: str) -> str:
+    raw = f"{user}:{pw}".encode()
+    return "Basic " + base64.b64encode(raw).decode("ascii")
+
+
+@pytest.fixture
+def auth_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("FINDAJOB_AUTH_USER", "tester")
+    monkeypatch.setenv("FINDAJOB_AUTH_PASS", "s3cret-token-xyz")
+    app = _make_app(tmp_path)
+    return TestClient(app)
+
+
+@pytest.fixture
+def open_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.delenv("FINDAJOB_AUTH_USER", raising=False)
+    monkeypatch.delenv("FINDAJOB_AUTH_PASS", raising=False)
+    app = _make_app(tmp_path)
+    return TestClient(app)
+
+
+def test_protected_route_without_creds_returns_401(auth_client: TestClient) -> None:
+    r = auth_client.get("/", follow_redirects=False)
+    assert r.status_code == 401
+    challenge = r.headers.get("www-authenticate", "")
+    assert challenge.lower().startswith("basic ")
+    assert 'realm="findajob"' in challenge
+
+
+def test_protected_route_with_correct_creds_passes(auth_client: TestClient) -> None:
+    r = auth_client.get(
+        "/",
+        headers={"Authorization": _basic("tester", "s3cret-token-xyz")},
+        follow_redirects=False,
+    )
+    assert r.status_code == 200
+
+
+def test_protected_route_with_wrong_password_returns_401(auth_client: TestClient) -> None:
+    r = auth_client.get(
+        "/",
+        headers={"Authorization": _basic("tester", "wrong")},
+        follow_redirects=False,
+    )
+    assert r.status_code == 401
+
+
+def test_protected_route_with_wrong_user_returns_401(auth_client: TestClient) -> None:
+    r = auth_client.get(
+        "/",
+        headers={"Authorization": _basic("attacker", "s3cret-token-xyz")},
+        follow_redirects=False,
+    )
+    assert r.status_code == 401
+
+
+def test_healthz_is_allowlisted(auth_client: TestClient) -> None:
+    r = auth_client.get("/healthz")
+    assert r.status_code == 200
+    assert r.text == "ok"
+
+
+def test_static_is_allowlisted(auth_client: TestClient) -> None:
+    r = auth_client.get("/static/app.css")
+    assert r.status_code != 401
+
+
+def test_favicon_is_allowlisted(auth_client: TestClient) -> None:
+    r = auth_client.get("/favicon.ico")
+    assert r.status_code == 200
+
+
+def test_no_env_vars_means_no_auth(open_client: TestClient) -> None:
+    r = open_client.get("/", follow_redirects=False)
+    assert r.status_code == 200
+
+
+def test_only_user_env_set_means_no_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FINDAJOB_AUTH_USER", "tester")
+    monkeypatch.delenv("FINDAJOB_AUTH_PASS", raising=False)
+    app = _make_app(tmp_path)
+    client = TestClient(app)
+    r = client.get("/", follow_redirects=False)
+    assert r.status_code == 200
+
+
+def test_only_pass_env_set_means_no_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FINDAJOB_AUTH_USER", raising=False)
+    monkeypatch.setenv("FINDAJOB_AUTH_PASS", "lonely")
+    app = _make_app(tmp_path)
+    client = TestClient(app)
+    r = client.get("/", follow_redirects=False)
+    assert r.status_code == 200
+
+
+def test_empty_string_env_vars_mean_no_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FINDAJOB_AUTH_USER", "")
+    monkeypatch.setenv("FINDAJOB_AUTH_PASS", "")
+    app = _make_app(tmp_path)
+    client = TestClient(app)
+    r = client.get("/", follow_redirects=False)
+    assert r.status_code == 200
+
+
+def test_malformed_authorization_header_returns_401(auth_client: TestClient) -> None:
+    r = auth_client.get("/", headers={"Authorization": "Bearer xyz"}, follow_redirects=False)
+    assert r.status_code == 401
+
+
+def test_garbage_base64_returns_401(auth_client: TestClient) -> None:
+    r = auth_client.get(
+        "/",
+        headers={"Authorization": "Basic !!!not-base64!!!"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 401
+
+
+def test_basic_with_no_colon_returns_401(auth_client: TestClient) -> None:
+    raw = base64.b64encode(b"nocolonhere").decode("ascii")
+    r = auth_client.get("/", headers={"Authorization": f"Basic {raw}"}, follow_redirects=False)
+    assert r.status_code == 401

--- a/tests/test_web_docs.py
+++ b/tests/test_web_docs.py
@@ -57,6 +57,7 @@ SETUP_INSTALL_DOCKER_MD = "# Install with Docker\n\nThe primary install path.\n"
 SETUP_INSTALL_LINUX_MD = "# Install on Linux (legacy)\n\nFallback.\n"
 SETUP_CONFIGURE_MD = "# Configure\n\nFile-by-file config walkthrough.\n"
 SETUP_STATE_MIGRATION_MD = "# State migration\n\nMoving from rclone to viewer.\n"
+SETUP_INTERNET_EXPOSURE_MD = "# Exposing findajob to the public internet\n\nBasic auth pattern.\n"
 
 
 @pytest.fixture
@@ -77,6 +78,7 @@ def client(tmp_path: Path) -> TestClient:
     (docs / "setup" / "install-linux.md").write_text(SETUP_INSTALL_LINUX_MD)
     (docs / "setup" / "configure.md").write_text(SETUP_CONFIGURE_MD)
     (docs / "setup" / "state-migration.md").write_text(SETUP_STATE_MIGRATION_MD)
+    (docs / "setup" / "internet-exposure.md").write_text(SETUP_INTERNET_EXPOSURE_MD)
 
     return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
 
@@ -126,6 +128,13 @@ def test_setup_subpage_renders(client: TestClient) -> None:
     r = client.get("/docs/setup/install-docker")
     assert r.status_code == 200
     assert "Install with Docker" in r.text
+
+
+def test_internet_exposure_subpage_renders(client: TestClient) -> None:
+    """#327: new pattern doc reachable in-app via the docs viewer's slug allowlist."""
+    r = client.get("/docs/setup/internet-exposure")
+    assert r.status_code == 200
+    assert "Exposing findajob to the public internet" in r.text
 
 
 def test_unknown_slug_404s(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

- New FastAPI middleware (`findajob.web.auth.BasicAuthMiddleware`) gates every request to the findajob web UI behind HTTP Basic Auth when `FINDAJOB_AUTH_USER` and `FINDAJOB_AUTH_PASS` env vars are both set. Allowlist for `/healthz`, `/static/*`, `/favicon.ico`. Constant-time compare via `hmac.compare_digest`.
- Startup logs the auth state on every container start (INFO when ENABLED or DISABLED, **WARNING** on partial misconfig where only one var is set) — silent fail-open on a typo'd `compose.yaml` is the real internet-facing foot-gun and observability is the cheap defense.
- New pattern doc at `docs/setup/internet-exposure.md` (also reachable in-app at `/docs/setup/internet-exposure`); roadmap Decision 16 supersedes Decision 3 for the public-exposure case; `CLAUDE.md` `/config/` paragraph updated to reflect the new optional gate.

## What this is and isn't

This is **shared-secret auth**, not identity. Threat model is drive-by scanning of per-tester instances reachable at `findajob-{tester}.example.com` (TLS terminates upstream at the Synology reverse proxy; geo-IP filter is upstream of that). Per-user RBAC, OIDC, 2FA — explicitly out of scope; remain a separate, future change.

When env vars are unset the middleware is not installed at all, so Wireguard-only deployments and the local-dev loop are completely unchanged.

## Topology

```
https://findajob-{tester}.example.com
  → Firewalla (USA-only)
  → Synology DSM (TLS term, GUI-managed reverse proxy)
  → docker.lan:<per-tester-port>
  → FastAPI BasicAuthMiddleware  ← this PR
  → route handlers
```

## Test plan

- [x] `tests/test_web_basic_auth.py` — 16 canary tests covering 401-without-creds, 200-with-correct-creds, 401-with-wrong-creds, allowlist behavior for `/healthz` + `/static/*` + `/favicon.ico`, no-op when env vars unset, partial-config WARNING emission, malformed-Authorization-header handling, garbage base64, missing-colon payload.
- [x] `tests/test_web_docs.py::test_internet_exposure_subpage_renders` — new doc reachable via the slug allowlist.
- [x] Full project gauntlet: `ruff check`, `ruff format --check`, `mypy src`, `pytest` (1133 passing, was 1130 — +3 net new).
- [ ] Operator end-to-end on docker.lan: set `FINDAJOB_AUTH_USER` / `FINDAJOB_AUTH_PASS` on a tester stack, configure Synology DSM reverse-proxy vhost, verify `curl -I` returns 401 and `curl -I -u user:pass` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)