### PR TITLE
docs(readme): #392 refresh getting-started for in-app onboarding + per-tester keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Self-hosted infrastructure for a sane job search.
 
 The modern job search grinds people down — hundreds of listings per day, most irrelevant; the same cover letter rewritten at midnight; no memory of which companies went silent weeks ago; no signal about whether the rejections mean "wrong skill," "wrong level," or "wrong field."
 
-Burnout is the default. findajob absorbs the triage, the tailoring, and the tracking so your attention goes to the few applications actually worth sending. It's a pre-1.0 personal project — used daily by one operator and one beta tester, not a polished product yet.
+Burnout is the default. findajob absorbs the triage, the tailoring, and the tracking so your attention goes to the few applications actually worth sending. It's a pre-1.0 personal project — used daily by the operator and a small wave of beta testers, not a polished product yet.
 
 LinkedIn, Indeed, Greenhouse, and Gmail flow in; a local LLM filters out the noise; a web UI lets you triage, prep, and track. Runs as a Docker container on any Linux host. ~$0.50–2/day in API usage.
 
@@ -115,6 +115,20 @@ Live status of every issue and milestone is on the **[project board](https://git
 
 The pipeline ships as `ghcr.io/brockamer/findajob` pulled via Docker Compose.
 
+### What you'll need
+
+Three API keys before you start. Sign-up walkthroughs + cost expectations are in [`docs/setup/api-keys.md`](docs/setup/api-keys.md):
+
+| Provider | Required? | Free tier | What findajob uses it for |
+|---|---|---|---|
+| **OpenRouter** | yes | pay-as-you-go from $0; ~$0.05–0.10 per fully-prepped job | All LLM calls + the in-app onboarding interview |
+| **RapidAPI (jobs-api14)** | optional | 150 req/month BASIC, no credit card | LinkedIn + Indeed search ingestion |
+| **Google AI Studio (Gemini)** | optional | free tier; no billing setup needed | Embeddings for the optional REPL RAG index |
+
+Skipping the optional two means LinkedIn/Indeed search is inactive (Greenhouse/Ashby/Lever feeds and Gmail alerts still work) and the REPL RAG rebuild is inactive — the daily pipeline runs identically without them. You collect all three on the onboarding page once your container is up.
+
+### Deploy
+
 ```bash
 # On your Docker host
 sudo mkdir -p /opt/stacks/findajob-<you>/state/{data,config,candidate_context,companies,logs,aichat_ng}
@@ -124,10 +138,18 @@ cd /opt/stacks/findajob-<you>
 curl -fsSL -o compose.yaml https://raw.githubusercontent.com/brockamer/findajob/main/ops/compose.yaml.example
 curl -fsSL -o .env         https://raw.githubusercontent.com/brockamer/findajob/main/ops/stack.env.example
 
-# Populate state/ with API keys, personal config, candidate profile
-# (templates + walkthrough in the install guide)
+# Edit .env (timezone, port, basic-auth password if internet-exposed)
 docker compose up -d
 ```
+
+### First-run onboarding
+
+Open `http://<your-host>:<port>/` in a browser. A fresh stack redirects you straight into onboarding — no need to know to navigate via Tools → Onboarding. Two paths:
+
+- **In-app interview (recommended where outbound network works).** Step 1 collects your three API keys; Step 2 runs a chat-based interview right inside findajob, server-side persistent so you can close the tab and resume. Funded by your own OpenRouter key from Step 1.
+- **Paste-back.** For environments that can't reach OpenRouter directly, or if you'd rather run the interview in claude.ai / ChatGPT / Gemini and paste the emission. Same Step 1 keys collection; Step 2 hands you the prompt and a paste box.
+
+Either way, the injector validates the emission, smoke-checks your OpenRouter key, atomically writes the config files findajob needs, and marks onboarding complete. The next scheduled triage run (00:00 in your `TZ`) ingests its first batch of jobs.
 
 Full walkthrough → [`docs/setup/install-docker.md`](docs/setup/install-docker.md) (or start at [`docs/setup/README.md`](docs/setup/README.md) for the guided sequence). Native-host install remains as a legacy fallback → [`docs/setup/install-linux.md`](docs/setup/install-linux.md).
 
@@ -154,7 +176,8 @@ Start here:
 | [docs/setup/prerequisites.md](docs/setup/prerequisites.md) | API keys, accounts, tools you need |
 | [docs/setup/install-docker.md](docs/setup/install-docker.md) | Docker Compose setup (recommended) |
 | [docs/setup/install-linux.md](docs/setup/install-linux.md) | Legacy native install (Ubuntu + systemd) |
-| [docs/setup/configure.md](docs/setup/configure.md) | Profile, resume, search queries, API keys |
+| [docs/setup/api-keys.md](docs/setup/api-keys.md) | Getting your three API keys (OpenRouter, RapidAPI, Google AI Studio) |
+| [docs/setup/configure.md](docs/setup/configure.md) | Profile, resume, search queries, advanced config |
 | [docs/setup/state-migration.md](docs/setup/state-migration.md) | Moving an existing pipeline to a new host |
 | [docs/operations.md](docs/operations.md) | Operator reference: manual commands, monitoring |
 | [docs/notifications.md](docs/notifications.md) | ntfy.sh setup and notification schedule |

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ LinkedIn, Indeed, Greenhouse, and Gmail flow in; a local LLM filters out the noi
 
 The pipeline narrows the funnel at every step where a human would otherwise waste attention — LLM triage on the way in, human triage on the way to prep, prep only for jobs worth applying to. Thirty days on the operator's instance looks like this:
 
-| Stage (30 days) | Count | Pass rate |
+| Funnel snapshot (30 days, except where noted) | Count | Conversion at this step |
 |---|---:|---:|
 | Listings ingested | **12,824** | — |
 | Scored ≥7 (surfaced to operator) | 393 | 3.1% of ingested |
 | Prepped (resume + cover letter + briefing) | 160 | 41% of surfaced |
 | Applications sent | **60** | 38% of prepped |
-| Interviews (lifetime) | 6 | 10% of applied |
+| Interviews (lifetime, not 30d) | 6 | — |
 
 ```
 Pass rate at each step:
@@ -61,7 +61,9 @@ Live status of every issue and milestone is on the **[project board](https://git
 
 ## How it works
 
-**1. Daily triage** (00:00, scheduler-driven) — fetches 100–500 listings from RapidAPI (LinkedIn), direct ATS feeds (Greenhouse, Ashby, Lever), and Gmail job alerts (LinkedIn + Indeed); cleans + deduplicates; enriches with JD text; scores each against your `profile.md` using an LLM. Results land in SQLite.
+**0. Onboarding** (one-time, on first visit to the web UI) — produces your candidate profile, target-companies list, prefilter rules, and search queries from a structured interview. See [Quick start](#quick-start) below for the two onboarding paths and what you'll need.
+
+**1. Daily triage** (00:00, scheduler-driven) — fetches 100–500 listings from RapidAPI (LinkedIn), direct ATS feeds (Greenhouse, Ashby, Lever), and Gmail job alerts (LinkedIn + Indeed); cleans + deduplicates; enriches with JD text; scores each against your candidate profile (the `profile.md` produced in step 0) using an LLM. Results land in SQLite.
 
 **2. Dashboard triage** — the web UI shows every scored job that cleared the threshold, with relevance/fit/probability scores, known contacts, and AI notes. You flag the ones worth prepping.
 
@@ -119,13 +121,13 @@ The pipeline ships as `ghcr.io/brockamer/findajob` pulled via Docker Compose.
 
 Three API keys before you start. Sign-up walkthroughs + cost expectations are in [`docs/setup/api-keys.md`](docs/setup/api-keys.md):
 
-| Provider | Required? | Free tier | What findajob uses it for |
+| Provider | Required? | What you'll spend | What findajob uses it for |
 |---|---|---|---|
-| **OpenRouter** | yes | pay-as-you-go from $0; ~$0.05–0.10 per fully-prepped job | All LLM calls + the in-app onboarding interview |
-| **RapidAPI (jobs-api14)** | optional | 150 req/month BASIC, no credit card | LinkedIn + Indeed search ingestion |
+| **OpenRouter** | yes | pay-as-you-go from $0; ~$0.50/day triage-only, $1.50–3.00 per fully-prepped job, ~$1 per in-app onboarding interview | All LLM calls (scoring, prep writing, in-app onboarding) |
+| **RapidAPI (jobs-api14)** | optional | BASIC plan: 150 req/month free, no credit card | LinkedIn + Indeed search ingestion |
 | **Google AI Studio (Gemini)** | optional | free tier; no billing setup needed | Embeddings for the optional REPL RAG index |
 
-Skipping the optional two means LinkedIn/Indeed search is inactive (Greenhouse/Ashby/Lever feeds and Gmail alerts still work) and the REPL RAG rebuild is inactive — the daily pipeline runs identically without them. You collect all three on the onboarding page once your container is up.
+Skipping the optional two means LinkedIn/Indeed search is inactive (Greenhouse/Ashby/Lever feeds and Gmail alerts still work) and the REPL RAG rebuild is inactive — the daily pipeline runs identically without them. The "What it costs to run" section near the bottom of this README breaks the OpenRouter spend down by component if you want a more granular budget. You collect all three keys on the onboarding page once your container is up.
 
 ### Deploy
 

--- a/docs/setup/api-keys.md
+++ b/docs/setup/api-keys.md
@@ -11,7 +11,7 @@ credit card to get started.
 
 | Key | What findajob uses it for | Cost on free tier | Required? |
 |---|---|---|---|
-| **OpenRouter** | All LLM calls (scoring, briefings, resume tailoring, cover letters, outreach drafts, in-app interview) | Pay-as-you-go from $0; no monthly minimum. Typical full pipeline run < $0.10/job. | **Yes** — pipeline cannot score or generate materials without it |
+| **OpenRouter** | All LLM calls (scoring, briefings, resume tailoring, cover letters, outreach drafts, in-app interview) | Pay-as-you-go from $0; no monthly minimum. ~$0.50/day triage-only; $1.50–3.00 per fully-prepped job (Claude Opus dominates that bill). | **Yes** — pipeline cannot score or generate materials without it |
 | **RapidAPI (jobs-api14)** | LinkedIn + Indeed job search ingestion | BASIC plan: 150 requests/month free | Optional — paste-back from Gmail LinkedIn alerts works without it |
 | **Google AI Studio (Gemini)** | Embeddings for the optional RAG index over your candidate context (REPL-only feature) | Free tier on Gemini embeddings; no billing setup needed | Optional — only used by the REPL workflow; pipeline is fully functional without it |
 
@@ -33,8 +33,10 @@ bill instead of holding direct accounts with five vendors.
 1. Go to <https://openrouter.ai>.
 2. Click **Sign In** (top right). Sign up with Google, GitHub, or email.
 3. Add credit to your account: **Settings** → **Credits** → **Buy
-   credits**. $5–$10 is a comfortable starter; the pipeline burns roughly
-   $0.05–$0.10 per job that gets a full briefing + resume + cover letter.
+   credits**. $20–$30 is a comfortable starter; the pipeline burns roughly
+   $1.50–$3.00 per job that gets a full briefing + tailored resume +
+   cover letter + recruiter critique + outreach drafts (Claude Opus
+   dominates that bill).
 4. Create an API key: **Settings** → **Keys** → **Create Key**. Give it
    a name like "findajob" so you can find it later. Copy the key — it
    starts with `sk-or-v1-` and is shown to you only once.
@@ -60,7 +62,7 @@ under "Pipeline Context Table."
 |---|---|
 | Score one job (no JD fetch) | < $0.001 |
 | Score one job (with JD + fit analysis) | $0.01–$0.05 |
-| Full prep package (briefing + tailored resume + cover letter + recruiter critique + outreach drafts) | $0.05–$0.10 |
+| Full prep package (briefing + tailored resume + cover letter + recruiter critique + outreach drafts) | $1.50–$3.00 (Claude Opus dominates) |
 | In-app onboarding interview, end to end | ~$1 |
 | Weekly company-discovery cron | ~$0.10 |
 


### PR DESCRIPTION
Closes #392.

Refreshes the README's Quick start to lead with the post-#336/#339 onboarding story:

- New 'What you'll need' subsection naming the three providers (OpenRouter required, RapidAPI + Google optional with free-tier callouts) and linking to `docs/setup/api-keys.md`.
- New 'First-run onboarding' subsection explains the two modalities (in-app interview, paste-back) and the first-run redirect from `/` to `/onboarding/`.
- Documentation index adds a row for `docs/setup/api-keys.md`; `configure.md` reframed as 'advanced config'.
- Opener tweak: 'one operator and one beta tester' → 'the operator and a small wave of beta testers' to reflect the actual five-tester cohort.

Polish pass per the issue's scope — no rewrite. Cross-checked against `docs/setup/install-docker.md` (which #339's main PR already updated) — high-altitude pitch in README; concrete walk-through in install-docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)