### PR TITLE
fix(web/board): #391 Not Selected is one-click; remove the two-step trap

### DIFF
--- a/src/findajob/web/templates/board/_reject_cell.html
+++ b/src/findajob/web/templates/board/_reject_cell.html
@@ -1,27 +1,30 @@
 {#
-  Reject reason dropdown for Dashboard / Applied / Review / Waitlist tabs.
-  Inputs:
+  Reject reason dropdown. Inputs:
     row — a sqlite3.Row (or dict)
     tab — "dashboard" | "applied" | "review" | "waitlist"
 
-  On change, dispatches a POST with the selected reason as form data. Routes
-  to /reject by default; if the status cell flagged the row for Not Selected
-  (applied tab only), routes to /not-selected instead. The flag is carried
-  on this select's own dataset so it survives any row-level DOM repaints —
-  mobile Chrome was losing the row-level dataset between cell focus events.
+  On Dashboard / Review / Waitlist: dropdown POSTs the selected reason to
+  /reject (user rejection — writes feedback_log, moves to _rejected/).
+
+  On Applied: rendered inert. As of #391 every transition off the Applied
+  tab is one-click via the status cell (Not Selected fires /not-selected
+  immediately with default reason "Company passed"; Withdrew fires
+  /withdraw). The previous two-step flow — pick Not Selected, then pick
+  a reason in this cell — was a UX trap and has been removed along with
+  the dataset.pendingAction coordination, focus pulse, and hint span.
 #}
 {% set fp = row.fingerprint %}
 <td class="px-3 py-1 align-top text-sm whitespace-nowrap">
+  {% if tab == 'applied' %}
+    <span class="text-xs text-slate-400" title="On Applied, status changes are one-click — pick from the STATUS column.">—</span>
+  {% else %}
   <select
     class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
     data-fp="{{ fp }}"
     onchange="if(this.value){
       const tr=this.closest('tr');
-      const action=this.dataset.pendingAction==='not-selected'?'not-selected':'reject';
-      htmx.ajax('POST',`/board/jobs/{{ fp }}/${action}`,{target:tr,swap:'outerHTML',values:{reason:this.value}});
+      htmx.ajax('POST',`/board/jobs/{{ fp }}/reject`,{target:tr,swap:'outerHTML',values:{reason:this.value}});
       this.value='';
-      delete this.dataset.pendingAction;
-      this.classList.remove('ring-2','ring-amber-400','animate-pulse');
     }">
     <option value="">— No reason —</option>
     <option value="Too Senior">Too Senior</option>
@@ -36,4 +39,5 @@
     <option value="Already Applied">Already Applied</option>
     <option value="Other">Other</option>
   </select>
+  {% endif %}
 </td>

--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -40,36 +40,26 @@
     {% if stage == 'not_selected' %}
       <span class="text-xs text-slate-500">Not Selected</span>
     {% else %}
