### PR TITLE
docs: move [Unreleased] → [0.12.0] in CHANGELOG (#69 process)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-05-02
+
+Minor bump bundling PR A (#402, originally targeted as v0.11.1 patch) and PR B (#403, P1 onboarding UX + prompt revisions). The two ship together because no tester stack was pinned to `:v0.11`, so a separate v0.11.1 tag would have served no installed base. Operator's stack and `findajob-test` already moved through `:latest`; tester stacks (alice, papa, dave, judy, tango) currently on `:v0.10` should bump to `:v0.12` in the cohort wave.
+
+**Migration required:** No code-side action — `docker compose pull && up -d` covers the image upgrade. Stacks deployed before `:v0.10.0` and missing the `./state/.backups:/app/.backups` bind mount need a one-time stack-config patch; see [`docs/setup/install-docker.md` → Operating an existing stack → Adding the `.backups` bind mount](docs/setup/install-docker.md). Stacks already on `:v0.10.x` or later are fine.
+
 ### Fixed
 
 - **Reverted operator-funded chat path (`OPENROUTER_OPERATOR_KEY`) (#401).** The v0.11.0 release re-enabled an operator-funded fallback for the in-app onboarding interview chat (precedence: operator env key → tester's own key). Operator clarified post-release that this path was deprecated and was never supposed to be supported — the only model is "tester pays for their own chat via the OpenRouter key collected in Step 1." Removed: `chat_subsidized_by_operator` Jinja global, the operator-key precedence branch in `_resolved_chat_key`, the operator-key fallback in `interview_runner.run_turn` (param renamed `operator_key` → `api_key`), template branching for the Step 2 cost notice and nav-bar lifetime-cost badge, all documentation references in `CLAUDE.md`, `docs/setup/configure.md`, `docs/setup/README.md`, and `docs/setup/install-docker.md`. **No migration required:** stacks that had `OPENROUTER_OPERATOR_KEY=…` set in `data/.env` continue to work unchanged — the env var is simply no longer read. Tester stacks (alice, papa, dave, judy, tango) on `:v0.10` are unaffected; the cohort will roll forward to `:v0.11.x` once this patch ships and a follow-up walkthrough verifies cleanly.
@@ -673,7 +679,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/brockamer/findajob/releases/tag/v0.12.0
 [0.11.0]: https://github.com/brockamer/findajob/releases/tag/v0.11.0
 [0.10.1]: https://github.com/brockamer/findajob/releases/tag/v0.10.1
 [0.10.0]: https://github.com/brockamer/findajob/releases/tag/v0.10.0


### PR DESCRIPTION
Promotes the bundled PR A (#402) + PR B (#403) entries from \`[Unreleased]\` to \`[0.12.0]\`. No code change.

## Why bundle as v0.12.0 instead of cutting v0.11.1 + v0.12.0 separately

PR A (#402) shipped as the planned v0.11.1 patch (operator-key path retired + cost-doc correction). PR B (#403) shipped as the planned v0.12.0 minor (P1 UX + prompt revisions). Per the PR B plan's operator-handoff section, the operator could either:

- Option α — cut v0.11.1 first, then v0.12.0 (two artifacts).
- Option β — skip v0.11.1, cut v0.12.0 only (one artifact).

**Going with β.** No tester stack is pinned to \`:v0.11\` (alice, papa, dave, judy, tango are all on \`:v0.10\` per CLAUDE.local.md "Pin discipline"). A v0.11.1 tag would have served no installed base — the next thing every tester pulls is v0.12.x via the cohort wave.

## Pre-tag smoke check

Ran \`scripts/test_container_integration.sh\` against \`ghcr.io/brockamer/findajob:latest\` (which was rebuilt from \`43befca\` after the #403 squash-merge). All 6 assertions passed:

- pipeline_complete with 17 scored jobs
- sync_complete event emitted
- jobs table has 17 scored/manual_review rows
- cost_log has 17 rows (#117 schema fold)
- /app/.config/aichat_ng/config.yaml present (#118 entrypoint seed)
- materials viewer + /healthz + /docs/ all green

## Test plan

- [x] CHANGELOG \`## [Unreleased]\` is empty above the new \`## [0.12.0]\`
- [x] Cross-reference link \`[Unreleased]: ...compare/v0.12.0...HEAD\` updated
- [x] New \`[0.12.0]: ...releases/tag/v0.12.0\` link added
- [x] Pre-tag smoke green on docker.lan
- [ ] Merge → CI rebuilds \`:latest\` off this commit
- [ ] Tag cut: \`git tag v0.12.0 && git push origin v0.12.0\`
- [ ] Post-tag verification per docs/release-process.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)