### PR TITLE
feat(onboarding): #336 interview_runner — multi-turn OpenRouter client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ### Added
 
+- **In-app onboarding interview — multi-turn LLM client (#336 Task 3).** New `findajob.onboarding.interview_runner` extends the `openrouter_smoke.py` urllib pattern to multi-turn chat completions. `run_turn(operator_key, system_prompt, history, user_message) -> (assistant_text, usage)` posts the full prior history + new user turn to OpenRouter's chat-completions endpoint, pinned to `anthropic/claude-sonnet-4-6`. Every non-success path raises `InterviewRunnerError` with a `user_message` attribute suitable for verbatim render in the chat UI's error banner — never a generic exception. Pure stdlib; no new deps. Used by upcoming Task 4 routes.
+
+### Added
+
 - **In-app onboarding interview — schema foundation (#336 Task 1).** New `onboarding_sessions` SQLite table persists multi-turn LLM conversations server-side so the upcoming embedded chat UI can survive tab close + reload. Pure-additive migration via `init_db.py`'s idempotent `CREATE TABLE IF NOT EXISTS` pattern; no behavior change in this commit.
 - **In-app onboarding interview — session_store CRUD (#336 Task 2).** New `findajob.onboarding.session_store` module wraps the `onboarding_sessions` table with a frozen `Session` dataclass + six CRUD helpers (`create_session`, `get_session`, `append_turn`, `update_captured_blocks`, `mark_complete`, `set_error`). Pure DB layer — no FastAPI, no LLM client; routes own connection lifecycle. No user-visible behavior change; foundation for Tasks 3+.
 

--- a/src/findajob/onboarding/interview_runner.py
+++ b/src/findajob/onboarding/interview_runner.py
@@ -1,0 +1,150 @@
+"""Multi-turn LLM interview runner for the in-app onboarding flow (#336 Task 3).
+
+Extends the ``openrouter_smoke.py`` urllib pattern to multi-turn chat
+completions. Pure stdlib — no new dependencies.
+
+Used by ``routes/onboarding_interview.py`` (Task 4) — one ``run_turn``
+call per HTMX-posted user turn from the chat UI.
+
+Every non-success path raises :class:`InterviewRunnerError` with a
+``user_message`` attribute suitable for verbatim render in the chat
+UI's error banner (Task 6). Never raises a generic exception.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+INTERVIEW_MODEL = "anthropic/claude-sonnet-4-6"
+INTERVIEW_TIMEOUT_S = 120
+INTERVIEW_MAX_TOKENS = 4096
+
+
+class InterviewRunnerError(Exception):
+    """Raised by :func:`run_turn` on any non-success path.
+
+    ``user_message`` is rendered verbatim in the chat UI's error banner.
+    """
+
+    def __init__(self, user_message: str) -> None:
+        super().__init__(user_message)
+        self.user_message = user_message
+
+
+def run_turn(
+    operator_key: str,
+    system_prompt: str,
+    history: list[dict[str, str]],
+    user_message: str,
+) -> tuple[str, dict]:
+    """Submit one user turn + receive the assistant turn.
+
+    Args:
+        operator_key: ``OPENROUTER_OPERATOR_KEY`` — operator-funded, distinct
+            from the per-tester key collected at finalize.
+        system_prompt: full role system prompt (typically the contents of
+            ``config/roles/onboarding_interviewer.md``).
+        history: prior turns as ``[{"role":"user"|"assistant","content":"..."}, ...]``.
+            May be an empty list for the first turn — caller supplies a
+            synthetic kick-off via ``user_message``.
+        user_message: the new user turn text.
+
+    Returns:
+        ``(assistant_text, usage_dict)``. ``usage_dict`` carries OpenRouter's
+        reported token + cost fields when present (empty dict otherwise).
+
+    Raises:
+        InterviewRunnerError: every non-success path — empty key, network,
+            auth, payment, rate-limit, model 5xx, malformed response.
+    """
+    if not operator_key or not operator_key.strip():
+        raise InterviewRunnerError(
+            "Operator's OpenRouter key is missing. The administrator of this "
+            "findajob deployment must set OPENROUTER_OPERATOR_KEY before the "
+            "in-app interview is available. You can still use the paste-back "
+            "option from the onboarding page."
+        )
+
+    messages: list[dict[str, str]] = [{"role": "system", "content": system_prompt}]
+    messages.extend(history)
+    messages.append({"role": "user", "content": user_message})
+
+    payload = json.dumps(
+        {
+            "model": INTERVIEW_MODEL,
+            "messages": messages,
+            "max_tokens": INTERVIEW_MAX_TOKENS,
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(  # noqa: S310 — POSTing to a fixed https URL
+        OPENROUTER_API_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {operator_key.strip()}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/brockamer/findajob",
+            "X-Title": "findajob in-app onboarding",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=INTERVIEW_TIMEOUT_S) as resp:  # noqa: S310
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        try:
+            error_body = e.read().decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            error_body = ""
+        if e.code == 401:
+            raise InterviewRunnerError(
+                "OpenRouter rejected the operator key (401 Unauthorized). The "
+                "administrator of this deployment needs to update "
+                "OPENROUTER_OPERATOR_KEY."
+            ) from e
+        if e.code == 402:
+            raise InterviewRunnerError(
+                "Operator's OpenRouter account is out of credit (402 Payment "
+                "Required). The administrator needs to add prepaid credit at "
+                "https://openrouter.ai/credits."
+            ) from e
+        if e.code == 429:
+            raise InterviewRunnerError("OpenRouter rate-limited the request (429). Wait a moment and try again.") from e
+        if 500 <= e.code < 600:
+            raise InterviewRunnerError(
+                f"OpenRouter or the upstream model returned a server error "
+                f"({e.code}). Try again in a moment; the issue is on their side."
+            ) from e
+        raise InterviewRunnerError(f"OpenRouter returned HTTP {e.code}: {error_body[:200]}") from e
+    except urllib.error.URLError as e:
+        raise InterviewRunnerError(
+            f"Could not reach OpenRouter ({e.reason}). Check the deployment's network connectivity and try again."
+        ) from e
+    except Exception as e:  # noqa: BLE001
+        raise InterviewRunnerError(f"Unexpected error talking to OpenRouter: {type(e).__name__}: {str(e)[:200]}") from e
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        raise InterviewRunnerError(f"OpenRouter returned non-JSON response: {body[:200]}") from e
+
+    if not isinstance(data, dict) or not data.get("choices"):
+        raise InterviewRunnerError(f"OpenRouter returned unexpected response shape: {body[:200]}")
+
+    try:
+        assistant_text = data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as e:
+        raise InterviewRunnerError(f"Could not parse assistant content from OpenRouter response: {body[:200]}") from e
+
+    if not isinstance(assistant_text, str):
+        raise InterviewRunnerError(f"Assistant content was not a string: {type(assistant_text).__name__}")
+
+    usage_raw = data.get("usage")
+    usage: dict = usage_raw if isinstance(usage_raw, dict) else {}
+
+    return assistant_text, usage

--- a/tests/test_onboarding_interview_runner.py
+++ b/tests/test_onboarding_interview_runner.py
@@ -1,0 +1,335 @@
+"""Tests for findajob.onboarding.interview_runner (#336 Task 3).
+
+Stub urllib.request.urlopen at the module level — no real network calls.
+Mirrors the test pattern in test_openrouter_smoke.py but validates the
+multi-turn semantics: payload includes the full prior history, every
+non-success path raises InterviewRunnerError with a user_message, and
+the (assistant_text, usage) tuple round-trips cleanly.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from findajob.onboarding.interview_runner import (
+    INTERVIEW_MAX_TOKENS,
+    INTERVIEW_MODEL,
+    InterviewRunnerError,
+    run_turn,
+)
+
+
+class _FakeResp:
+    """urlopen() context-manager-compatible fake."""
+
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _ok_resp(body: dict) -> _FakeResp:
+    return _FakeResp(json.dumps(body).encode("utf-8"))
+
+
+def _success_body(text: str = "hello", usage: dict | None = None) -> dict:
+    body = {"choices": [{"message": {"role": "assistant", "content": text}}]}
+    if usage is not None:
+        body["usage"] = usage
+    return body
+
+
+# ── Pre-flight validation ───────────────────────────────────────────────
+
+
+def test_empty_operator_key_raises_immediately() -> None:
+    """No network call when the operator key is empty."""
+    with patch("findajob.onboarding.interview_runner.urllib.request.urlopen") as mock_urlopen:
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("", "system", [], "hi")
+        mock_urlopen.assert_not_called()
+    assert "OPENROUTER_OPERATOR_KEY" in exc.value.user_message
+    assert "paste-back" in exc.value.user_message
+
+
+def test_whitespace_operator_key_raises_immediately() -> None:
+    with patch("findajob.onboarding.interview_runner.urllib.request.urlopen") as mock_urlopen:
+        with pytest.raises(InterviewRunnerError):
+            run_turn("   \t\n  ", "system", [], "hi")
+        mock_urlopen.assert_not_called()
+
+
+# ── Happy path + payload contract ───────────────────────────────────────
+
+
+def test_successful_turn_returns_text_and_usage() -> None:
+    body = _success_body(
+        text="Hi! What role are you targeting?",
+        usage={"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120},
+    )
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_ok_resp(body),
+    ):
+        text, usage = run_turn("sk-or-v1-operator", "ROLE PROMPT", [], "begin")
+    assert text == "Hi! What role are you targeting?"
+    assert usage == {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120}
+
+
+def test_payload_contains_system_history_and_user_in_order() -> None:
+    """Multi-turn contract: system + full prior history + new user_message."""
+    history = [
+        {"role": "user", "content": "begin"},
+        {"role": "assistant", "content": "What role?"},
+        {"role": "user", "content": "DC ops"},
+        {"role": "assistant", "content": "Tell me about your team."},
+    ]
+    captured: dict = {}
+
+    def _capture(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _ok_resp(_success_body("Got it."))
+
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=_capture,
+    ):
+        run_turn("sk-or-v1-operator", "SYSTEM", history, "Founded RTP Labs at Meta.")
+
+    assert captured["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert captured["body"]["model"] == INTERVIEW_MODEL
+    assert captured["body"]["max_tokens"] == INTERVIEW_MAX_TOKENS
+    assert captured["body"]["messages"] == [
+        {"role": "system", "content": "SYSTEM"},
+        {"role": "user", "content": "begin"},
+        {"role": "assistant", "content": "What role?"},
+        {"role": "user", "content": "DC ops"},
+        {"role": "assistant", "content": "Tell me about your team."},
+        {"role": "user", "content": "Founded RTP Labs at Meta."},
+    ]
+
+
+def test_authorization_header_uses_operator_key() -> None:
+    captured: dict = {}
+
+    def _capture(req, timeout=None):
+        captured["headers"] = dict(req.headers)
+        return _ok_resp(_success_body())
+
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=_capture,
+    ):
+        run_turn("  sk-or-v1-operator-with-spaces  ", "SYSTEM", [], "hi")
+
+    # urllib title-cases header keys.
+    assert captured["headers"]["Authorization"] == "Bearer sk-or-v1-operator-with-spaces"
+    assert captured["headers"]["Content-type"] == "application/json"
+    assert "findajob" in captured["headers"]["X-title"].lower()
+
+
+def test_empty_history_works_for_first_turn() -> None:
+    """First turn: history=[] + user kick-off → still valid payload."""
+    captured: dict = {}
+
+    def _capture(req, timeout=None):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _ok_resp(_success_body("Welcome."))
+
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=_capture,
+    ):
+        text, _ = run_turn("sk-or-v1-operator", "SYSTEM", [], "begin the interview")
+    assert text == "Welcome."
+    assert captured["body"]["messages"] == [
+        {"role": "system", "content": "SYSTEM"},
+        {"role": "user", "content": "begin the interview"},
+    ]
+
+
+def test_usage_defaults_to_empty_dict_when_omitted() -> None:
+    body = _success_body("ok")  # no usage field
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_ok_resp(body),
+    ):
+        _, usage = run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert usage == {}
+
+
+def test_usage_defaults_to_empty_dict_when_non_dict() -> None:
+    """Defensive: OpenRouter returns 'usage': null or some unexpected shape."""
+    body = {"choices": [{"message": {"content": "ok"}}], "usage": None}
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_ok_resp(body),
+    ):
+        _, usage = run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert usage == {}
+
+
+# ── HTTP error paths ────────────────────────────────────────────────────
+
+
+def test_401_raises_with_friendly_admin_message() -> None:
+    err = HTTPError("u", 401, "Unauthorized", {}, fp=io.BytesIO(b'{"error":"bad key"}'))  # type: ignore[arg-type]
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    msg = exc.value.user_message
+    assert "401" in msg
+    assert "OPENROUTER_OPERATOR_KEY" in msg
+
+
+def test_402_raises_with_credit_message() -> None:
+    err = HTTPError("u", 402, "Payment Required", {}, fp=io.BytesIO(b""))  # type: ignore[arg-type]
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    msg = exc.value.user_message
+    assert "credit" in msg.lower()
+    assert "https://openrouter.ai/credits" in msg
+
+
+def test_429_raises_with_rate_limit_message() -> None:
+    err = HTTPError("u", 429, "Too Many Requests", {}, fp=io.BytesIO(b""))  # type: ignore[arg-type]
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "429" in exc.value.user_message or "rate" in exc.value.user_message.lower()
+
+
+@pytest.mark.parametrize("code", [500, 502, 503, 504, 599])
+def test_5xx_raises_with_server_error_message(code: int) -> None:
+    err = HTTPError("u", code, "Server Error", {}, fp=io.BytesIO(b""))  # type: ignore[arg-type]
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    msg = exc.value.user_message
+    assert str(code) in msg
+    assert "server error" in msg.lower() or "their side" in msg.lower()
+
+
+def test_other_4xx_raises_with_generic_http_message() -> None:
+    err = HTTPError("u", 418, "I'm a teapot", {}, fp=io.BytesIO(b'{"detail":"teapot"}'))  # type: ignore[arg-type]
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=err,
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "418" in exc.value.user_message
+
+
+# ── Network + parse error paths ─────────────────────────────────────────
+
+
+def test_network_error_raises_with_connectivity_message() -> None:
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=URLError("Name or service not known"),
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "OpenRouter" in exc.value.user_message
+    assert "network" in exc.value.user_message.lower()
+
+
+def test_unexpected_exception_raises_friendly_wrapper() -> None:
+    """If urlopen raises something completely unexpected, we still wrap it."""
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        side_effect=RuntimeError("disk on fire"),
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "Unexpected error" in exc.value.user_message
+    assert "RuntimeError" in exc.value.user_message
+
+
+def test_non_json_response_raises() -> None:
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_FakeResp(b"<html>500 Bad Gateway</html>"),
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "non-JSON" in exc.value.user_message
+
+
+def test_response_missing_choices_raises() -> None:
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_ok_resp({"unexpected": "shape"}),
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "unexpected response shape" in exc.value.user_message.lower()
+
+
+def test_response_with_empty_choices_raises() -> None:
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_ok_resp({"choices": []}),
+    ):
+        with pytest.raises(InterviewRunnerError):
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+
+
+def test_response_missing_message_content_raises() -> None:
+    """choices[0] exists but has no 'message' field."""
+    body = {"choices": [{"index": 0, "finish_reason": "stop"}]}
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_ok_resp(body),
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "Could not parse assistant content" in exc.value.user_message
+
+
+def test_assistant_content_non_string_raises() -> None:
+    """Defensive: some models return content as a list of blocks."""
+    body = {"choices": [{"message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}}]}
+    with patch(
+        "findajob.onboarding.interview_runner.urllib.request.urlopen",
+        return_value=_ok_resp(body),
+    ):
+        with pytest.raises(InterviewRunnerError) as exc:
+            run_turn("sk-or-v1-operator", "SYSTEM", [], "hi")
+    assert "not a string" in exc.value.user_message
+
+
+# ── Model pin sanity ────────────────────────────────────────────────────
+
+
+def test_interview_model_is_sonnet_4_6() -> None:
+    """Model pin: see issue #336 'Decisions adopted'."""
+    assert INTERVIEW_MODEL == "anthropic/claude-sonnet-4-6"


### PR DESCRIPTION
## Summary

Second PR boundary on the #336 in-app onboarding interview plan: pure-additive **multi-turn LLM client**. Builds on schema + session_store from #381.

- **Task 3** — `findajob.onboarding.interview_runner.run_turn(operator_key, system_prompt, history, user_message) -> (assistant_text, usage)`. Posts full prior history + new user turn to OpenRouter chat-completions, pinned to `anthropic/claude-sonnet-4-6` (per #336 "Decisions adopted"). 120s timeout, 4096 max_tokens.
- **`InterviewRunnerError`** wraps every non-success path (empty/whitespace key, network, 401/402/429/5xx, generic-4xx, non-JSON, missing choices, choices[0] missing message.content, non-string content) with a `user_message` attribute the chat UI (Task 6) will render verbatim. Never raises a generic exception.
- Pure stdlib (urllib + json) — no new dependencies. Module is **not yet imported** anywhere; Task 4 (routes, future PR) supplies the callsite.

Plan: `docs/superpowers/plans/2026-05-01-336-in-app-onboarding-interview.md`.

## Why this boundary

The runner is a small, tightly-scoped LLM client with a self-contained contract. Landing it on `main` first means Task 4's routes can stack against a reviewed API. If review reshapes the (text, usage) tuple or the error-message phrasing, the change is one file deep — not three layers down a route + UI stack.

## No migration

Pure-additive code, no schema/config/crontab/mount changes.

## Test plan

- [x] `uv run pytest tests/test_onboarding_interview_runner.py -v` — 25/25 pass:
  - Pre-flight: empty/whitespace key raises with no network call (mock not called)
  - Happy path: tuple round-trip with usage dict
  - Payload contract: system + full prior history + new user_message in order, model + max_tokens correct
  - Authorization header: `Bearer <trimmed-key>`
  - Empty history (first-turn case)
  - Usage defaults to `{}` when omitted or null
  - HTTP errors: 401 / 402 / 429 / parameterized 5xx (500/502/503/504/599) / generic 4xx (418)
  - Network: `URLError` → connectivity message
  - Wrap unknown: `RuntimeError` → "Unexpected error" with type name
  - Parse defenses: non-JSON, missing `choices`, empty `choices`, missing `message.content`, non-string content
  - Model pin sanity: `INTERVIEW_MODEL == "anthropic/claude-sonnet-4-6"`
- [x] `uv run pytest tests/ -k onboarding` — full onboarding suite 170/170 (was 145; +25 from Task 3)
- [x] `uv run ruff check` + `ruff format --check` clean
- [ ] CI green
- [ ] Manual smoke deferred to Task 4 PR — runner has no callsite yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)