+    {# #391: every status pick on Applied is a one-click action — picking
+       "Not Selected" fires /not-selected immediately with empty reason
+       (handler defaults to "Company passed"). The earlier two-step flow
+       that required the user to also pick a reason was a UX trap; the
+       reject-cell coordination + hint span + dataset.pendingAction logic
+       are gone. The reject cell on Applied is rendered as an inert dash
+       (see _reject_cell.html). #}
     <select
       class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
       data-fp="{{ fp }}"
       onchange="if(!this.value)return;
         const tr=this.closest('tr');
-        const rejectSel=this.closest('td').nextElementSibling && this.closest('td').nextElementSibling.querySelector('select');
-        const hint=this.parentElement.querySelector('.js-status-hint');
-        if(this.value==='not-selected'){
-          if(rejectSel){
-            rejectSel.dataset.pendingAction='not-selected';
-            rejectSel.classList.add('ring-2','ring-amber-400','animate-pulse');
-            rejectSel.focus();
-          }
-          if(hint)hint.textContent='Pick a reason →';
-        } else {
-          if(rejectSel){
-            delete rejectSel.dataset.pendingAction;
-            rejectSel.classList.remove('ring-2','ring-amber-400','animate-pulse');
-          }
-          if(hint)hint.textContent='';
-          htmx.ajax('POST',`/board/jobs/{{ fp }}/${this.value}`,{target:tr,swap:'outerHTML'});
-          this.value='';
-        }">
+        htmx.ajax('POST',`/board/jobs/{{ fp }}/${this.value}`,{target:tr,swap:'outerHTML'});
+        this.value='';">
       <option value="">— Change status —</option>
       {% if stage != 'interview' %}<option value="interview">Interviewing</option>{% endif %}
       {% if stage != 'offer' %}<option value="offer">Offer</option>{% endif %}
       <option value="withdraw">Withdrew</option>
       <option value="not-selected">Not Selected</option>
     </select>
-    <span class="js-status-hint ml-2 text-xs font-medium text-amber-700"></span>
     {% endif %}
   {% elif tab == 'review' %}
     <button type="button"

--- a/tests/test_web_board_applied.py
+++ b/tests/test_web_board_applied.py
@@ -90,19 +90,65 @@ def test_applied_recruiter_flow_captures_interview_as_applied_date(client: TestC
     assert "row-applied-fresh" in r.text
 
 
-def test_applied_status_cell_writes_pending_action_to_reject_select(client: TestClient) -> None:
-    """#361 regression — pending-action lives on the reject select's own dataset,
-    not the parent <tr>. Mobile Chrome was losing the row-level dataset between
-    cell focus events and routing the reject pick to /reject instead of
-    /not-selected. Asserts the JS contract end-to-end on the rendered HTML."""
+def test_applied_status_cell_fires_not_selected_one_click(client: TestClient) -> None:
+    """#391 — picking 'Not Selected' on the Applied tab fires
+    /not-selected immediately, no two-step reason picker. The earlier
+    coordination scheme (#361 / #374) made the user pick a status THEN
+    a reason, which the operator surfaced as confusing UX in #391:
+    'I click Not Selected and I just get this message Pick a reason.
+    The reason IS not selected.'
+
+    The fix removes the dataset.pendingAction handoff, the
+    js-status-hint span, the reject-cell focus-and-pulse, and the
+    'Pick a reason →' hint. The status cell now POSTs the chosen
+    action straight to its endpoint regardless of which option fires."""
     r = client.get("/board/applied")
     assert r.status_code == 200
-    # Status cell must set the pending action on the reject select directly.
-    assert "rejectSel.dataset.pendingAction='not-selected'" in r.text
-    # Reject cell must read from its own dataset (this.dataset), not tr.dataset.
-    assert "this.dataset.pendingAction==='not-selected'" in r.text
-    # Defensive: the old tr.dataset.pendingAction pattern must NOT reappear.
+
+    # The one-click POST shape must be present — picking a status fires
+    # htmx.ajax with /board/jobs/{fp}/${this.value} immediately.
+    assert "htmx.ajax('POST',`/board/jobs/" in r.text
+    assert "${this.value}`" in r.text
+
+    # The two-step coordination MUST be gone in its entirety.
+    assert "rejectSel.dataset.pendingAction" not in r.text, (
+        "#391: dataset.pendingAction handoff was the symptom of the old two-step UX. It should not reappear."
+    )
     assert "tr.dataset.pendingAction" not in r.text
+    assert "this.dataset.pendingAction" not in r.text
+    assert "Pick a reason" not in r.text
+    assert "js-status-hint" not in r.text
+
+
+def test_applied_reject_cell_renders_inert_dash(client: TestClient) -> None:
+    """#391 — every transition off Applied is now one-click via the
+    status cell. The reject cell's role on Applied (collect a reason
+    for /not-selected) is gone with the two-step. The cell renders an
+    inert dash so the column position aligns visually with other tabs
+    where the cell is still active (Dashboard / Review / Waitlist).
+
+    The reject cell must NOT POST /reject from Applied — that would
+    treat a user-rejection as if they were rejecting a job they had
+    already applied to, which writes feedback_log and contaminates
+    the scorer's loop."""
+    r = client.get("/board/applied")
+    assert r.status_code == 200
+    # The reject-reason <select> must not render on Applied — confirming
+    # by checking that the no-reason placeholder option (only present
+    # in the active select) is absent.
+    assert "— No reason —" not in r.text
+    # The /reject endpoint must not be wired up from any onchange handler
+    # rendered on Applied.
+    assert (
+        "/board/jobs/" not in r.text
+        or "/reject`" not in r.text
+        or (
+            # /reject can only appear in the company-history cell's link list,
+            # never as an onchange POST target on the Applied tab. The simplest
+            # invariant: no onchange that targets /reject is present.
+            "htmx.ajax('POST',`/board/jobs/" not in r.text or "/reject`" not in r.text
+        )
+    )
 
 
 def test_base_template_surfaces_htmx_response_errors(client: TestClient) -> None:


### PR DESCRIPTION
Closes #391. Picking Not Selected on the Applied tab now fires /not-selected immediately. Reason defaults to 'Company passed' (handler already supported empty reason). Removes the dataset.pendingAction handoff, js-status-hint span, focus pulse — all dead code from #361/#374 hardening attempts that targeted dataset stability when the actual issue was the two-step UX itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)