### PR TITLE
feat(onboarding): #336 in-app interview routes (Task 4)

### DIFF
--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -78,6 +78,14 @@ def create_app(
             admin_stacks.router,
             dependencies=[Depends(require_onboarding_complete)],
         )
+    # In-app onboarding interview routes (#336): only registered when the
+    # operator opts in by setting OPENROUTER_OPERATOR_KEY. When unset, the
+    # in-app interview is unavailable and /onboarding/ falls back to
+    # paste-back only — no broken affordance (acceptance criterion #6).
+    if (os.environ.get("OPENROUTER_OPERATOR_KEY") or "").strip():
+        from findajob.web.routes import onboarding_interview
+
+        app.include_router(onboarding_interview.router)
     install_basic_auth(app)
     return app
 

--- a/src/findajob/web/routes/onboarding_interview.py
+++ b/src/findajob/web/routes/onboarding_interview.py
@@ -1,0 +1,308 @@
+"""In-app onboarding interview routes (#336 Task 4).
+
+Wires session_store + interview_runner + parser + injector into a chat
+surface so non-technical testers can complete onboarding without leaving
+findajob's UI. Conditionally registered in :func:`findajob.web.app.create_app`
+only when ``OPENROUTER_OPERATOR_KEY`` is set — when unset, the in-app
+interview is unavailable and ``/onboarding/`` falls back to paste-back only
+(acceptance criterion #6 of #336).
+
+Cross-task constraints (from #336 Session 2026-05-01):
+- Emission detection runs against the cumulative assistant transcript on every
+  turn, driven by :data:`findajob.onboarding.parser.ALLOWED_FILENAMES` (NEVER
+  hardcoded counts) so #212 / #283 changes land cleanly.
+- Finalize collects the user's OpenRouter key in a section structured to accept
+  RapidAPI + Google fields later (#339).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from findajob.onboarding import OnboardingSmokeCheckFailed, inject
+from findajob.onboarding.interview_runner import InterviewRunnerError, run_turn
+from findajob.onboarding.parser import ALLOWED_FILENAMES, parse_emission
+from findajob.onboarding.session_store import (
+    append_turn,
+    create_session,
+    get_session,
+    mark_complete,
+    set_error,
+    update_captured_blocks,
+)
+
+router = APIRouter()
+
+OPERATOR_KEY_ENV = "OPENROUTER_OPERATOR_KEY"
+_SYSTEM_PROMPT_RELPATH = Path("config") / "roles" / "onboarding_interviewer.md"
+_KICKOFF_USER_MESSAGE = "Begin the interview."
+
+
+def _operator_key() -> str:
+    return (os.environ.get(OPERATOR_KEY_ENV) or "").strip()
+
+
+def _conn(request: Request) -> sqlite3.Connection:
+    db_path: Path = request.app.state.db_path
+    conn = sqlite3.connect(str(db_path), timeout=30)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _system_prompt(request: Request) -> str:
+    base_root: Path = request.app.state.base_root
+    return (base_root / _SYSTEM_PROMPT_RELPATH).read_text(encoding="utf-8")
+
+
+def _captured_from_history(history: list[dict[str, str]]) -> dict[str, str]:
+    """Run :func:`parse_emission` over the cumulative assistant transcript.
+
+    LLMs occasionally split emission blocks across turns, so we re-scan
+    the full assistant transcript on every turn rather than just the latest
+    message. ``parse_emission`` is idempotent — re-running it cannot lose
+    blocks that were captured earlier.
+    """
+    transcript = "\n\n".join(turn["content"] for turn in history if turn.get("role") == "assistant")
+    return parse_emission(transcript).found
+
+
+def _render_chat(
+    request: Request,
+    *,
+    session_id: str,
+    history: list[dict[str, str]],
+    captured: dict[str, str],
+    error: str | None = None,
+    status_code: int = 200,
+) -> HTMLResponse:
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="onboarding/interview.html",
+        context={
+            "session_id": session_id,
+            "history": history,
+            "captured_count": len(captured),
+            "required_count": len(ALLOWED_FILENAMES),
+            "finalize_ready": len(captured) >= len(ALLOWED_FILENAMES),
+            "error": error,
+        },
+        status_code=status_code,
+    )
+
+
+@router.post("/onboarding/interview/start", response_model=None)
+def start_interview(request: Request) -> HTMLResponse | RedirectResponse:
+    """Create a session, run the synthetic kickoff turn, redirect to the chat page.
+
+    The router is registered only when ``OPENROUTER_OPERATOR_KEY`` is set, but
+    we re-check here so the failure mode is a 503 rather than a 500 if env
+    state shifts mid-process (and so this module is safe to import in tests
+    that monkeypatch env after app construction).
+    """
+    operator_key = _operator_key()
+    if not operator_key:
+        raise HTTPException(status_code=503, detail="In-app interview unavailable on this deployment")
+
+    conn = _conn(request)
+    try:
+        session_id = create_session(conn)
+        try:
+            assistant_text, _usage = run_turn(
+                operator_key=operator_key,
+                system_prompt=_system_prompt(request),
+                history=[],
+                user_message=_KICKOFF_USER_MESSAGE,
+            )
+        except InterviewRunnerError as e:
+            set_error(conn, session_id, e.user_message)
+            return _render_chat(
+                request,
+                session_id=session_id,
+                history=[],
+                captured={},
+                error=e.user_message,
+                status_code=502,
+            )
+
+        append_turn(conn, session_id, "user", _KICKOFF_USER_MESSAGE)
+        append_turn(conn, session_id, "assistant", assistant_text)
+        captured = _captured_from_history(
+            [
+                {"role": "user", "content": _KICKOFF_USER_MESSAGE},
+                {"role": "assistant", "content": assistant_text},
+            ]
+        )
+        if captured:
+            update_captured_blocks(conn, session_id, captured)
+    finally:
+        conn.close()
+
+    return RedirectResponse(url=f"/onboarding/interview/{session_id}", status_code=303)
+
+
+@router.post("/onboarding/interview/turn", response_class=HTMLResponse)
+def post_turn(
+    request: Request,
+    session_id: str = Form(...),
+    message: str = Form(...),
+) -> HTMLResponse:
+    """Append a user turn, call ``run_turn``, persist + scan the assistant reply."""
+    operator_key = _operator_key()
+    if not operator_key:
+        raise HTTPException(status_code=503, detail="In-app interview unavailable on this deployment")
+
+    conn = _conn(request)
+    try:
+        sess = get_session(conn, session_id)
+        if sess is None:
+            raise HTTPException(status_code=404, detail="session not found")
+
+        try:
+            assistant_text, _usage = run_turn(
+                operator_key=operator_key,
+                system_prompt=_system_prompt(request),
+                history=sess.history,
+                user_message=message,
+            )
+        except InterviewRunnerError as e:
+            set_error(conn, session_id, e.user_message)
+            return _render_chat(
+                request,
+                session_id=session_id,
+                history=sess.history,
+                captured=sess.captured_blocks,
+                error=e.user_message,
+                status_code=502,
+            )
+
+        append_turn(conn, session_id, "user", message)
+        append_turn(conn, session_id, "assistant", assistant_text)
+
+        new_history = sess.history + [
+            {"role": "user", "content": message},
+            {"role": "assistant", "content": assistant_text},
+        ]
+        captured = _captured_from_history(new_history)
+        if captured != sess.captured_blocks:
+            update_captured_blocks(conn, session_id, captured)
+
+        templates = request.app.state.templates
+        return templates.TemplateResponse(
+            request=request,
+            name="onboarding/_turn.html",
+            context={
+                "session_id": session_id,
+                "user_message": message,
+                "assistant_message": assistant_text,
+                "captured_count": len(captured),
+                "required_count": len(ALLOWED_FILENAMES),
+                "finalize_ready": len(captured) >= len(ALLOWED_FILENAMES),
+            },
+        )
+    finally:
+        conn.close()
+
+
+@router.get("/onboarding/interview/{session_id}", response_class=HTMLResponse)
+def resume_interview(request: Request, session_id: str) -> HTMLResponse:
+    """Render the full chat UI seeded with the persisted history."""
+    conn = _conn(request)
+    try:
+        sess = get_session(conn, session_id)
+    finally:
+        conn.close()
+    if sess is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    return _render_chat(
+        request,
+        session_id=session_id,
+        history=sess.history,
+        captured=sess.captured_blocks,
+        error=sess.error_state,
+    )
+
+
+@router.post("/onboarding/interview/{session_id}/finalize", response_model=None)
+def finalize_interview(
+    request: Request,
+    session_id: str,
+    openrouter_api_key: str = Form(default=""),
+) -> HTMLResponse | RedirectResponse:
+    """Validate captured blocks, run :func:`inject`, mark session complete."""
+    conn = _conn(request)
+    try:
+        sess = get_session(conn, session_id)
+        if sess is None:
+            raise HTTPException(status_code=404, detail="session not found")
+
+        missing = [name for name in ALLOWED_FILENAMES if name not in sess.captured_blocks]
+        if missing:
+            return _render_chat(
+                request,
+                session_id=session_id,
+                history=sess.history,
+                captured=sess.captured_blocks,
+                error=(
+                    f"Interview not yet complete — still missing {len(missing)} of "
+                    f"{len(ALLOWED_FILENAMES)} required blocks: {', '.join(missing)}. "
+                    "Continue the conversation until every block has been emitted."
+                ),
+                status_code=400,
+            )
+
+        if not openrouter_api_key.strip():
+            return _render_chat(
+                request,
+                session_id=session_id,
+                history=sess.history,
+                captured=sess.captured_blocks,
+                error=(
+                    "OpenRouter API key is missing. Paste your personal key (starts "
+                    "with sk-or-v1-…) from https://openrouter.ai/keys into the API key "
+                    "field, then click Finalize again. The key is required so we can "
+                    "verify it works before sealing your stack."
+                ),
+                status_code=400,
+            )
+
+        base_root: Path = request.app.state.base_root
+        try:
+            inject_result = inject(base_root, sess.captured_blocks, openrouter_api_key=openrouter_api_key)
+        except OnboardingSmokeCheckFailed as e:
+            return _render_chat(
+                request,
+                session_id=session_id,
+                history=sess.history,
+                captured=sess.captured_blocks,
+                error=(
+                    "OpenRouter rejected the key when we tried to verify it. "
+                    f"{e.user_message} Fix the key and click Finalize again — your "
+                    "interview history is preserved."
+                ),
+                status_code=400,
+            )
+
+        mark_complete(conn, session_id)
+    finally:
+        conn.close()
+
+    # Mirror the existing /onboarding/inject contract: clear the cached guard
+    # state and render complete.html inline. No /onboarding/complete GET
+    # route exists yet, so a redirect would 404.
+    request.app.state.onboarding_complete = True
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="onboarding/complete.html",
+        context={
+            "discovery_success": inject_result.discovery.success,
+            "discovery_count": inject_result.discovery.count,
+            "discovery_error": inject_result.discovery.error,
+        },
+    )

--- a/src/findajob/web/templates/onboarding/_turn.html
+++ b/src/findajob/web/templates/onboarding/_turn.html
@@ -1,0 +1,28 @@
+{# Single-turn HTMX partial (#336 Task 4 stub).
+
+   Stub template — Task 5 replaces with role-styled message bubbles + the
+   captured/required progress badge. Tests assert on the assistant message
+   content appearing in the response, so this minimal version covers them.
+#}
+<div class="border rounded p-3" data-role="user">
+  <div class="text-xs uppercase text-slate-500">user</div>
+  <div class="whitespace-pre-wrap">{{ user_message }}</div>
+</div>
+<div class="border rounded p-3" data-role="assistant">
+  <div class="text-xs uppercase text-slate-500">assistant</div>
+  <div class="whitespace-pre-wrap">{{ assistant_message }}</div>
+</div>
+<p class="text-xs text-slate-500" data-captured-count="{{ captured_count }}" data-required-count="{{ required_count }}">
+  Captured {{ captured_count }} of {{ required_count }} required blocks.
+</p>
+{% if finalize_ready %}
+<form action="/onboarding/interview/{{ session_id }}/finalize" method="post" hx-boost="false"
+      hx-swap-oob="true" id="finalize-form" class="border-t pt-4 space-y-2 mt-4">
+  <h2 class="text-lg font-medium">Finalize</h2>
+  <label class="block text-sm">
+    Your OpenRouter API key
+    <input type="text" name="openrouter_api_key" required class="w-full border rounded p-2 mt-1">
+  </label>
+  <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">Finalize</button>
+</form>
+{% endif %}

--- a/src/findajob/web/templates/onboarding/interview.html
+++ b/src/findajob/web/templates/onboarding/interview.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{# In-app onboarding interview chat surface (#336 Task 4 stub).
+
+   Stub template — Task 5 replaces this with the full Tailwind/HTMX UI.
+   Renders just enough to verify route behavior in tests:
+   - the session_id (so HTMX form posts can target /interview/turn)
+   - the message history (so resume tests can find their markers)
+   - captured_count / required_count
+   - error banner when set
+   - finalize form when finalize_ready
+#}
+
+{% block title %}Onboarding interview — findajob{% endblock %}
+
+{% block content %}
+<div class="max-w-3xl mx-auto p-6 space-y-4" data-session-id="{{ session_id }}">
+  <h1 class="text-2xl font-semibold">Onboarding interview</h1>
+
+  {% if error %}
+  <div class="border border-red-300 bg-red-50 text-red-900 px-4 py-3 rounded">
+    <p class="font-medium">Something went wrong</p>
+    <p class="text-sm mt-1">{{ error }}</p>
+  </div>
+  {% endif %}
+
+  <p class="text-sm text-slate-600">
+    Captured {{ captured_count }} of {{ required_count }} required blocks.
+  </p>
+
+  <div id="messages" class="space-y-3">
+    {% for turn in history %}
+    <div class="border rounded p-3" data-role="{{ turn.role }}">
+      <div class="text-xs uppercase text-slate-500">{{ turn.role }}</div>
+      <div class="whitespace-pre-wrap">{{ turn.content }}</div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <form action="/onboarding/interview/turn" method="post" hx-boost="false">
+    <input type="hidden" name="session_id" value="{{ session_id }}">
+    <textarea name="message" rows="3" required
+              class="w-full border rounded p-2"
+              placeholder="Type your reply..."></textarea>
+    <button type="submit" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded">Send</button>
+  </form>
+
+  {% if finalize_ready %}
+  <form action="/onboarding/interview/{{ session_id }}/finalize" method="post" hx-boost="false"
+        class="border-t pt-4 space-y-2">
+    <h2 class="text-lg font-medium">Finalize</h2>
+    <label class="block text-sm">
+      Your OpenRouter API key (starts with <code>sk-or-v1-</code>)
+      <input type="text" name="openrouter_api_key" required class="w-full border rounded p-2 mt-1">
+    </label>
+    <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded">Finalize</button>
+  </form>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_web_onboarding_interview_routes.py
+++ b/tests/test_web_onboarding_interview_routes.py
@@ -1,0 +1,499 @@
+"""Integration tests for /onboarding/interview/* routes (#336 Task 4).
+
+The four routes wire session_store + interview_runner + parser + injector
+into a chat surface. Tests mock the OpenRouter call (interview_runner.run_turn)
+and the OpenRouter smoke check, then assert on observable state: session
+rows, captured_blocks, redirects, error_state.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding.interview_runner import InterviewRunnerError
+from findajob.web.app import create_app
+
+# Schema covers the three tables the route module + the onboarding guard
+# touch: jobs/audit_log (used by the guard's no-op-OK path under TestClient)
+# and onboarding_sessions (the route's read/write target).
+_SCHEMA = """
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    stage TEXT DEFAULT 'discovered',
+    created_at TEXT DEFAULT (datetime('now')),
+    synthetic INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    field_changed TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_at TEXT DEFAULT (datetime('now'))
+);
+CREATE TABLE onboarding_sessions (
+    id TEXT PRIMARY KEY,
+    history_json TEXT NOT NULL,
+    captured_blocks_json TEXT NOT NULL DEFAULT '{}',
+    started_at TEXT NOT NULL,
+    last_turn_at TEXT NOT NULL,
+    completed_at TEXT,
+    error_state TEXT
+);
+"""
+
+_OPERATOR_KEY = "sk-or-v1-operator-test"
+_USER_KEY = "sk-or-v1-user-test"
+
+
+def _build_emission_blob() -> str:
+    """A complete emission covering every ALLOWED_FILENAMES entry.
+
+    Used to test the finalize path. Each block body is minimal but parses.
+    """
+    from findajob.onboarding.parser import ALLOWED_FILENAMES
+
+    parts = []
+    for name in ALLOWED_FILENAMES:
+        parts.append(f"<<<FILE: {name}>>>\nbody for {name}\n<<<END FILE: {name}>>>")
+    return "\n\n".join(parts)
+
+
+@pytest.fixture
+def base_root(tmp_path: Path) -> Path:
+    (tmp_path / "data").mkdir()
+    (tmp_path / "companies").mkdir()
+    (tmp_path / "candidate_context").mkdir()
+    (tmp_path / "config" / "roles").mkdir(parents=True)
+    repo_role = Path(__file__).parent.parent / "config" / "roles" / "onboarding_interviewer.md"
+    shutil.copy(repo_role, tmp_path / "config" / "roles" / "onboarding_interviewer.md")
+
+    db_path = tmp_path / "data" / "pipeline.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_SCHEMA)
+    conn.close()
+    return tmp_path
+
+
+@pytest.fixture
+def client_with_key(base_root: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("OPENROUTER_OPERATOR_KEY", _OPERATOR_KEY)
+    app = create_app(
+        companies_root=base_root / "companies",
+        db_path=base_root / "data" / "pipeline.db",
+        base_root=base_root,
+    )
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture
+def client_no_key(base_root: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.delenv("OPENROUTER_OPERATOR_KEY", raising=False)
+    app = create_app(
+        companies_root=base_root / "companies",
+        db_path=base_root / "data" / "pipeline.db",
+        base_root=base_root,
+    )
+    return TestClient(app, follow_redirects=False)
+
+
+def _stub_run_turn(monkeypatch: pytest.MonkeyPatch, assistant_text: str) -> list[dict[str, Any]]:
+    """Replace run_turn with a stub that records calls and returns a fixed reply."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake(operator_key: str, system_prompt: str, history: list, user_message: str):
+        calls.append(
+            {
+                "operator_key": operator_key,
+                "system_prompt": system_prompt,
+                "history": list(history),
+                "user_message": user_message,
+            }
+        )
+        return assistant_text, {"prompt_tokens": 10, "completion_tokens": 20}
+
+    monkeypatch.setattr("findajob.web.routes.onboarding_interview.run_turn", _fake)
+    return calls
+
+
+def _stub_run_turn_error(monkeypatch: pytest.MonkeyPatch, message: str) -> None:
+    def _fake(*_args, **_kwargs):
+        raise InterviewRunnerError(message)
+
+    monkeypatch.setattr("findajob.web.routes.onboarding_interview.run_turn", _fake)
+
+
+def _read_session(base_root: Path, session_id: str) -> tuple[str, str, str | None, str | None]:
+    """Return (history_json, captured_blocks_json, completed_at, error_state)."""
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        row = conn.execute(
+            "SELECT history_json, captured_blocks_json, completed_at, error_state "
+            "FROM onboarding_sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, f"session {session_id} not found"
+    return row
+
+
+# ── Conditional registration ──────────────────────────────────────────────
+
+
+def test_router_not_registered_when_operator_key_unset(client_no_key: TestClient) -> None:
+    """Acceptance #6: when OPENROUTER_OPERATOR_KEY is unset, the in-app
+    interview is unavailable — routes return 404 (not registered)."""
+    resp = client_no_key.post("/onboarding/interview/start")
+    assert resp.status_code == 404
+
+
+def test_paste_back_path_still_available_when_operator_key_unset(client_no_key: TestClient) -> None:
+    """Acceptance #6 negative side: existing paste-back must keep working."""
+    resp = client_no_key.get("/onboarding/")
+    assert resp.status_code == 200
+    assert 'name="emission"' in resp.text  # paste form survives
+
+
+def test_router_registered_when_operator_key_set(client_with_key: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_run_turn(monkeypatch, "hello — what's your full name?")
+    resp = client_with_key.post("/onboarding/interview/start")
+    # Whatever the response, it MUST NOT be 404 (router not registered).
+    assert resp.status_code != 404
+
+
+# ── /start ────────────────────────────────────────────────────────────────
+
+
+def test_start_creates_session_and_runs_first_turn(
+    client_with_key: TestClient,
+    base_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _stub_run_turn(monkeypatch, "hello — what's your full name?")
+    resp = client_with_key.post("/onboarding/interview/start")
+
+    assert resp.status_code == 303  # redirect to GET /interview/{sid}
+    location = resp.headers["location"]
+    assert location.startswith("/onboarding/interview/")
+    sid = location.rsplit("/", 1)[-1]
+
+    # run_turn was called exactly once with the operator key + non-empty system prompt + empty history
+    assert len(calls) == 1
+    assert calls[0]["operator_key"] == _OPERATOR_KEY
+    assert "interviewer" in calls[0]["system_prompt"].lower() or len(calls[0]["system_prompt"]) > 100
+    assert calls[0]["history"] == []
+    assert calls[0]["user_message"]  # synthetic kickoff non-empty
+
+    # Session row has both turns persisted
+    history_json, _captured_json, completed_at, error_state = _read_session(base_root, sid)
+    import json as _json
+
+    history = _json.loads(history_json)
+    assert len(history) == 2
+    assert history[0]["role"] == "user"
+    assert history[1]["role"] == "assistant"
+    assert history[1]["content"] == "hello — what's your full name?"
+    assert completed_at is None
+    assert error_state is None
+
+
+def test_start_handles_runner_error(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_run_turn_error(monkeypatch, "OpenRouter rejected the operator key (401 Unauthorized).")
+    resp = client_with_key.post("/onboarding/interview/start")
+
+    # Error responses render in-page rather than redirecting (so the user sees the banner)
+    assert resp.status_code in (200, 502)
+    assert "401" in resp.text or "OpenRouter" in resp.text
+
+    # Session was created and error_state captured (so the operator can debug from the DB)
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        row = conn.execute(
+            "SELECT id, error_state FROM onboarding_sessions ORDER BY started_at DESC LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row[1] is not None
+    assert "401" in row[1] or "OpenRouter" in row[1]
+
+
+# ── /turn ─────────────────────────────────────────────────────────────────
+
+
+def _create_session_directly(base_root: Path) -> str:
+    """Insert a session row directly so /turn tests don't depend on /start."""
+    from findajob.onboarding.session_store import create_session
+
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        sid = create_session(conn)
+    finally:
+        conn.close()
+    return sid
+
+
+def test_turn_appends_pair_and_returns_assistant_partial(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sid = _create_session_directly(base_root)
+    _stub_run_turn(monkeypatch, "got it — and your timezone?")
+
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "Test User"},
+    )
+    assert resp.status_code == 200
+    # The assistant turn body should appear in the response (partial render)
+    assert "got it — and your timezone?" in resp.text
+
+    history_json, _captured, _completed, _err = _read_session(base_root, sid)
+    import json as _json
+
+    history = _json.loads(history_json)
+    assert len(history) == 2
+    assert history[0] == {"role": "user", "content": "Test User"}
+    assert history[1] == {"role": "assistant", "content": "got it — and your timezone?"}
+
+
+def test_turn_passes_persisted_history_to_run_turn(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Multi-turn safety: each /turn call must ship the full prior history."""
+    from findajob.onboarding.session_store import append_turn
+
+    sid = _create_session_directly(base_root)
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        append_turn(conn, sid, "user", "kickoff")
+        append_turn(conn, sid, "assistant", "first question?")
+    finally:
+        conn.close()
+
+    calls = _stub_run_turn(monkeypatch, "next question?")
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "first answer"},
+    )
+    assert resp.status_code == 200
+    assert len(calls) == 1
+    history_sent = calls[0]["history"]
+    # The prior two turns must have been included; the new user message is in user_message
+    assert {"role": "user", "content": "kickoff"} in history_sent
+    assert {"role": "assistant", "content": "first question?"} in history_sent
+    assert calls[0]["user_message"] == "first answer"
+
+
+def test_turn_detects_emission_blocks_on_assistant_message(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the assistant emits a `<<<FILE: ...>>>` block, captured_blocks updates."""
+    sid = _create_session_directly(base_root)
+    assistant_with_block = (
+        "Great — here is your profile:\n\n"
+        "<<<FILE: profile.md>>>\nname: Test\n<<<END FILE: profile.md>>>\n\n"
+        "Now let's continue."
+    )
+    _stub_run_turn(monkeypatch, assistant_with_block)
+
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "ready"},
+    )
+    assert resp.status_code == 200
+
+    _hist, captured_json, _completed, _err = _read_session(base_root, sid)
+    import json as _json
+
+    captured = _json.loads(captured_json)
+    assert "profile.md" in captured
+    assert "name: Test" in captured["profile.md"]
+
+
+def test_turn_handles_runner_error(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(monkeypatch, "OpenRouter rate-limited the request (429).")
+
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "anything"},
+    )
+    assert resp.status_code in (200, 502, 429)
+    assert "429" in resp.text or "rate" in resp.text.lower()
+
+
+def test_turn_404_for_unknown_session(client_with_key: TestClient) -> None:
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": "does-not-exist", "message": "hi"},
+    )
+    assert resp.status_code == 404
+
+
+# ── GET /{session_id} (resume) ────────────────────────────────────────────
+
+
+def test_resume_renders_persisted_history(client_with_key: TestClient, base_root: Path) -> None:
+    from findajob.onboarding.session_store import append_turn
+
+    sid = _create_session_directly(base_root)
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        append_turn(conn, sid, "user", "first user msg with marker MARK_USER")
+        append_turn(conn, sid, "assistant", "first assistant reply with marker MARK_ASSISTANT")
+    finally:
+        conn.close()
+
+    resp = client_with_key.get(f"/onboarding/interview/{sid}")
+    assert resp.status_code == 200
+    assert "MARK_USER" in resp.text
+    assert "MARK_ASSISTANT" in resp.text
+
+
+def test_resume_404_for_unknown_session(client_with_key: TestClient) -> None:
+    resp = client_with_key.get("/onboarding/interview/nope")
+    assert resp.status_code == 404
+
+
+# ── /finalize ─────────────────────────────────────────────────────────────
+
+
+def test_finalize_rejects_when_blocks_missing(client_with_key: TestClient, base_root: Path) -> None:
+    """captured_blocks must contain every ALLOWED_FILENAMES entry before finalize."""
+    sid = _create_session_directly(base_root)
+
+    resp = client_with_key.post(
+        f"/onboarding/interview/{sid}/finalize",
+        data={"openrouter_api_key": _USER_KEY},
+    )
+    assert resp.status_code == 400
+    assert "missing" in resp.text.lower() or "complete" in resp.text.lower()
+
+
+def test_finalize_rejects_when_user_key_blank(client_with_key: TestClient, base_root: Path) -> None:
+    """Even if all blocks captured, a blank user OpenRouter key is rejected."""
+    from findajob.onboarding.parser import parse_emission
+    from findajob.onboarding.session_store import update_captured_blocks
+
+    sid = _create_session_directly(base_root)
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        all_captured = parse_emission(_build_emission_blob()).found
+        update_captured_blocks(conn, sid, all_captured)
+    finally:
+        conn.close()
+
+    resp = client_with_key.post(
+        f"/onboarding/interview/{sid}/finalize",
+        data={"openrouter_api_key": "  "},
+    )
+    assert resp.status_code == 400
+    assert "key" in resp.text.lower()
+
+
+def test_finalize_calls_inject_and_marks_complete(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: all captured + valid key → inject() called → mark_complete + redirect."""
+    from findajob.onboarding.injector import DiscoveryStatus, InjectResult
+    from findajob.onboarding.parser import parse_emission
+    from findajob.onboarding.session_store import update_captured_blocks
+
+    sid = _create_session_directly(base_root)
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        all_captured = parse_emission(_build_emission_blob()).found
+        update_captured_blocks(conn, sid, all_captured)
+    finally:
+        conn.close()
+
+    inject_calls: list[dict[str, Any]] = []
+
+    def _fake_inject(base_root, parsed_files, *, openrouter_api_key):  # type: ignore[no-untyped-def]
+        inject_calls.append(
+            {
+                "base_root": base_root,
+                "parsed_files": dict(parsed_files),
+                "openrouter_api_key": openrouter_api_key,
+            }
+        )
+        return InjectResult(
+            backup_dir=Path("/tmp/fake-backup"),
+            discovery=DiscoveryStatus(success=True, count=3, error=None),
+        )
+
+    monkeypatch.setattr("findajob.web.routes.onboarding_interview.inject", _fake_inject)
+
+    resp = client_with_key.post(
+        f"/onboarding/interview/{sid}/finalize",
+        data={"openrouter_api_key": _USER_KEY},
+    )
+
+    # Either renders complete page directly (200) or redirects to /onboarding/complete
+    assert resp.status_code in (200, 303)
+    if resp.status_code == 303:
+        assert "/onboarding/complete" in resp.headers["location"]
+
+    # inject was called with the captured blocks + the user's key
+    assert len(inject_calls) == 1
+    assert inject_calls[0]["openrouter_api_key"] == _USER_KEY
+    assert set(inject_calls[0]["parsed_files"].keys()) >= set(all_captured.keys())
+
+    # Session marked complete
+    _hist, _cap, completed_at, _err = _read_session(base_root, sid)
+    assert completed_at is not None
+
+
+def test_finalize_handles_smoke_check_failed(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If inject() raises OnboardingSmokeCheckFailed, render the friendly error
+    so the user can fix their key and retry. Session is NOT marked complete."""
+    from findajob.onboarding.openrouter_smoke import OnboardingSmokeCheckFailed
+    from findajob.onboarding.parser import parse_emission
+    from findajob.onboarding.session_store import update_captured_blocks
+
+    sid = _create_session_directly(base_root)
+    conn = sqlite3.connect(base_root / "data" / "pipeline.db")
+    try:
+        all_captured = parse_emission(_build_emission_blob()).found
+        update_captured_blocks(conn, sid, all_captured)
+    finally:
+        conn.close()
+
+    def _fake_inject(*_args, **_kwargs):
+        raise OnboardingSmokeCheckFailed("OpenRouter rejected the key (401).")
+
+    monkeypatch.setattr("findajob.web.routes.onboarding_interview.inject", _fake_inject)
+
+    resp = client_with_key.post(
+        f"/onboarding/interview/{sid}/finalize",
+        data={"openrouter_api_key": _USER_KEY},
+    )
+    assert resp.status_code == 400
+    assert "401" in resp.text or "key" in resp.text.lower()
+
+    _hist, _cap, completed_at, _err = _read_session(base_root, sid)
+    assert completed_at is None  # NOT marked complete on smoke-check failure
+
+
+def test_finalize_404_for_unknown_session(client_with_key: TestClient) -> None:
+    resp = client_with_key.post(
+        "/onboarding/interview/nope/finalize",
+        data={"openrouter_api_key": _USER_KEY},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Task 4 of the #336 in-app onboarding interview plan — four FastAPI routes (`start` / `turn` / resume / `finalize`) that compose Tasks 1–3 (`session_store` + `interview_runner` + parser + injector) into the chat surface
- Conditionally registered on `OPENROUTER_OPERATOR_KEY`: when unset, the router is not included and `/onboarding/` falls back to paste-back only — acceptance criterion #6 satisfied
- Templates `interview.html` + `_turn.html` ship as minimal stubs sufficient for route tests; Task 5 replaces them with the full Tailwind/HTMX UI

## Cross-task constraints baked in

Per the #336 Session 2026-05-01 note (three constraints from the Up-Next dependency scan):

1. **#212 / #283 readiness**: emission detection scans the cumulative assistant transcript via `parser.ALLOWED_FILENAMES` (no hardcoded counts), so adding a new emission filename is a 1-line list addition
2. **#339 readiness**: finalize collects only the user's OpenRouter key, in a section structurally extensible to accept RapidAPI + Google keys later without re-doing the form

## Verification

- 17 new tests in `test_web_onboarding_interview_routes.py` covering: conditional registration (router-absent when key unset, paste-back survives), `/start` (session creation + first-turn persistence + runner-error → error_state captured), `/turn` (turn-pair persistence + history forwarded to `run_turn` + emission detection + 404 on unknown session), resume (history rendered + 404), finalize (rejects missing blocks, rejects blank user key, calls `inject()` + `mark_complete()`, handles `OnboardingSmokeCheckFailed`, 404)
- 87/87 onboarding-suite tests green; full suite 1409 passed, 1 skipped
- `ruff check` clean; `ruff format --check` clean

## Test plan

- [ ] `uv run pytest tests/test_web_onboarding_interview_routes.py -v`
- [ ] `uv run pytest tests/test_onboarding* tests/test_web_onboarding*`
- [ ] `uv run ruff check && uv run ruff format --check`

## Out of scope (subsequent tasks)

- Task 5: full Tailwind/HTMX templates + the "Run interview here" affordance on `/onboarding/`
- Task 6: emission state-machine refinements (per-turn progress badge)
- Task 7: paste-back coexistence wiring
- Task 8–11: error UX polish, integration tests, docs, self-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)