### PR TITLE
fix(onboarding): paste form opts out of hx-boost; specific error messages

### DIFF
--- a/src/findajob/web/routes/onboarding.py
+++ b/src/findajob/web/routes/onboarding.py
@@ -8,12 +8,70 @@ from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse, PlainTextResponse, RedirectResponse
 
 from findajob.onboarding import OnboardingSmokeCheckFailed, inject, parse_emission
+from findajob.onboarding.parser import ALLOWED_FILENAMES
 
 router = APIRouter()
 
 
 def _interview_prompt_path(base_root: Path) -> Path:
     return base_root / "config" / "roles" / "onboarding_interviewer.md"
+
+
+def _format_parse_error(
+    emission: str,
+    missing: list[str],
+    unknown: list[str],
+) -> str:
+    """Build a diagnostic error message for a failed emission parse.
+
+    Distinguishes the three real-world failure shapes — empty paste, no
+    delimited blocks at all (=> wrong content type), and partial paste
+    with some blocks present — so the user gets a remedy specific to
+    what actually went wrong, not a generic 'something is missing'.
+    Surfaces unknown block names (likely typos) as a separate hint.
+    """
+    blob = emission.strip()
+    found_count = len(ALLOWED_FILENAMES) - len(missing)
+
+    if not blob:
+        msg = (
+            "The paste box is empty. After your LLM finishes the interview "
+            "and emits the file blocks, copy the entire chat (or at least "
+            "everything from the first `<<<FILE: …>>>` line to the last "
+            "`<<<END FILE: …>>>` line) and paste it here."
+        )
+    elif found_count == 0:
+        # Pasted SOMETHING, but parser found zero recognizable blocks.
+        # Most often: copied just the chat-prose, missed the delimited blocks;
+        # or LLM produced markdown headings instead of `<<<FILE: …>>>` markers.
+        msg = (
+            "We couldn't find any `<<<FILE: name>>>` … `<<<END FILE: name>>>` "
+            "block in your paste. Common causes: (a) the LLM didn't actually "
+            'emit the delimited file blocks — re-prompt it with "Now emit the '
+            'ten file blocks per the interview spec"; (b) you copied only '
+            "the chat prose and missed the blocks at the end of the "
+            "transcript; (c) markdown formatting stripped the `<<<` markers — "
+            "try copying from the LLM's raw-text view if it has one."
+        )
+    else:
+        # Some blocks parsed, others didn't. Likely the LLM stopped emitting
+        # mid-list, or the user's paste was truncated.
+        msg = (
+            f"We found {found_count} of {len(ALLOWED_FILENAMES)} required "
+            "blocks, but these are still missing: "
+            f"{', '.join(missing)}. Scroll through your chat to make sure "
+            "every `<<<FILE: name>>> … <<<END FILE: name>>>` block is in "
+            "your paste — re-prompt the LLM if it stopped early."
+        )
+
+    if unknown:
+        msg += (
+            f" We also found these unrecognized block names (likely typos): "
+            f"{', '.join(unknown)}. If one of those was supposed to be a "
+            "required block, fix the filename in your paste and re-submit."
+        )
+
+    return msg
 
 
 @router.get("/onboarding/", response_class=HTMLResponse)
