### PR TITLE
feat(onboarding): #336 schema + session_store foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **In-app onboarding interview — schema foundation (#336 Task 1).** New `onboarding_sessions` SQLite table persists multi-turn LLM conversations server-side so the upcoming embedded chat UI can survive tab close + reload. Pure-additive migration via `init_db.py`'s idempotent `CREATE TABLE IF NOT EXISTS` pattern; no behavior change in this commit.
+
+### Migration required
+
+- **Schema:** new `onboarding_sessions` table. Pulled automatically on next `docker compose pull` + entrypoint init_db run; no operator action required.
+
 ## [0.9.2] — 2026-05-01
 
 Patch bump. Three independent web/cron bug fixes surfaced by today's overnight tester triage observation. No migration required — bind mounts, schema, crontab, and compose unchanged. Operators on `:latest` and testers on `:v0.9` both pull and recreate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 ### Added
 
 - **In-app onboarding interview — schema foundation (#336 Task 1).** New `onboarding_sessions` SQLite table persists multi-turn LLM conversations server-side so the upcoming embedded chat UI can survive tab close + reload. Pure-additive migration via `init_db.py`'s idempotent `CREATE TABLE IF NOT EXISTS` pattern; no behavior change in this commit.
+- **In-app onboarding interview — session_store CRUD (#336 Task 2).** New `findajob.onboarding.session_store` module wraps the `onboarding_sessions` table with a frozen `Session` dataclass + six CRUD helpers (`create_session`, `get_session`, `append_turn`, `update_captured_blocks`, `mark_complete`, `set_error`). Pure DB layer — no FastAPI, no LLM client; routes own connection lifecycle. No user-visible behavior change; foundation for Tasks 3+.
 
 ### Migration required
 

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -147,6 +147,18 @@ CREATE TABLE IF NOT EXISTS speculative_requests (
 
 CREATE INDEX IF NOT EXISTS idx_speculative_status ON speculative_requests(status);
 CREATE INDEX IF NOT EXISTS idx_speculative_company_submitted ON speculative_requests(company, submitted_at);
+
+CREATE TABLE IF NOT EXISTS onboarding_sessions (
+    id TEXT PRIMARY KEY,
+    history_json TEXT NOT NULL,
+    captured_blocks_json TEXT NOT NULL DEFAULT '{}',
+    started_at TEXT NOT NULL,
+    last_turn_at TEXT NOT NULL,
+    completed_at TEXT,
+    error_state TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_sessions_completed ON onboarding_sessions(completed_at);
 """)
 conn.close()
 print("Database initialized:", DB_PATH)

--- a/src/findajob/onboarding/session_store.py
+++ b/src/findajob/onboarding/session_store.py
@@ -1,0 +1,109 @@
+"""Onboarding session_store (#336 Task 2).
+
+CRUD wrapper for the ``onboarding_sessions`` table. Pure DB layer — no
+FastAPI, no LLM client. Routes (Task 4) and the interview_runner (Task 3)
+compose this into the full chat-session lifecycle.
+
+Conventions:
+- All write functions commit before returning.
+- Reads return a frozen :class:`Session` dataclass, or ``None`` when missing.
+- Connection lifecycle is owned by the caller (the routes layer); this
+  module never opens its own connection so it stays trivially testable
+  against tmp-path DBs.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+
+@dataclass(frozen=True)
+class Session:
+    id: str
+    history: list[dict[str, str]]
+    captured_blocks: dict[str, str]
+    started_at: str
+    last_turn_at: str
+    completed_at: str | None
+    error_state: str | None
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def create_session(db: sqlite3.Connection) -> str:
+    session_id = str(uuid.uuid4())
+    now = _utcnow_iso()
+    db.execute(
+        """
+        INSERT INTO onboarding_sessions
+            (id, history_json, captured_blocks_json, started_at, last_turn_at)
+        VALUES (?, '[]', '{}', ?, ?)
+        """,
+        (session_id, now, now),
+    )
+    db.commit()
+    return session_id
+
+
+def get_session(db: sqlite3.Connection, session_id: str) -> Session | None:
+    row = db.execute(
+        """SELECT id, history_json, captured_blocks_json, started_at,
+                  last_turn_at, completed_at, error_state
+           FROM onboarding_sessions WHERE id = ?""",
+        (session_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return Session(
+        id=row[0],
+        history=json.loads(row[1]),
+        captured_blocks=json.loads(row[2]),
+        started_at=row[3],
+        last_turn_at=row[4],
+        completed_at=row[5],
+        error_state=row[6],
+    )
+
+
+def append_turn(db: sqlite3.Connection, session_id: str, role: str, content: str) -> None:
+    if role not in ("user", "assistant"):
+        raise ValueError(f"role must be 'user' or 'assistant', got {role!r}")
+    sess = get_session(db, session_id)
+    if sess is None:
+        raise KeyError(session_id)
+    new_history = sess.history + [{"role": role, "content": content}]
+    db.execute(
+        "UPDATE onboarding_sessions SET history_json = ?, last_turn_at = ? WHERE id = ?",
+        (json.dumps(new_history), _utcnow_iso(), session_id),
+    )
+    db.commit()
+
+
+def update_captured_blocks(db: sqlite3.Connection, session_id: str, blocks: dict[str, str]) -> None:
+    db.execute(
+        "UPDATE onboarding_sessions SET captured_blocks_json = ? WHERE id = ?",
+        (json.dumps(blocks), session_id),
+    )
+    db.commit()
+
+
+def mark_complete(db: sqlite3.Connection, session_id: str) -> None:
+    db.execute(
+        "UPDATE onboarding_sessions SET completed_at = ? WHERE id = ?",
+        (_utcnow_iso(), session_id),
+    )
+    db.commit()
+
+
+def set_error(db: sqlite3.Connection, session_id: str, message: str) -> None:
+    db.execute(
+        "UPDATE onboarding_sessions SET error_state = ? WHERE id = ?",
+        (message, session_id),
+    )
+    db.commit()

--- a/tests/test_onboarding_session_store.py
+++ b/tests/test_onboarding_session_store.py
@@ -1,0 +1,241 @@
+"""Unit tests for findajob.onboarding.session_store (#336 Task 2)."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+from findajob.onboarding.session_store import (
+    Session,
+    append_turn,
+    create_session,
+    get_session,
+    mark_complete,
+    set_error,
+    update_captured_blocks,
+)
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Initialize a fresh pipeline.db via init_db.py and yield a connection."""
+    base = tmp_path / "repo"
+    (base / "data").mkdir(parents=True)
+    (base / "src" / "findajob").mkdir(parents=True)
+    (base / "src" / "findajob" / "__init__.py").write_text("")
+    (base / "src" / "findajob" / "paths.py").write_text(f'BASE = r"{base}"\n')
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(base / "src")
+    repo_root = Path(__file__).resolve().parents[1]
+    init_db = repo_root / "scripts" / "init_db.py"
+    result = subprocess.run([sys.executable, str(init_db)], env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+    conn = sqlite3.connect(str(base / "data" / "pipeline.db"))
+    yield conn
+    conn.close()
+
+
+def test_create_session_returns_uuid_and_persists_row(db):
+    sid = create_session(db)
+    # Validates UUID4 format.
+    parsed = uuid.UUID(sid)
+    assert parsed.version == 4
+
+    row = db.execute(
+        "SELECT id, history_json, captured_blocks_json, started_at, last_turn_at, "
+        "completed_at, error_state FROM onboarding_sessions WHERE id = ?",
+        (sid,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == sid
+    assert row[1] == "[]"
+    assert row[2] == "{}"
+    assert row[3] is not None and row[3].endswith("Z")
+    assert row[4] == row[3]
+    assert row[5] is None
+    assert row[6] is None
+
+
+def test_create_session_writes_commit_visible_to_fresh_connection(db, tmp_path):
+    """A second connection to the same DB sees the row immediately."""
+    sid = create_session(db)
+    db_path = tmp_path / "repo" / "data" / "pipeline.db"
+    other = sqlite3.connect(str(db_path))
+    try:
+        row = other.execute("SELECT id FROM onboarding_sessions WHERE id = ?", (sid,)).fetchone()
+        assert row is not None
+    finally:
+        other.close()
+
+
+def test_get_session_roundtrip_returns_frozen_session(db):
+    sid = create_session(db)
+    sess = get_session(db, sid)
+    assert isinstance(sess, Session)
+    assert sess.id == sid
+    assert sess.history == []
+    assert sess.captured_blocks == {}
+    assert sess.completed_at is None
+    assert sess.error_state is None
+    # Frozen dataclass — direct attribute mutation must fail.
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        sess.id = "mutated"  # type: ignore[misc]
+
+
+def test_get_session_returns_none_for_unknown_id(db):
+    assert get_session(db, "nonexistent-uuid") is None
+
+
+def test_append_turn_extends_history_in_order(db):
+    sid = create_session(db)
+    append_turn(db, sid, "assistant", "Welcome — what role are you targeting?")
+    append_turn(db, sid, "user", "Data center operations.")
+    append_turn(db, sid, "assistant", "Got it. Tell me about your last team.")
+    sess = get_session(db, sid)
+    assert sess is not None
+    assert sess.history == [
+        {"role": "assistant", "content": "Welcome — what role are you targeting?"},
+        {"role": "user", "content": "Data center operations."},
+        {"role": "assistant", "content": "Got it. Tell me about your last team."},
+    ]
+
+
+def test_append_turn_updates_last_turn_at(db):
+    sid = create_session(db)
+    sess0 = get_session(db, sid)
+    assert sess0 is not None
+    initial_last = sess0.last_turn_at
+    # Force a clock tick by patching the helper. Otherwise sub-second precision
+    # collapses both timestamps to the same second-resolution string.
+    import findajob.onboarding.session_store as store
+
+    real_utcnow = store._utcnow_iso
+    store._utcnow_iso = lambda: "2099-01-01T00:00:00Z"
+    try:
+        append_turn(db, sid, "assistant", "next turn")
+    finally:
+        store._utcnow_iso = real_utcnow
+    sess1 = get_session(db, sid)
+    assert sess1 is not None
+    assert sess1.last_turn_at == "2099-01-01T00:00:00Z"
+    assert sess1.last_turn_at != initial_last
+
+
+def test_append_turn_rejects_bad_role(db):
+    sid = create_session(db)
+    with pytest.raises(ValueError, match="role must be"):
+        append_turn(db, sid, "system", "not allowed")
+
+
+def test_append_turn_raises_keyerror_for_unknown_session(db):
+    with pytest.raises(KeyError):
+        append_turn(db, "nonexistent", "user", "hi")
+
+
+def test_update_captured_blocks_replaces_map(db):
+    sid = create_session(db)
+    update_captured_blocks(db, sid, {"profile.md": "# profile\n"})
+    sess1 = get_session(db, sid)
+    assert sess1 is not None
+    assert sess1.captured_blocks == {"profile.md": "# profile\n"}
+    # Replacement, not merge.
+    update_captured_blocks(db, sid, {"master_resume.md": "# resume\n"})
+    sess2 = get_session(db, sid)
+    assert sess2 is not None
+    assert sess2.captured_blocks == {"master_resume.md": "# resume\n"}
+
+
+def test_update_captured_blocks_serializes_unicode(db):
+    sid = create_session(db)
+    update_captured_blocks(db, sid, {"profile.md": "# Bröck — naïve résumé"})
+    sess = get_session(db, sid)
+    assert sess is not None
+    assert sess.captured_blocks["profile.md"] == "# Bröck — naïve résumé"
+
+
+def test_mark_complete_sets_completed_at(db):
+    sid = create_session(db)
+    mark_complete(db, sid)
+    sess = get_session(db, sid)
+    assert sess is not None
+    assert sess.completed_at is not None
+    assert sess.completed_at.endswith("Z")
+
+
+def test_set_error_persists_message(db):
+    sid = create_session(db)
+    set_error(db, sid, "OpenRouter 429 — rate limit; retry in 30s")
+    sess = get_session(db, sid)
+    assert sess is not None
+    assert sess.error_state == "OpenRouter 429 — rate limit; retry in 30s"
+    # Empty string clears.
+    set_error(db, sid, "")
+    sess2 = get_session(db, sid)
+    assert sess2 is not None
+    assert sess2.error_state == ""
+
+
+def test_history_json_round_trips_complex_content(db):
+    """Multi-line content with quotes + escapes survives JSON round-trip."""
+    sid = create_session(db)
+    tricky = 'She said "I\'m here" and the LLM\nsaid:\n```python\nprint("x")\n```'
+    append_turn(db, sid, "user", tricky)
+    sess = get_session(db, sid)
+    assert sess is not None
+    assert sess.history[0]["content"] == tricky
+
+
+def test_session_dataclass_is_frozen():
+    """Session must be frozen so callers can't accidentally mutate persisted state."""
+    s = Session(
+        id="x",
+        history=[],
+        captured_blocks={},
+        started_at="2026-05-01T00:00:00Z",
+        last_turn_at="2026-05-01T00:00:00Z",
+        completed_at=None,
+        error_state=None,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        s.id = "mutated"  # type: ignore[misc]
+
+
+def test_get_session_history_is_a_list_not_string(db):
+    """Defends against accidentally returning the raw json string."""
+    sid = create_session(db)
+    append_turn(db, sid, "assistant", "hello")
+    sess = get_session(db, sid)
+    assert sess is not None
+    assert isinstance(sess.history, list)
+    assert isinstance(sess.captured_blocks, dict)
+
+
+def test_create_session_ids_are_unique(db):
+    """Two consecutive create_session calls produce distinct ids."""
+    sid1 = create_session(db)
+    sid2 = create_session(db)
+    assert sid1 != sid2
+
+
+def test_history_json_is_canonical_after_create(db):
+    """create_session must write '[]' / '{}' literals so the dataclass parses cleanly."""
+    sid = create_session(db)
+    raw = db.execute(
+        "SELECT history_json, captured_blocks_json FROM onboarding_sessions WHERE id = ?",
+        (sid,),
+    ).fetchone()
+    assert raw[0] == "[]"
+    assert raw[1] == "{}"
+    # And the parsed values are the empty containers.
+    assert json.loads(raw[0]) == []
+    assert json.loads(raw[1]) == {}

--- a/tests/test_onboarding_sessions_schema.py
+++ b/tests/test_onboarding_sessions_schema.py
@@ -1,0 +1,128 @@
+"""Schema tests for onboarding_sessions table (#336 Task 1).
+
+Mirrors the fixture pattern in test_init_db_schema.py: run init_db.py against
+a scratch BASE, then assert column presence + idempotency.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fresh_db(tmp_path):
+    base = tmp_path / "repo"
+    (base / "data").mkdir(parents=True)
+    (base / "src" / "findajob").mkdir(parents=True)
+    (base / "src" / "findajob" / "__init__.py").write_text("")
+    (base / "src" / "findajob" / "paths.py").write_text(f'BASE = r"{base}"\n')
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(base / "src")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    init_db = repo_root / "scripts" / "init_db.py"
+
+    result = subprocess.run(
+        [sys.executable, str(init_db)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"init_db.py failed: {result.stderr}"
+    return base, init_db, env
+
+
+def _columns(db_path: Path, table: str) -> dict[str, dict]:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {
+            row[1]: {"type": row[2], "notnull": row[3], "default": row[4], "pk": row[5]}
+            for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+    finally:
+        conn.close()
+
+
+def test_onboarding_sessions_table_exists(fresh_db):
+    base, _, _ = fresh_db
+    cols = _columns(base / "data" / "pipeline.db", "onboarding_sessions")
+    assert cols, "onboarding_sessions table not created"
+
+
+def test_onboarding_sessions_required_columns(fresh_db):
+    base, _, _ = fresh_db
+    cols = _columns(base / "data" / "pipeline.db", "onboarding_sessions")
+    expected = {
+        "id",
+        "history_json",
+        "captured_blocks_json",
+        "started_at",
+        "last_turn_at",
+        "completed_at",
+        "error_state",
+    }
+    assert expected <= set(cols.keys()), f"missing columns: {expected - set(cols.keys())}"
+
+
+def test_onboarding_sessions_id_is_primary_key(fresh_db):
+    base, _, _ = fresh_db
+    cols = _columns(base / "data" / "pipeline.db", "onboarding_sessions")
+    assert cols["id"]["pk"] == 1
+
+
+def test_onboarding_sessions_notnull_constraints(fresh_db):
+    base, _, _ = fresh_db
+    cols = _columns(base / "data" / "pipeline.db", "onboarding_sessions")
+    assert cols["history_json"]["notnull"] == 1
+    assert cols["captured_blocks_json"]["notnull"] == 1
+    assert cols["started_at"]["notnull"] == 1
+    assert cols["last_turn_at"]["notnull"] == 1
+    assert cols["completed_at"]["notnull"] == 0
+    assert cols["error_state"]["notnull"] == 0
+
+
+def test_init_db_idempotent(fresh_db):
+    """Running init_db.py twice must not error or duplicate rows/tables."""
+    base, init_db, env = fresh_db
+    result = subprocess.run(
+        [sys.executable, str(init_db)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"second init_db.py run failed: {result.stderr}"
+
+
+def test_onboarding_sessions_insert_and_read_roundtrip(fresh_db):
+    base, _, _ = fresh_db
+    db_path = base / "data" / "pipeline.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            INSERT INTO onboarding_sessions
+                (id, history_json, started_at, last_turn_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            ("test-uuid-1", '[{"role":"assistant","content":"hi"}]', "2026-05-01T00:00:00Z", "2026-05-01T00:00:00Z"),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT id, history_json, captured_blocks_json, completed_at, error_state "
+            "FROM onboarding_sessions WHERE id = ?",
+            ("test-uuid-1",),
+        ).fetchone()
+        assert row[0] == "test-uuid-1"
+        assert row[1] == '[{"role":"assistant","content":"hi"}]'
+        assert row[2] == "{}"
+        assert row[3] is None
+        assert row[4] is None
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

First PR boundary on the #336 in-app onboarding interview plan: pure-additive **schema** + **CRUD layer**, no routes, no UI, no behavior change.

- **Task 1** — new `onboarding_sessions` SQLite table via `init_db.py`'s idempotent CREATE-IF-NOT-EXISTS pattern. Columns: `id`, `history_json`, `captured_blocks_json`, `started_at`, `last_turn_at`, `completed_at`, `error_state`. Index on `completed_at` for cheap filtering of in-flight sessions.
- **Task 2** — `findajob.onboarding.session_store` module: frozen `Session` dataclass + six CRUD helpers (`create_session`, `get_session`, `append_turn`, `update_captured_blocks`, `mark_complete`, `set_error`). Pure DB layer, no FastAPI/LLM dependencies. Routes (Task 4, future PR) will own connection lifecycle.

Plan: `docs/superpowers/plans/2026-05-01-336-in-app-onboarding-interview.md`.

## Why this boundary

Schema + store are foundational primitives for Tasks 3+ (interview_runner, routes, chat UI). Landing them on `main` first de-risks the bigger work and gives the migration pipeline a clear release-notes anchor. Same instinct as #229 Metric Layer C.0.

## Migration

- New `onboarding_sessions` table — pulled automatically on next `docker compose pull` + entrypoint init_db run; no operator action required.
- Tagged `migration-required` per CLAUDE.md so release notes surface it.

## Test plan

- [x] `uv run pytest tests/test_onboarding_sessions_schema.py -v` — 6/6 pass (table creation, columns, NOT NULL constraints, idempotency, insert/read roundtrip exercising the captured_blocks_json default)
- [x] `uv run pytest tests/test_onboarding_session_store.py -v` — 17/17 pass (UUID4 ids, frozen dataclass, history append in order, role validation, KeyError on unknown session, JSON unicode/newline/quote round-trip, mark_complete + set_error, commit visibility across connections)
- [x] `uv run pytest tests/ -k onboarding` — full onboarding suite 145 passed (no regression in parser/injector/voice_processor/onboarding_smoke)
- [x] `uv run ruff check` + `ruff format --check` clean
- [ ] CI green
- [ ] Manual smoke: `docker compose pull` on a tester stack reveals new table via `sqlite3 ... .schema onboarding_sessions` (deferred until merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)