### PR TITLE
fix(onboarding): #365 add .backups bind mount + short-circuit empty backup

### DIFF
--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -24,7 +24,7 @@ See [configure.md](configure.md). API keys and personal config end up in `state/
 
 ```bash
 # On the Docker host
-sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng}
+sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng,.backups}
 sudo chown -R $(id -u):$(id -g) /opt/stacks/findajob-<you>/
 ```
 

--- a/ops/compose.yaml.example
+++ b/ops/compose.yaml.example
@@ -50,6 +50,7 @@ services:
       - ./state/companies:/app/companies
       - ./state/logs:/app/logs
       - ./state/aichat_ng:/app/.config/aichat_ng
+      - ./state/.backups:/app/.backups
     networks:
       - findajob-network
 

--- a/src/findajob/onboarding/injector.py
+++ b/src/findajob/onboarding/injector.py
@@ -179,15 +179,27 @@ def _parse_ntfy_topic_body(body: str) -> str:
 def backup_existing(base_root: Path, stamp: str) -> Path:
     """Copy any existing destinations to ``{base_root}/.backups/{stamp}/``.
 
-    Returns the backup directory path (possibly empty). Preserves the
-    relative path structure of every copied file.
+    Returns the backup directory path. If no extant sources are present
+    (first onboarding run on a fresh stack), no directory is created and
+    the returned path will not exist on disk. Preserves the relative path
+    structure of every copied file.
+
+    Skipping the mkdir on first runs is defense-in-depth against #365: if
+    the operator's host is missing the ``./state/.backups:/app/.backups``
+    bind mount, an unconditional mkdir on a fresh stack would fail with
+    EPERM (parent ``/app`` is root-owned in the image). Short-circuiting
+    when there is nothing to back up means a fresh first run never
+    touches that path — the bind mount only matters on re-runs, which is
+    when there's something to back up anyway.
     """
+    sources = [base_root / r for r in _backup_relpaths()]
+    extant = [s for s in sources if s.is_file()]
     dest_root = base_root / _BACKUP_ROOT / stamp
+    if not extant:
+        return dest_root
     dest_root.mkdir(parents=True, exist_ok=True)
-    for relpath in _backup_relpaths():
-        src = base_root / relpath
-        if not src.is_file():
-            continue
+    for src in extant:
+        relpath = src.relative_to(base_root)
         target = dest_root / relpath
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, target)

--- a/tests/test_onboarding_injector.py
+++ b/tests/test_onboarding_injector.py
@@ -111,11 +111,31 @@ def test_mark_and_is_complete_roundtrip(tmp_path: Path) -> None:
 # ---- backup_existing ------------------------------------------------------
 
 
-def test_backup_on_empty_base_creates_empty_dir(tmp_path: Path) -> None:
+def test_backup_on_empty_base_short_circuits_no_mkdir(tmp_path: Path) -> None:
+    """First onboarding on a fresh stack must NOT mkdir into .backups (#365).
+
+    If the operator forgot the ``./state/.backups:/app/.backups`` bind mount,
+    an unconditional mkdir would fail with EPERM (the parent ``/app`` is
+    root-owned in the image). Short-circuiting when there's nothing to
+    back up means first runs never touch that path — the bind mount is
+    only required on re-runs, where there's actual existing state to
+    preserve.
+    """
     dest = backup_existing(tmp_path, "20260423T120000Z")
+    # Returned path matches the contract, but is NOT created on disk
+    # when the source set is empty.
     assert dest == tmp_path / ".backups" / "20260423T120000Z"
+    assert not dest.exists()
+    assert not (tmp_path / ".backups").exists()
+
+
+def test_backup_when_only_one_source_exists_creates_dir(tmp_path: Path) -> None:
+    """Single existing destination triggers normal backup flow."""
+    (tmp_path / "candidate_context").mkdir()
+    (tmp_path / "candidate_context" / "profile.md").write_text("p\n")
+    dest = backup_existing(tmp_path, "20260423T120000Z")
     assert dest.is_dir()
-    assert list(dest.rglob("*")) == []
+    assert (dest / "candidate_context" / "profile.md").read_text() == "p\n"
 
 
 def test_backup_copies_existing_destinations(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #365.

## Summary

Onboarding paste-back returned 500 (\`PermissionError\`) on the very first click. Two-part fix.

## What changed

**Template + docs (durable for future installs):**
- \`ops/compose.yaml.example\`: add \`./state/.backups:/app/.backups\` to the scheduler service volumes
- \`docs/setup/install-docker.md\` step 1 mkdir: add \`.backups\` to the brace expansion

**Defense-in-depth (so a misconfigured stack still works on first run):**
- \`backup_existing()\` now short-circuits when no extant sources are present. First-run onboarding never touches \`/app/.backups\` at all; the bind mount is only required on \`?mode=rerun\`, where there's real state to preserve.

**Test:**
- Existing \`test_backup_on_empty_base_creates_empty_dir\` renamed + reshaped to \`test_backup_on_empty_base_short_circuits_no_mkdir\` to assert the new contract (no mkdir when nothing to back up).
- Added \`test_backup_when_only_one_source_exists_creates_dir\` for the boundary case.

## Migration required

Existing tester stacks (alice, papa, judy, tango, dave) need the new bind mount line added to their \`compose.yaml\` AND \`mkdir -p ./state/.backups\` on the host before the next \`docker compose pull && up -d\`. Without it, first-run onboarding works (defense-in-depth covers it), but \`?mode=rerun\` would still 500.

For each stack:
\`\`\`bash
cd /opt/stacks/findajob-<handle>
mkdir -p state/.backups && sudo chown lad:lad state/.backups
# Edit compose.yaml: add the new bind mount line under the scheduler service volumes
docker compose pull && docker compose up -d
\`\`\`

## Test plan

- [x] \`pytest tests/test_onboarding_injector.py\` → 36 passed
- [x] Full suite: 1278 passed, 1 skipped
- [x] ruff check + format clean
- [ ] Operator manual: rebuild image, deploy clean stack with \`./state/\` containing only the documented dirs (no \`.backups\`), click Inject — confirm onboarding completes without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)