### PR TITLE
fix(materials): use <button> for download to eliminate anchor-href race

### DIFF
--- a/src/findajob/web/templates/materials/folder.html
+++ b/src/findajob/web/templates/materials/folder.html
@@ -100,12 +100,13 @@
           </button>
           {% endif %}
           {# Primary action — View for .md/.txt (server-rendered HTML), Blob-download
-             for binaries. The Blob path exists because reverse proxies (Synology in
-             front of internet-exposed instances, see #327) sometimes strip
-             Content-Disposition or rewrite Content-Type, causing browsers to render
-             docx bytes as text on screen. Fetching as a Blob and triggering a
-             download from a local object URL bypasses the proxy's response headers
-             entirely — the browser's only signal is the synthetic <a download>. #}
+             for binaries. Button (not anchor) so there's no native browser default
+             to race against — reverse proxies (Synology, #327) strip
+             Content-Disposition / rewrite Content-Type on docx responses, and any
+             native navigation that slips through renders the bytes as text. The JS
+             fetch builds a Blob locally and triggers a synthetic <a download> on a
+             same-origin object URL, which the browser always saves — proxy headers
+             don't enter the picture. #}
           {% if f.is_view %}
             <a class="inline-flex items-center px-3 py-1.5 rounded text-sm font-medium bg-emerald-600 hover:bg-emerald-700 text-white"
                href="/materials/{{ fingerprint }}/{{ f.name }}">
@@ -113,32 +114,30 @@
             </a>
           {% else %}
             {% set dl_url = '/materials/' ~ fingerprint ~ '/' ~ f.name %}
-            <a class="inline-flex items-center px-3 py-1.5 rounded text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white"
-               href="{{ dl_url }}"
-               download="{{ f.name }}"
-               type="application/octet-stream"
-               x-data="{ busy: false }"
-               :class="busy ? 'opacity-60 pointer-events-none' : ''"
-               @click.prevent="
-                 busy = true;
-                 fetch('{{ dl_url }}', { credentials: 'same-origin' })
-                   .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.blob(); })
-                   .then(blob => {
-                     const url = URL.createObjectURL(blob);
-                     const a = document.createElement('a');
-                     a.href = url;
-                     a.download = '{{ f.name }}';
-                     document.body.appendChild(a);
-                     a.click();
-                     document.body.removeChild(a);
-                     setTimeout(() => URL.revokeObjectURL(url), 1000);
-                   })
-                   .catch(e => alert('Download failed: ' + e.message))
-                   .finally(() => { busy = false });
-               ">
+            <button type="button"
+                    class="inline-flex items-center px-3 py-1.5 rounded text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-60"
+                    x-data="{ busy: false }"
+                    :disabled="busy"
+                    @click="
+                      busy = true;
+                      fetch('{{ dl_url }}', { credentials: 'same-origin' })
+                        .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.blob(); })
+                        .then(blob => {
+                          const url = URL.createObjectURL(blob);
+                          const a = document.createElement('a');
+                          a.href = url;
+                          a.download = '{{ f.name }}';
+                          document.body.appendChild(a);
+                          a.click();
+                          document.body.removeChild(a);
+                          setTimeout(() => URL.revokeObjectURL(url), 1000);
+                        })
+                        .catch(e => alert('Download failed: ' + e.message))
+                        .finally(() => { busy = false });
+                    ">
               <span x-show="!busy">↓ Download</span>
               <span x-show="busy">Downloading…</span>
-            </a>
+            </button>
           {% endif %}
         </div>
       </li>


### PR DESCRIPTION
## Summary
The Blob-download fix in #348 left a race: clicking the \`<a href download @click.prevent>\` triggered both the browser's native navigation AND the JS Blob download, so users saw the docx bytes rendered as text on screen *and* got the file. \`@click.prevent\` should have stopped the native nav but didn't reliably (likely due to Alpine's deferred init vs. the browser's immediate handling of the \`download\` attribute on a left-click).

Replace the anchor with a \`<button>\`. No \`href\`, no native default behavior to race against — only the JS handler runs.

## Test plan
- [x] Materials tests pass (47/47)
- [ ] Click Download on a docx after deploy — file saves, page does NOT render bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)