### PR TITLE
fix(admin): #333 stuck-prep query uses stage_updated (not invented prep_started_at)

### DIFF
--- a/src/findajob/admin/stack_health.py
+++ b/src/findajob/admin/stack_health.py
@@ -69,12 +69,17 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
                     row["stage"]: row["n"]
                     for row in conn.execute("SELECT stage, COUNT(*) AS n FROM jobs GROUP BY stage")
                 }
+                # `stage_updated` is the canonical "when did stage last change"
+                # column written by web handlers (and read by scripts/watchdog.py
+                # for the same stuck-prep reset query). The earlier draft used
+                # a fictional `prep_started_at` column — production smoke 2026-04-30
+                # surfaced "no such column".
                 cutoff = (now - timedelta(minutes=60)).isoformat()
                 stuck_prep_count = conn.execute(
                     "SELECT COUNT(*) FROM jobs "
                     "WHERE stage = 'prep_in_progress' "
-                    "AND prep_started_at IS NOT NULL "
-                    "AND prep_started_at < ?",
+                    "AND stage_updated IS NOT NULL "
+                    "AND stage_updated < ?",
                     (cutoff,),
                 ).fetchone()[0]
         except sqlite3.Error as e:

--- a/tests/conftest_admin.py
+++ b/tests/conftest_admin.py
@@ -14,8 +14,7 @@ _JOBS_SCHEMA = """
 CREATE TABLE jobs (
     id TEXT PRIMARY KEY,
     stage TEXT NOT NULL,
-    flagged_at TEXT,
-    prep_started_at TEXT
+    stage_updated TEXT
 );
 """
 
@@ -27,15 +26,17 @@ def build_pipeline_db(
 ) -> None:
     """Build a minimal pipeline.db with just the columns stack_health reads.
 
-    `rows` is a list of dicts with keys: id, stage, prep_started_at (ISO 8601 UTC).
+    `rows` is a list of dicts with keys: id, stage, stage_updated (ISO 8601 UTC).
+    The `stage_updated` field is what scripts/watchdog.py uses to detect stuck
+    prep — same column the production stuck-prep query reads.
     """
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
     conn.executescript(_JOBS_SCHEMA)
     for r in rows or []:
         conn.execute(
-            "INSERT INTO jobs (id, stage, prep_started_at) VALUES (?, ?, ?)",
-            (r["id"], r["stage"], r.get("prep_started_at")),
+            "INSERT INTO jobs (id, stage, stage_updated) VALUES (?, ?, ?)",
+            (r["id"], r["stage"], r.get("stage_updated") or r.get("prep_started_at")),
         )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary

Second production-smoke fix for #333. Plan-stage code referenced a fictional \`prep_started_at\` column; production \`jobs\` table has no such field. Canonical column is \`stage_updated\` — same one watchdog.py reads.

Pairs with #356 (immutable=1 cross-stack reads).

## Test plan

- [x] \`uv run pytest tests/test_admin_*.py -q\` → 34 passed
- [x] ruff/format clean
- [ ] Post-merge: pull on operator stack, verify per-row stage distribution + stuck-prep count render

🤖 Generated with [Claude Code](https://claude.com/claude-code)