### PR TITLE
docs: #393 comb-through to align project docs with new onboarding flow

### DIFF
--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -16,11 +16,13 @@ Create `/opt/stacks/findajob-<you>/`, drop `compose.yaml`, start the container. 
 
 ## 3. Configure → three paths
 
-After the container is up, open `http://<your-host>:${FINDAJOB_MATERIALS_PORT}/onboarding/` in a browser. There are now two interview paths and a manual escape hatch:
+After the container is up, open `http://<your-host>:${FINDAJOB_MATERIALS_PORT}/` in a browser. A fresh stack 307s straight into `/onboarding/` — no need to know to navigate via Tools → Onboarding. The page presents Step 1 (collect your three API keys) and then Step 2, where you pick how to onboard:
 
-**In-app interview (operator opt-in, easiest for testers):** When the operator sets `OPENROUTER_OPERATOR_KEY` on the stack, `/onboarding/` shows a "Run interview here" button. Click it and the entire interview happens inside findajob as a chat — no tab-switching, no copy-paste. Server-side persistent: close the tab and reload the page to see a "Resume your interview" affordance and pick up where you left off. findajob bills the operator's OpenRouter key (~$1 per onboarding for Sonnet 4.6); your own key is collected at the end and used for the post-onboarding pipeline. See [`configure.md`](configure.md#openrouter_operator_key-in-app-onboarding-interview-optional) for opt-in details.
+**In-app interview (default for self-deploy):** Step 1 collects your OpenRouter, RapidAPI, and Google API keys (sign-up walkthrough at [`api-keys.md`](api-keys.md)); Step 2 enables a "Start interview" button that runs the entire interview inside findajob as a chat — no tab-switching, no copy-paste. Server-side persistent: close the tab and reload the page to see a "Resume your interview" affordance. The chat is funded by your own OpenRouter key from Step 1.
 
-**Paste-back (the original path, always available):** You paste the interview prompt into ChatGPT / Claude / Gemini in another tab, answer its questions in conversation, then paste the structured output back. Works for outbound-blocked deployments and for operators who haven't opted into the in-app path. The "I already ran the interview elsewhere" section on `/onboarding/` collapses this option when the in-app path is enabled.
+**Paste-back (the fallback):** For environments that can't reach OpenRouter directly, or if you'd rather run the interview in claude.ai / ChatGPT / Gemini in another tab and paste the emission. Same Step 1 keys collection; Step 2's "I'll run the interview elsewhere and paste back" section hands you the prompt and a paste box. Same config files written either way.
+
+**Operator-funded fallback (optional, for `findajob-test` and operator-deployed-for-tester scenarios):** When the operator sets `OPENROUTER_OPERATOR_KEY` on the stack, the in-app affordance enables before Step 1 keys are collected — useful for the operator's own dogfood instance or a tester whose stack the operator stood up directly. Self-deploy testers do not need this. See [`configure.md`](configure.md#openrouter_operator_key-operator-funded-fallback-optional) for cost (~$1/onboarding) and operational notes.
 
 Both interview paths produce the same emission protocol and write the same config files (profile, resume, prefilter rules, search queries, and more), back up anything they replace, and clear the onboarding sentinel on success.
 

--- a/docs/setup/api-keys.md
+++ b/docs/setup/api-keys.md
@@ -12,7 +12,7 @@ credit card to get started.
 | Key | What findajob uses it for | Cost on free tier | Required? |
 |---|---|---|---|
 | **OpenRouter** | All LLM calls (scoring, briefings, resume tailoring, cover letters, outreach drafts, in-app interview) | Pay-as-you-go from $0; no monthly minimum. ~$0.50/day triage-only; $1.50–3.00 per fully-prepped job (Claude Opus dominates that bill). | **Yes** — pipeline cannot score or generate materials without it |
-| **RapidAPI (jobs-api14)** | LinkedIn + Indeed job search ingestion | BASIC plan: 150 requests/month free | Optional — paste-back from Gmail LinkedIn alerts works without it |
+| **RapidAPI (jobs-api14)** | LinkedIn + Indeed job search ingestion | BASIC plan: 150 requests/month free | Optional — Gmail LinkedIn-alert ingestion still works without it |
 | **Google AI Studio (Gemini)** | Embeddings for the optional RAG index over your candidate context (REPL-only feature) | Free tier on Gemini embeddings; no billing setup needed | Optional — only used by the REPL workflow; pipeline is fully functional without it |
 
 You can leave RapidAPI and Google blank during onboarding and add them

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -116,13 +116,14 @@ Protect this file: `chmod 600 data/.env`
 
 ---
 