@@ -59,6 +117,7 @@ def onboarding_inject(
     templates = request.app.state.templates
     result = parse_emission(emission)
     if result.missing:
+        paste_error = _format_parse_error(emission, result.missing, result.unknown)
         return templates.TemplateResponse(
             request=request,
             name="onboarding/index.html",
@@ -66,11 +125,7 @@ def onboarding_inject(
                 "is_rerun": False,
                 "paste_content": emission,
                 "openrouter_api_key": openrouter_api_key,
-                "paste_error": (
-                    f"Your paste is missing: {', '.join(result.missing)}. "
-                    "Scroll through your chat for any <<<FILE: name>>> block "
-                    "that's not in your paste and include it."
-                ),
+                "paste_error": paste_error,
             },
             status_code=400,
         )
@@ -83,7 +138,11 @@ def onboarding_inject(
                 "paste_content": emission,
                 "openrouter_api_key": "",
                 "paste_error": (
-                    "OpenRouter API key is required. Paste the key from https://openrouter.ai/ into the API key field."
+                    "OpenRouter API key is missing. Paste your key (starts with sk-or-v1-…) "
+                    "from https://openrouter.ai/keys into the API key field above the paste box, "
+                    "then click Inject again. The key is required so we can verify it works "
+                    "before sealing your stack — failing to verify here would let the pipeline "
+                    "silently break on first scheduled triage."
                 ),
             },
             status_code=400,
@@ -94,7 +153,8 @@ def onboarding_inject(
     except OnboardingSmokeCheckFailed as e:
         # Files were committed; only the sentinel is missing. The next paste-back
         # with a corrected key will overwrite cleanly. Render the user-facing
-        # error so they can see what went wrong.
+        # error so they can see what went wrong. e.user_message is already a
+        # specific, actionable string — surface it without further wrapping.
         return templates.TemplateResponse(
             request=request,
             name="onboarding/index.html",
@@ -102,7 +162,11 @@ def onboarding_inject(
                 "is_rerun": False,
                 "paste_content": emission,
                 "openrouter_api_key": openrouter_api_key,
-                "paste_error": (f"OpenRouter key check failed: {e.user_message} Fix the key and re-paste."),
+                "paste_error": (
+                    "OpenRouter rejected the key when we tried to verify it. "
+                    f"{e.user_message} "
+                    "Fix the key and click Inject again — your paste content is preserved above."
+                ),
             },
             status_code=400,
         )

--- a/src/findajob/web/templates/onboarding/_paste_form.html
+++ b/src/findajob/web/templates/onboarding/_paste_form.html
@@ -1,6 +1,6 @@
 {# Paste form partial — re-rendered by POST /onboarding/inject on parse failure
    so `paste_content`, `paste_error`, and `openrouter_api_key` preserve user input. #}
-<form method="post" action="/onboarding/inject" class="space-y-3">
+<form method="post" action="/onboarding/inject" class="space-y-3" hx-boost="false">
   {% if paste_error %}
   <div class="border border-red-300 bg-red-50 text-red-900 px-4 py-3 rounded">
     <p class="font-medium">Couldn't complete onboarding.</p>

--- a/tests/test_web_onboarding_routes.py
+++ b/tests/test_web_onboarding_routes.py
@@ -76,6 +76,34 @@ def test_onboarding_index_returns_200(client: TestClient) -> None:
     assert "copy the prompt" in body.lower() or "Copy the prompt" in body
 
 
+def test_paste_form_opts_out_of_hx_boost(client: TestClient) -> None:
+    """Paste form must opt out of base.html's body-level hx-boost.
+
+    The /onboarding/inject route returns 400 on validation errors
+    (missing paste blocks, missing API key, OpenRouter smoke-check failed).
+    HTMX by default does NOT swap 4xx responses — silently drops them — so
+    a boosted form on a 400 leaves the page unchanged with no user feedback.
+    Native form submit handles 4xx HTML responses correctly.
+    """
+    resp = client.get("/onboarding/")
+    assert resp.status_code == 200
+    # The exact form tag must contain hx-boost="false". A loose substring
+    # check would pass if the attribute lived anywhere on the page; this
+    # constrains it to the form opening tag.
+    import re
+
+    form_tag = re.search(
+        r'<form\s+[^>]*action="/onboarding/inject"[^>]*>',
+        resp.text,
+    )
+    assert form_tag is not None, "paste form not found"
+    assert 'hx-boost="false"' in form_tag.group(0), (
+        'Paste form must include hx-boost="false" so 400 responses from '
+        "/onboarding/inject render natively. Without this, HTMX silently "
+        "drops 4xx responses and the user sees no feedback."
+    )
+
+
 def test_rerun_mode_shows_backup_warning(client: TestClient) -> None:
     resp = client.get("/onboarding/?mode=rerun")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Papa's onboarding click silently no-ops because:

1. \`base.html\` has \`<body hx-boost=\"true\">\` — every form submit is converted to AJAX.
2. \`/onboarding/inject\` returns **400** on validation errors (missing paste blocks, missing OpenRouter key, smoke-check failed).
3. HTMX's default behavior is to NOT swap 4xx responses — they get silently dropped. Page renders unchanged. User sees no feedback. Looks like the button isn't responding to the click.

Confirmed from \`docker compose logs scheduler\` on \`findajob-papa\`: 15+ \`POST /onboarding/inject HTTP/1.1 400 Bad Request\` from papa's external IP, all silent on the page.

Fix: add \`hx-boost=\"false\"\` to the form so 400 responses render natively. Mirrors the pattern already used in \`speculative/_status_fragment.html\` and \`speculative/review.html\`.

## Bonus: better error messages

Replaces the single \"Your paste is missing: X, Y, Z\" with three diagnostic shapes:

- Empty paste → \"the box is empty, here's exactly what to copy\"
- Non-empty but zero blocks parsed → \"we found nothing — three most common causes (LLM didn't emit; you pasted only prose; markdown ate the markers)\"
- Some blocks parsed, some missing → \"we found N of 10; still missing: list — re-prompt if the LLM stopped early\"

Plus surfaces unknown block names (typos in \`<<<FILE: name>>>\`) as a separate hint.

OpenRouter paths tightened: empty-key message points to https://openrouter.ai/keys with format hint; smoke-check wrapper surfaces the underlying \`e.user_message\` (already specific: 401/402/429/network) without a generic \"key check failed\" preamble.

## Test plan

- [x] Existing 12 \`test_web_onboarding_routes.py\` tests still pass
- [x] New regression: \`test_paste_form_opts_out_of_hx_boost\` asserts \`hx-boost=\"false\"\` appears literally in the form opening tag — silent regression here is the main risk if someone refactors the template later
- [ ] Operator manual: deploy to \`findajob-papa\`, click Inject without an OpenRouter key, confirm error renders inline with new message
- [ ] Operator manual: with key but malformed paste, confirm specific shape-of-failure message

🤖 Generated with [Claude Code](https://claude.com/claude-code)