### PR TITLE
feat(onboarding): #336 emission detection + error UX (Tasks 6+7)

### DIFF
--- a/src/findajob/onboarding/interview_runner.py
+++ b/src/findajob/onboarding/interview_runner.py
@@ -28,11 +28,23 @@ class InterviewRunnerError(Exception):
     """Raised by :func:`run_turn` on any non-success path.
 
     ``user_message`` is rendered verbatim in the chat UI's error banner.
+    ``kind`` classifies the failure so the route layer (#336 Task 7) can
+    pick a UX variant (auth/payment/rate-limit/upstream/network/malformed/
+    config) without re-parsing the message string. ``status_code`` is the
+    HTTP status from OpenRouter when available.
     """
 
-    def __init__(self, user_message: str) -> None:
+    def __init__(
+        self,
+        user_message: str,
+        *,
+        kind: str = "unknown",
+        status_code: int | None = None,
+    ) -> None:
         super().__init__(user_message)
         self.user_message = user_message
+        self.kind = kind
+        self.status_code = status_code
 
 
 def run_turn(
@@ -66,7 +78,8 @@ def run_turn(
             "Operator's OpenRouter key is missing. The administrator of this "
             "findajob deployment must set OPENROUTER_OPERATOR_KEY before the "
             "in-app interview is available. You can still use the paste-back "
-            "option from the onboarding page."
+            "option from the onboarding page.",
+            kind="config",
         )
 
     messages: list[dict[str, str]] = [{"role": "system", "content": system_prompt}]
@@ -105,44 +118,74 @@ def run_turn(
             raise InterviewRunnerError(
                 "OpenRouter rejected the operator key (401 Unauthorized). The "
                 "administrator of this deployment needs to update "
-                "OPENROUTER_OPERATOR_KEY."
+                "OPENROUTER_OPERATOR_KEY.",
+                kind="auth",
+                status_code=401,
             ) from e
         if e.code == 402:
             raise InterviewRunnerError(
                 "Operator's OpenRouter account is out of credit (402 Payment "
                 "Required). The administrator needs to add prepaid credit at "
-                "https://openrouter.ai/credits."
+                "https://openrouter.ai/credits.",
+                kind="payment",
+                status_code=402,
             ) from e
         if e.code == 429:
-            raise InterviewRunnerError("OpenRouter rate-limited the request (429). Wait a moment and try again.") from e
+            raise InterviewRunnerError(
+                "OpenRouter rate-limited the request (429). Wait a moment and try again.",
+                kind="rate_limit",
+                status_code=429,
+            ) from e
         if 500 <= e.code < 600:
             raise InterviewRunnerError(
                 f"OpenRouter or the upstream model returned a server error "
-                f"({e.code}). Try again in a moment; the issue is on their side."
+                f"({e.code}). Try again in a moment; the issue is on their side.",
+                kind="upstream",
+                status_code=e.code,
             ) from e
-        raise InterviewRunnerError(f"OpenRouter returned HTTP {e.code}: {error_body[:200]}") from e
+        raise InterviewRunnerError(
+            f"OpenRouter returned HTTP {e.code}: {error_body[:200]}",
+            kind="upstream",
+            status_code=e.code,
+        ) from e
     except urllib.error.URLError as e:
         raise InterviewRunnerError(
-            f"Could not reach OpenRouter ({e.reason}). Check the deployment's network connectivity and try again."
+            f"Could not reach OpenRouter ({e.reason}). Check the deployment's network connectivity and try again.",
+            kind="network",
         ) from e
     except Exception as e:  # noqa: BLE001
-        raise InterviewRunnerError(f"Unexpected error talking to OpenRouter: {type(e).__name__}: {str(e)[:200]}") from e
+        raise InterviewRunnerError(
+            f"Unexpected error talking to OpenRouter: {type(e).__name__}: {str(e)[:200]}",
+            kind="unknown",
+        ) from e
 
     try:
         data = json.loads(body)
     except json.JSONDecodeError as e:
-        raise InterviewRunnerError(f"OpenRouter returned non-JSON response: {body[:200]}") from e
+        raise InterviewRunnerError(
+            f"OpenRouter returned non-JSON response: {body[:200]}",
+            kind="malformed",
+        ) from e
 
     if not isinstance(data, dict) or not data.get("choices"):
-        raise InterviewRunnerError(f"OpenRouter returned unexpected response shape: {body[:200]}")
+        raise InterviewRunnerError(
+            f"OpenRouter returned unexpected response shape: {body[:200]}",
+            kind="malformed",
+        )
 
     try:
         assistant_text = data["choices"][0]["message"]["content"]
     except (KeyError, IndexError, TypeError) as e:
-        raise InterviewRunnerError(f"Could not parse assistant content from OpenRouter response: {body[:200]}") from e
+        raise InterviewRunnerError(
+            f"Could not parse assistant content from OpenRouter response: {body[:200]}",
+            kind="malformed",
+        ) from e
 
     if not isinstance(assistant_text, str):
-        raise InterviewRunnerError(f"Assistant content was not a string: {type(assistant_text).__name__}")
+        raise InterviewRunnerError(
+            f"Assistant content was not a string: {type(assistant_text).__name__}",
+            kind="malformed",
+        )
 
     usage_raw = data.get("usage")
     usage: dict = usage_raw if isinstance(usage_raw, dict) else {}

--- a/src/findajob/web/routes/onboarding_interview.py
+++ b/src/findajob/web/routes/onboarding_interview.py
@@ -35,6 +35,7 @@ from findajob.onboarding.session_store import (
     set_error,
     update_captured_blocks,
 )
+from findajob.utils import log_event
 
 router = APIRouter()
 
@@ -69,6 +70,49 @@ def _captured_from_history(history: list[dict[str, str]]) -> dict[str, str]:
     """
     transcript = "\n\n".join(turn["content"] for turn in history if turn.get("role") == "assistant")
     return parse_emission(transcript).found
+
+
+def _log_runner_error(*, session_id: str, route: str, err: InterviewRunnerError) -> None:
+    """Emit a structured pipeline.jsonl event for every runner failure.
+
+    Failure modes here are upstream (operator credit, rate limit, network)
+    — surfacing them in the same log used for triage / scoring lets the
+    operator correlate "interview died at 14:02" with other infra signals.
+    """
+    log_event(
+        "onboarding_interview_error",
+        session_id=session_id,
+        route=route,
+        error_kind=err.kind,
+        status_code=err.status_code,
+    )
+
+
+def _render_error_partial(
+    request: Request,
+    *,
+    session_id: str,
+    last_message: str,
+    err: InterviewRunnerError,
+) -> HTMLResponse:
+    """Render the per-turn error partial (HTMX-appended into #messages).
+
+    Status code is intentionally 200: HTMX's default config silently
+    drops 4xx/5xx responses — using 200 lets the swap go through and the
+    user sees the actionable error bubble + Try Again button.
+    """
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="onboarding/_turn_error.html",
+        context={
+            "session_id": session_id,
+            "last_message": last_message,
+            "error_kind": err.kind,
+            "error_message": err.user_message,
+            "status_code": err.status_code,
+        },
+    )
 
 
 def _render_chat(
@@ -121,13 +165,17 @@ def start_interview(request: Request) -> HTMLResponse | RedirectResponse:
             )
         except InterviewRunnerError as e:
             set_error(conn, session_id, e.user_message)
+            _log_runner_error(session_id=session_id, route="start", err=e)
+            # /start is the very first turn — no chat to splice an error
+            # bubble into yet, so render the full chat page seeded with
+            # the error banner. /turn renders the OOB partial instead.
             return _render_chat(
                 request,
                 session_id=session_id,
                 history=[],
                 captured={},
                 error=e.user_message,
-                status_code=502,
+                status_code=200,
             )
 
         append_turn(conn, session_id, "user", _KICKOFF_USER_MESSAGE)
@@ -172,13 +220,12 @@ def post_turn(
             )
         except InterviewRunnerError as e:
             set_error(conn, session_id, e.user_message)
-            return _render_chat(
+            _log_runner_error(session_id=session_id, route="turn", err=e)
+            return _render_error_partial(
                 request,
                 session_id=session_id,
-                history=sess.history,
-                captured=sess.captured_blocks,
-                error=e.user_message,
-                status_code=502,
+                last_message=message,
+                err=e,
             )
 
         append_turn(conn, session_id, "user", message)

--- a/src/findajob/web/templates/onboarding/_turn_error.html
+++ b/src/findajob/web/templates/onboarding/_turn_error.html
@@ -1,0 +1,65 @@
+{# Per-turn error partial (#336 Task 7).
+
+   Returned by POST /onboarding/interview/turn when the runner raises
+   InterviewRunnerError. Appended into #messages via HTMX so the chat
+   surface keeps the prior history intact and just adds an error bubble
+   the user can act on (Try Again button posts the same turn).
+
+   Context:
+     session_id     — for the retry form
+     last_message   — the user's just-sent message, replayed by the retry form
+     error_kind     — "auth" | "payment" | "rate_limit" | "upstream" |
+                       "network" | "malformed" | "config" | "unknown"
+     error_message  — the runner's user_message rendered verbatim
+     status_code    — when present, the HTTP status from OpenRouter
+#}
+<div class="border border-red-300 bg-red-50 rounded p-3" data-role="error" data-error-kind="{{ error_kind }}">
+  <div class="flex items-start justify-between gap-3">
+    <div class="space-y-1 flex-1">
+      <div class="text-xs uppercase tracking-wide text-red-600 font-semibold">
+        {% if error_kind == "auth" %}Operator key rejected
+        {% elif error_kind == "payment" %}Operator credit exhausted
+        {% elif error_kind == "rate_limit" %}Rate-limited
+        {% elif error_kind == "upstream" %}OpenRouter / model error
+        {% elif error_kind == "network" %}Network error
+        {% elif error_kind == "malformed" %}Unexpected response shape
+        {% elif error_kind == "config" %}Configuration error
+        {% else %}Error
+        {% endif %}
+        {% if status_code %}<span class="ml-1 text-red-500">({{ status_code }})</span>{% endif %}
+      </div>
+      <p class="text-sm text-red-900 whitespace-pre-wrap">{{ error_message }}</p>
+
+      {% if error_kind == "auth" or error_kind == "payment" %}
+      <p class="text-xs text-red-800 mt-2">
+        This is on the operator's side, not yours. The administrator of this
+        findajob deployment can fix it at
+        <a class="underline" target="_blank"
+           href="{% if error_kind == 'payment' %}https://openrouter.ai/credits{% else %}https://openrouter.ai/keys{% endif %}">
+          openrouter.ai/{% if error_kind == 'payment' %}credits{% else %}keys{% endif %}</a>.
+      </p>
+      {% endif %}
+
+      {% if error_kind == "rate_limit" %}
+      <p class="text-xs text-red-800 mt-2"
+         data-auto-retry-seconds="10"
+         x-data="{ s: 10 }"
+         x-init="setInterval(() => { if (s > 0) s--; }, 1000)">
+        We'll retry automatically in <span x-text="s">10</span> seconds.
+        Or click Retry now.
+      </p>
+      {% endif %}
+    </div>
+    <form hx-post="/onboarding/interview/turn"
+          hx-target="#messages"
+          hx-swap="beforeend"
+          class="shrink-0">
+      <input type="hidden" name="session_id" value="{{ session_id }}">
+      <input type="hidden" name="message" value="{{ last_message }}">
+      <button type="submit"
+              class="px-3 py-1.5 bg-red-700 text-white rounded text-sm hover:bg-red-800">
+        Try again
+      </button>
+    </form>
+  </div>
+</div>

--- a/tests/test_web_onboarding_interview_routes.py
+++ b/tests/test_web_onboarding_interview_routes.py
@@ -125,9 +125,15 @@ def _stub_run_turn(monkeypatch: pytest.MonkeyPatch, assistant_text: str) -> list
     return calls
 
 
-def _stub_run_turn_error(monkeypatch: pytest.MonkeyPatch, message: str) -> None:
+def _stub_run_turn_error(
+    monkeypatch: pytest.MonkeyPatch,
+    message: str,
+    *,
+    kind: str = "unknown",
+    status_code: int | None = None,
+) -> None:
     def _fake(*_args, **_kwargs):
-        raise InterviewRunnerError(message)
+        raise InterviewRunnerError(message, kind=kind, status_code=status_code)
 
     monkeypatch.setattr("findajob.web.routes.onboarding_interview.run_turn", _fake)
 
@@ -497,3 +503,266 @@ def test_finalize_404_for_unknown_session(client_with_key: TestClient) -> None:
         data={"openrouter_api_key": _USER_KEY},
     )
     assert resp.status_code == 404
+
+
+# ── Multi-turn emission tracking (#336 Task 6) ────────────────────────────
+
+
+def test_emission_split_across_turns_captures_after_close(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `<<<FILE: ...>>> ... <<<END FILE: ...>>>` block whose markers
+    straddle two assistant turns must be captured.
+
+    LLMs sometimes split blocks across turns mid-stream. The route's
+    `_captured_from_history` joins assistant turns with `\\n\\n` and re-runs
+    `parse_emission` over the full transcript so the regex can match
+    across turn boundaries — this test pins that behavior.
+    """
+    sid = _create_session_directly(base_root)
+
+    # Turn 1: open marker only — parse_emission on this single turn returns nothing
+    turn1_text = "Here is your profile, splitting across turns:\n<<<FILE: profile.md>>>\nname: Test\nrole: alpha"
+    # Turn 2: close marker only
+    turn2_text = "second half of the body\n<<<END FILE: profile.md>>>\nNext question?"
+
+    # First /turn — captured_blocks stays empty
+    monkeypatch.setattr(
+        "findajob.web.routes.onboarding_interview.run_turn",
+        lambda *a, **kw: (turn1_text, {}),
+    )
+    resp1 = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "ready for first half"},
+    )
+    assert resp1.status_code == 200
+    _h, captured_json_after_turn1, _c, _e = _read_session(base_root, sid)
+    import json as _json
+
+    assert _json.loads(captured_json_after_turn1) == {}
+
+    # Second /turn — cumulative-transcript parse now finds the complete block
+    monkeypatch.setattr(
+        "findajob.web.routes.onboarding_interview.run_turn",
+        lambda *a, **kw: (turn2_text, {}),
+    )
+    resp2 = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "ready for second half"},
+    )
+    assert resp2.status_code == 200
+
+    _h, captured_json_after_turn2, _c, _e = _read_session(base_root, sid)
+    captured = _json.loads(captured_json_after_turn2)
+    assert "profile.md" in captured
+    body = captured["profile.md"]
+    assert "name: Test" in body
+    assert "second half of the body" in body
+
+
+# ── Error UX (#336 Task 7) ────────────────────────────────────────────────
+
+
+def test_error_turn_renders_partial_not_full_page(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`/turn` errors return an HTMX-friendly partial (no <html> wrapper)
+    so the chat surface keeps the prior history and just appends an
+    error bubble. /start errors render the full page (no chat to splice
+    into yet)."""
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(monkeypatch, "boom", kind="upstream", status_code=503)
+
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "any"},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    # Partial — no full-document wrappers
+    assert "<html" not in body.lower()
+    assert "<body" not in body.lower()
+    # Error bubble present, distinguishable in the DOM
+    assert 'data-role="error"' in body
+    assert 'data-error-kind="upstream"' in body
+
+
+def test_error_kind_auth_surfaces_openrouter_keys_link(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """401 → keys page link (operator-side fix), distinct from per-tester
+    smoke-check finalize message which references the user's own key."""
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(
+        monkeypatch,
+        "OpenRouter rejected the operator key (401 Unauthorized).",
+        kind="auth",
+        status_code=401,
+    )
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "any"},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'data-error-kind="auth"' in body
+    assert "openrouter.ai/keys" in body
+    assert "401" in body
+
+
+def test_error_kind_payment_surfaces_credits_link(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """402 → credits page link."""
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(
+        monkeypatch,
+        "Operator's OpenRouter account is out of credit (402).",
+        kind="payment",
+        status_code=402,
+    )
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "any"},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'data-error-kind="payment"' in body
+    assert "openrouter.ai/credits" in body
+
+
+def test_error_kind_rate_limit_includes_auto_retry_hint(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """429 → countdown hint + Try Again button (manual override)."""
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(
+        monkeypatch,
+        "OpenRouter rate-limited the request (429).",
+        kind="rate_limit",
+        status_code=429,
+    )
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "any"},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'data-error-kind="rate_limit"' in body
+    assert "data-auto-retry-seconds" in body
+    # Manual retry affordance still present so the user can override the wait
+    assert "/onboarding/interview/turn" in body  # retry form posts here
+
+
+def test_error_kind_upstream_renders_status_code(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """5xx → render the specific status code so the operator can grep logs."""
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(
+        monkeypatch,
+        "OpenRouter or the upstream model returned a server error (504).",
+        kind="upstream",
+        status_code=504,
+    )
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "any"},
+    )
+    body = resp.text
+    assert 'data-error-kind="upstream"' in body
+    assert "504" in body
+
+
+def test_error_kind_network_renders_friendly_message(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """URLError → kind=network, no OpenRouter dashboard link."""
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(
+        monkeypatch,
+        "Could not reach OpenRouter (timed out). Check the deployment's network connectivity.",
+        kind="network",
+    )
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "any"},
+    )
+    body = resp.text
+    assert 'data-error-kind="network"' in body
+    assert "openrouter.ai/keys" not in body  # no dashboard link for network errors
+    assert "openrouter.ai/credits" not in body
+
+
+def test_error_retry_replays_user_message(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Try Again form must carry the user's just-sent message so a
+    retry replays the same turn rather than losing input."""
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(
+        monkeypatch,
+        "OpenRouter rate-limited (429).",
+        kind="rate_limit",
+        status_code=429,
+    )
+    resp = client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "the user's important reply"},
+    )
+    body = resp.text
+    # The hidden input replays the original message
+    assert 'name="message"' in body
+    assert "the user&#39;s important reply" in body or "the user's important reply" in body
+
+
+def test_error_emits_log_event(
+    client_with_key: TestClient,
+    base_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Every InterviewRunnerError emits a structured pipeline.jsonl entry."""
+    import json as _json
+
+    log_calls: list[dict[str, object]] = []
+
+    def _fake_log(event_type: str, **kwargs: object) -> None:
+        log_calls.append({"event": event_type, **kwargs})
+
+    monkeypatch.setattr("findajob.web.routes.onboarding_interview.log_event", _fake_log)
+
+    sid = _create_session_directly(base_root)
+    _stub_run_turn_error(monkeypatch, "boom", kind="auth", status_code=401)
+    client_with_key.post(
+        "/onboarding/interview/turn",
+        data={"session_id": sid, "message": "anything"},
+    )
+
+    err_events = [c for c in log_calls if c["event"] == "onboarding_interview_error"]
+    assert len(err_events) == 1
+    assert err_events[0]["session_id"] == sid
+    assert err_events[0]["route"] == "turn"
+    assert err_events[0]["error_kind"] == "auth"
+    assert err_events[0]["status_code"] == 401
+    # Just exercise the JSON shape — don't assert on serialization specifics
+    _json.dumps(err_events[0])
+
+
+def test_start_error_emits_log_event(
+    client_with_key: TestClient, base_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """/start errors also log via the same channel — different route value."""
+    log_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "findajob.web.routes.onboarding_interview.log_event",
+        lambda evt, **kwargs: log_calls.append({"event": evt, **kwargs}),
+    )
+    _stub_run_turn_error(monkeypatch, "boom", kind="upstream", status_code=503)
+    client_with_key.post("/onboarding/interview/start")
+
+    err_events = [c for c in log_calls if c["event"] == "onboarding_interview_error"]
+    assert len(err_events) == 1
+    assert err_events[0]["route"] == "start"
+    assert err_events[0]["error_kind"] == "upstream"
+    assert err_events[0]["status_code"] == 503


### PR DESCRIPTION
## Summary

- Tasks 6 + 7 of #336, bundled because the route changes are tightly coupled
- Pins multi-turn split-emission capture behavior (Task 6)
- Adds actionable, kind-specific error UI for OpenRouter failures mid-interview (Task 7) + structured logging via \`log_event\`

## Task 6 — Emission detection across multi-turn assistant transcript

The cumulative-transcript parse already landed in Task 4 (\`_captured_from_history\` joins assistant turns with \`\\n\\n\` and re-runs \`parse_emission\`). This PR pins the behavior with a dedicated test: a \`<<<FILE: profile.md>>>\` block whose open marker arrives in turn 1 and close marker arrives in turn 2 is captured correctly after turn 2.

## Task 7 — Actionable error UI for OpenRouter failures mid-interview

**\`InterviewRunnerError\`** grows \`.kind\` and \`.status_code\` attrs (backward compatible — \`.user_message\` contract preserved). Each runner raise sets the kind:
- 401 → \`auth\`
- 402 → \`payment\`
- 429 → \`rate_limit\`
- 5xx → \`upstream\`
- URLError → \`network\`
- malformed JSON / shape → \`malformed\`
- empty operator key → \`config\`

**New \`_turn_error.html\` partial** renders kind-specific UX:
- \`auth\` → links to \`openrouter.ai/keys\` (operator-side fix)
- \`payment\` → links to \`openrouter.ai/credits\`
- \`rate_limit\` → auto-retry countdown hint + manual Try Again
- \`upstream\` → surfaces specific status code for log correlation
- \`network\` → friendly retry message, no dashboard link

**Route changes:**
- \`/turn\` errors return the partial (HTMX-appendable into \`#messages\`, status 200 so HTMX swap doesn't drop it)
- \`/start\` errors render the full page (no chat surface to splice into yet)
- Retry form replays the user's last message verbatim — retry doesn't lose input
- Every \`InterviewRunnerError\` emits \`log_event("onboarding_interview_error", session_id=..., route=..., error_kind=..., status_code=...)\`

## Verification

- 27 route tests pass (10 new — 1 split-emission + 7 error UX kinds + 2 log_event)
- 25 runner tests pass (backward-compat verified)
- Full suite: 1428 passed, 1 skipped
- \`ruff check\` clean; \`ruff format --check\` clean

## Test plan

- [ ] \`uv run pytest tests/test_web_onboarding_interview_routes.py -v\`
- [ ] \`uv run pytest tests/test_onboarding_interview_runner.py -v\`
- [ ] \`uv run ruff check && uv run ruff format --check\`

## Out of scope (subsequent tasks)

- Task 8: tab-close-resume affordance on \`/onboarding/\`
- Task 9: end-to-end integration test
- Task 10: docs (\`docs/setup/configure.md\`, \`CLAUDE.md\`, \`CHANGELOG.md\`)
- Task 11: whole-feature verification gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)