-## OPENROUTER_OPERATOR_KEY (in-app onboarding interview, optional)
+## OPENROUTER_OPERATOR_KEY (operator-funded fallback, optional)
 
-Operator-only opt-in. Set this in the stack's compose `.env` (separate from
-the per-tester `OPENROUTER_API_KEY` which lives in `data/.env`) to enable
-the in-app onboarding interview path: testers run the entire interview as
-a chat inside findajob's UI, instead of opening another tab to an LLM and
-copy-pasting the emission back.
+This is the **operator-funded fallback** for the in-app onboarding interview. Self-deploy testers do not need it — they collect their own OpenRouter key at `/onboarding/` Step 1, and the in-app interview runs on that key. `OPENROUTER_OPERATOR_KEY` exists for two specific scenarios:
+
+- **`findajob-test`** — the operator's dogfood instance for NUX walkthroughs (#389). Lets the operator test the in-app interview themselves without procuring a separate tester key.
+- **Operator-deployed-for-tester** — the operator stood up a tester's stack on their behalf and wants the tester to be able to start the interview before they've completed Step 1.
+
+When set, the in-app affordance enables in `/onboarding/` Step 2 even before Step 1 keys are collected. Tester credentials always win over the env value when both are present.
 
 **How to enable:**
 
@@ -130,24 +131,15 @@ copy-pasting the emission back.
    ```
    OPENROUTER_OPERATOR_KEY=sk-or-v1-...
    ```
-   This key is **operator-funded** — findajob bills your OpenRouter account
-   for the interview, then collects the tester's own key at the end (used
-   only for the post-onboarding pipeline).
+   This key is **operator-funded** — findajob bills your OpenRouter account for the interview chat. The tester's own keys (collected at Step 1) are still used for the post-onboarding pipeline.
 
 2. Restart the stack: `docker compose -f /opt/stacks/findajob-<handle>/compose.yaml up -d`.
 
-3. Visit `/onboarding/` — a "Run interview here" affordance now sits above
-   the existing paste-back form. Paste-back stays as the fallback.
+3. Visit `/onboarding/` — Step 2's "Start interview" button is now available immediately, even on a stack with no Step 1 keys collected yet.
 
-**What it costs:** ~$1 per onboarding (Sonnet 4.6 at ~$3 per 1M output
-tokens × ~30k output tokens per interview). Cheaper if you pin a smaller
-model in the runner. Verify your spend on
-[openrouter.ai/credits](https://openrouter.ai/credits).
+**What it costs:** ~$1 per onboarding (Sonnet 4.6 at ~$3 per 1M output tokens × ~30k output tokens per interview). Cheaper if you pin a smaller model in the runner. Verify your spend on [openrouter.ai/credits](https://openrouter.ai/credits).
 
-**What happens if unset:** the route module isn't registered and the
-"Run interview here" affordance doesn't render. `/onboarding/` falls
-back to paste-back-only (the v0.x.x default). Existing testers who
-already onboarded are unaffected.
+**What happens if unset:** the in-app affordance is disabled until the tester completes `/onboarding/` Step 1. Posting to `/onboarding/interview/start` directly returns 503 with a pointer back to `/onboarding/`. Existing testers who already onboarded are unaffected — their sentinel skips the new collection flow entirely.
 
 **Operational notes:**
 


### PR DESCRIPTION
Closes #393.

Three targeted edits to retire pre-#336/#339 framings that survived in `docs/setup/` after the #339 PR landed. Polish pass per the issue's scope — no rewrites.

- `docs/setup/README.md` 'Configure → three paths' — in-app is now described as the default; paste-back as the fallback; `OPENROUTER_OPERATOR_KEY` as the operator-funded fallback for `findajob-test` / operator-deployed-for-tester scenarios.
- `docs/setup/configure.md` `OPENROUTER_OPERATOR_KEY` section rewritten as 'operator-funded fallback (optional)'. Removed the 'paste-back-only (the v0.x.x default)' wording.
- `docs/setup/api-keys.md` term-collision fix: 'paste-back from Gmail LinkedIn alerts' → 'Gmail LinkedIn-alert ingestion'.

Anti-targets per the issue body respected: `docs/superpowers/specs/` + plans/archived/, `docs/handoff/`, `docs/roadmap.md` — all untouched. Source code paste-back references audited; all are accurate 'one of two paths' framings, no edits.

Sequenced after #392 per the original plan; can land in any order with #392 (no overlap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)