### PR TITLE
fix(watchdog): sweep orphan prep folders to .stale/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-04-30
+
+Patch bump. Closes a longstanding orphan-folder leak in the prep-application pipeline by adding a watchdog sweep, complementing the existing `quarantine_stale_prep_folders` (#174) which only fires on the *next* prep attempt for the same job.
+
+### Fixed
+
+- **Watchdog now sweeps orphan prep folders into `companies/.stale/` (#TBD).** Top-level subdirectories of `companies/` that have no `jobs.prep_folder_path` pointing at them AND mtime older than `ORPHAN_FOLDER_MIN_AGE_MIN=120` (2h) are moved to `.stale/` on each watchdog cycle. Caused-by paths covered: (a) `prep_application.py`'s bare-except handler clears `prep_folder_path` from the DB but doesn't `shutil.rmtree` the partial folder; (b) `watchdog.run_watchdog`'s `reset_prep_to_scored` call doesn't have `outdir` info to clean up; (c) container OOM/SIGKILL during prep — process never wrote `prep_folder_path` to DB. The 2h grace prevents sweeping a folder mid-prep. Discovered when two stacks on a multi-tenant host accumulated stale folders from regenerate failures and various process kills; both stacks cleaned up at deploy time. 6 new unit tests cover the happy path, in-flight grace, db-tracked exclusion, underscore/dot exclusion, dst-collision skip, and missing-dir tolerance.
+
 ## [0.8.1] — 2026-04-30
 
 Patch bump. Fixes a deployment-time gap in v0.8.0: `ops/compose.yaml.example` did not pass the new `FINDAJOB_<JOB>_SCHEDULE` / `FINDAJOB_<JOB>_ENABLED` env vars from `.env` into the container, so multi-tenant stagger overrides had no effect on existing stacks. Two coupled fixes ship together so a fresh-install operator can stagger schedules without editing compose.yaml by hand.

--- a/scripts/watchdog.py
+++ b/scripts/watchdog.py
@@ -1,17 +1,28 @@
 #!/usr/bin/env python3
 """Stale-prep cleanup watchdog.
 
-Runs every 10 min via supercronic. Single responsibility: reset jobs stuck in
-stage='prep_in_progress' for more than STALE_PREP_MINUTES back to 'scored'
-so the operator can re-flag them. A subprocess crash (container restart, OOM,
-timeout) leaves the stage stuck; this is the safety net.
+Runs every 10 min via supercronic. Three responsibilities:
+
+1. Reset jobs stuck in stage='prep_in_progress' > STALE_PREP_MINUTES back
+   to 'scored' so the operator can re-flag them. A subprocess crash
+   (container restart, OOM, timeout) leaves the stage stuck; this is the
+   safety net.
+2. Fail speculative_requests rows stuck in 'researching' > STALE_RESEARCH_MINUTES
+   so the operator's status page stops polling forever.
+3. Sweep orphan folders in companies/ that have no matching jobs row pointing
+   at them and are older than ORPHAN_FOLDER_MIN_AGE_MIN. Moves them to
+   companies/.stale/ for forensic inspection rather than deleting.
+   Catches any code path that creates a folder but fails to write the
+   prep_folder_path back to DB (in-process exception, OOM during prep, etc.).
 
 Replaces scripts/poll_flags.py — all transition logic now lives in the web
 POST handlers (findajob.web.routes.board_actions) calling findajob.actions.
 """
 
+import shutil
 import sqlite3
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from findajob.actions import reset_prep_to_scored
 from findajob.paths import BASE
@@ -20,6 +31,9 @@ from findajob.utils import log_event
 DB_PATH = f"{BASE}/data/pipeline.db"
 STALE_PREP_MINUTES = 60
 STALE_RESEARCH_MINUTES = 15
+ORPHAN_FOLDER_MIN_AGE_MIN = 120
+"""2h grace before sweeping an orphan — long enough that an in-flight prep
+that hasn't yet written prep_folder_path won't get swept mid-run."""
 
 
 def run_watchdog(conn: sqlite3.Connection) -> int:
@@ -87,15 +101,85 @@ def fail_stuck_speculative(conn: sqlite3.Connection) -> int:
     return count
 
 
+def sweep_orphan_folders(conn: sqlite3.Connection) -> int:
+    """Move orphan top-level folders in companies/ to companies/.stale/.
+
+    An orphan is a top-level subdirectory (not starting with `_` or `.`) that
+    no `jobs` row's `prep_folder_path` references AND whose mtime is older
+    than ORPHAN_FOLDER_MIN_AGE_MIN. The age guard prevents sweeping a folder
+    mid-prep — a slow in-flight run hasn't yet written prep_folder_path.
+
+    Caused-by paths covered:
+    - prep_application.py exception handler nulls prep_folder_path but doesn't
+      shutil.rmtree the partial folder.
+    - watchdog's reset_prep_to_scored() nulls prep_folder_path because at
+      reset time it doesn't have outdir info.
+    - Container kill / OOM during prep — process never wrote prep_folder_path
+      to DB.
+
+    Returns count of folders moved.
+    """
+    companies_dir = Path(BASE) / "companies"
+    if not companies_dir.is_dir():
+        return 0
+
+    db_paths = {
+        r[0]
+        for r in conn.execute(
+            "SELECT prep_folder_path FROM jobs WHERE prep_folder_path IS NOT NULL AND prep_folder_path != ''"
+        ).fetchall()
+    }
+
+    cutoff_ts = (datetime.now(UTC) - timedelta(minutes=ORPHAN_FOLDER_MIN_AGE_MIN)).timestamp()
+    stale_dir = companies_dir / ".stale"
+
+    count = 0
+    for entry in companies_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith(("_", ".")):
+            continue
+        # DB stores paths as `/app/companies/<name>` (per BASE inside container)
+        if str(entry) in db_paths:
+            continue
+        try:
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        if mtime > cutoff_ts:
+            continue  # too fresh — possibly an in-flight prep
+        # Move to .stale/. mkdir is idempotent.
+        stale_dir.mkdir(exist_ok=True)
+        dst = stale_dir / entry.name
+        if dst.exists():
+            # Defensive: don't clobber an earlier sweep's same-named entry.
+            log_event("orphan_folder_sweep_skipped", folder=entry.name, reason="dst_exists")
+            continue
+        try:
+            shutil.move(str(entry), str(dst))
+        except OSError as e:
+            log_event("orphan_folder_sweep_failed", folder=entry.name, error=str(e))
+            continue
+        log_event("orphan_folder_swept", folder=entry.name)
+        count += 1
+    return count
+
+
 def main() -> None:
     conn = sqlite3.connect(DB_PATH, timeout=30)
     conn.row_factory = sqlite3.Row
     try:
         count = run_watchdog(conn)
         spec_failed = fail_stuck_speculative(conn)
+        orphans = sweep_orphan_folders(conn)
     finally:
         conn.close()
-    log_event("watchdog_run", stale_reset=count, speculative_failed=spec_failed)
+    log_event(
+        "watchdog_run",
+        stale_reset=count,
+        speculative_failed=spec_failed,
+        orphans_swept=orphans,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -207,3 +207,121 @@ def test_fail_stuck_speculative_marks_failed(db, _patch_log):
     assert stale["status"] == "failed"
     assert "timed out" in (stale["error_message"] or "").lower()
     assert fresh["status"] == "researching"
+
+
+# ── sweep_orphan_folders ──────────────────────────────────────────────────
+
+
+def test_sweep_orphan_folders_moves_untracked_old_folder(db, tmp_path, monkeypatch):
+    """Folder on disk with no jobs row pointing at it AND mtime > 2h → moved to .stale/."""
+    monkeypatch.setattr(watchdog, "BASE", str(tmp_path))
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    orphan = companies / "Acme_Director_Of_Ops_2026-04-23_120000"
+    orphan.mkdir()
+    # backdate mtime to 3h ago
+    old_ts = (datetime.now(UTC) - timedelta(hours=3)).timestamp()
+    import os
+
+    os.utime(orphan, (old_ts, old_ts))
+
+    count = watchdog.sweep_orphan_folders(db)
+
+    assert count == 1
+    assert not orphan.exists()
+    assert (companies / ".stale" / orphan.name).is_dir()
+
+
+def test_sweep_orphan_folders_skips_in_flight_prep(db, tmp_path, monkeypatch):
+    """Fresh folder (mtime < 2h) is left alone — could be an in-flight prep."""
+    monkeypatch.setattr(watchdog, "BASE", str(tmp_path))
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    fresh = companies / "Acme_In_Flight_2026-04-30_120000"
+    fresh.mkdir()
+    # mtime is current time (just created) — well within the 2h grace
+
+    count = watchdog.sweep_orphan_folders(db)
+
+    assert count == 0
+    assert fresh.is_dir()
+    assert not (companies / ".stale").exists()
+
+
+def test_sweep_orphan_folders_skips_db_tracked_folder(db, tmp_path, monkeypatch):
+    """Folder whose path appears in jobs.prep_folder_path is NOT swept."""
+    monkeypatch.setattr(watchdog, "BASE", str(tmp_path))
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    tracked = companies / "Acme_Tracked_2026-04-23_120000"
+    tracked.mkdir()
+    old_ts = (datetime.now(UTC) - timedelta(hours=3)).timestamp()
+    import os
+
+    os.utime(tracked, (old_ts, old_ts))
+
+    db.execute(
+        "INSERT INTO jobs (id, fingerprint, url, title, company, stage, prep_folder_path) "
+        "VALUES (?, 'fp1', 'http://x', 'Director', 'Acme', 'materials_drafted', ?)",
+        (str(uuid.uuid4()), str(tracked)),
+    )
+    db.commit()
+
+    count = watchdog.sweep_orphan_folders(db)
+
+    assert count == 0
+    assert tracked.is_dir()
+
+
+def test_sweep_orphan_folders_ignores_underscore_and_dot_dirs(db, tmp_path, monkeypatch):
+    """_applied/, _rejected/, .stale/ etc. are stage holders — never swept."""
+    monkeypatch.setattr(watchdog, "BASE", str(tmp_path))
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    for name in ("_applied", "_rejected", "_waitlisted", ".stale"):
+        (companies / name).mkdir()
+        old_ts = (datetime.now(UTC) - timedelta(hours=3)).timestamp()
+        import os
+
+        os.utime(companies / name, (old_ts, old_ts))
+
+    count = watchdog.sweep_orphan_folders(db)
+
+    assert count == 0
+    for name in ("_applied", "_rejected", "_waitlisted", ".stale"):
+        assert (companies / name).is_dir()
+
+
+def test_sweep_orphan_folders_does_not_clobber_existing_stale_entry(db, tmp_path, monkeypatch):
+    """If .stale/ already has a folder with the same name (sweep ran before),
+    don't overwrite — log and skip."""
+    monkeypatch.setattr(watchdog, "BASE", str(tmp_path))
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    name = "Acme_Dup_2026-04-23_120000"
+    orphan = companies / name
+    orphan.mkdir()
+    (orphan / "marker_new.txt").write_text("new")
+    old_ts = (datetime.now(UTC) - timedelta(hours=3)).timestamp()
+    import os
+
+    os.utime(orphan, (old_ts, old_ts))
+    # Pre-existing .stale entry with the same name
+    stale_existing = companies / ".stale" / name
+    stale_existing.mkdir(parents=True)
+    (stale_existing / "marker_old.txt").write_text("old")
+
+    count = watchdog.sweep_orphan_folders(db)
+
+    assert count == 0  # skipped, not moved
+    assert orphan.is_dir()
+    # Existing .stale entry unchanged
+    assert (stale_existing / "marker_old.txt").read_text() == "old"
+    assert not (stale_existing / "marker_new.txt").exists()
+
+
+def test_sweep_orphan_folders_handles_missing_companies_dir(db, tmp_path, monkeypatch):
+    """If companies/ doesn't exist, return 0 without raising."""
+    monkeypatch.setattr(watchdog, "BASE", str(tmp_path))
+    # companies/ deliberately not created
+    assert watchdog.sweep_orphan_folders(db) == 0


### PR DESCRIPTION
## Summary

Closes #353. Adds `sweep_orphan_folders()` to the every-10-min watchdog. Top-level subdirs of `companies/` with no `jobs.prep_folder_path` pointing at them AND mtime older than 2h are moved to `companies/.stale/` (matching the existing `quarantine_stale_prep_folders` from #174).

## Why

Two orphan-creation paths uncovered while diagnosing stack health-check warnings:

1. `prep_application.py:574-594` bare-except handler — clears `prep_folder_path` via `reset_prep_to_scored()` but doesn't `shutil.rmtree(outdir)` because `outdir` is local to `main()`. The other two failure paths in the same file already do `shutil.rmtree`.
2. `watchdog.run_watchdog`'s reset call — no `outdir` info to clean up.
3. Container OOM/SIGKILL during prep — process never writes `prep_folder_path` to DB at all.

`quarantine_stale_prep_folders` (#174) already covers (1) for the regenerate-retry case but only fires on the *next* prep attempt for the same `{company, title}` prefix. If the operator doesn't retry, the orphan persists indefinitely. The watchdog sweep covers the indefinite case.

## Behavior

- `ORPHAN_FOLDER_MIN_AGE_MIN=120` (2h grace) — prevents sweeping in-flight prep that hasn't yet written its DB row
- Skips `_*` and `.*` directories (stage holders, already-quarantined)
- Doesn't clobber existing same-named entry in `.stale/` (logs `orphan_folder_sweep_skipped` with reason)
- Logs `orphan_folder_swept` per move
- `watchdog_run` event now includes `orphans_swept` count

## Test plan

- [x] `uv run pytest tests/test_watchdog.py` — 12 pass (6 new + 6 existing)
- [x] Full suite: `uv run pytest -q` — 1243 pass + 1 skip (legacy guard)
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean
- [x] `uv run mypy src/findajob/ scripts/watchdog.py` — clean
- [x] Live deployment cleanup completed at PR-prep time on impacted stacks (orphans moved to `.stale/`)

## Migration

Not required for operators. Watchdog runs at next scheduled cron tick and idempotently moves any pre-existing orphans to `.stale/` (no clobbering, no destructive action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)