### PR TITLE
fix(admin): #333 cross-stack SQLite reads need immutable=1

### DIFF
--- a/src/findajob/admin/stack_health.py
+++ b/src/findajob/admin/stack_health.py
@@ -53,7 +53,16 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
 
     if not db_missing:
         try:
-            uri = f"file:{stack.db_path}?mode=ro"
+            # `immutable=1` treats the DB as a fixed snapshot — no journal /
+            # WAL / shm sidecar reads, no locking. Cross-stack reads from the
+            # operator container (uid 1000) against tester DBs owned by host
+            # uid 1001 fail under default mode=ro because the producer's WAL
+            # sidecar is unreadable to the foreign uid (#333 production smoke
+            # 2026-04-30 surfaced "unable to open database file" until
+            # immutable=1 was added). Tradeoff: the dashboard sees a snapshot
+            # at the last checkpoint, missing in-flight WAL writes — fine for
+            # a "is this stack alive" health view.
+            uri = f"file:{stack.db_path}?mode=ro&immutable=1"
             with sqlite3.connect(uri, uri=True) as conn:
                 conn.row_factory = sqlite3.Row
                 stage_counts = {


### PR DESCRIPTION
## Summary

Production smoke surfaced \`unable to open database file\` on every per-row stage-distribution cell of \`/admin/stacks/\` after #355 deployed.

Root cause: the operator container runs as uid 1000 (\`findajob\`); tester DBs at \`/opt/stacks/findajob-*/state/data/pipeline.db\` are owned by host uid 1001 (\`lad\`). Default \`mode=ro\` still tries to read the producer's WAL/shm sidecar files, which the foreign uid cannot access.

\`immutable=1\` makes SQLite treat the DB as a fixed snapshot — no sidecar reads, no locking, no WAL coherence. Acceptable tradeoff for a "is this stack alive" view that already ships static-on-load.

## Test plan

- [x] \`uv run pytest tests/test_admin_*.py -q\` → still passes
- [x] \`uv run ruff check && uv run ruff format --check && uv run mypy\` clean
- [ ] Post-merge: pull on operator stack, verify per-row stage distribution renders for all 6 stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)