### PR TITLE
fix(harness): #405 corpus drift + cost-reader fixes

### DIFF
--- a/scripts/walkthrough_harness.py
+++ b/scripts/walkthrough_harness.py
@@ -9,9 +9,15 @@ machine-readable findings report.
 Usage:
   uv run python scripts/walkthrough_harness.py \\
     --base-url https://findajob-test.example.com/ \\
-    --replay-from tmp/onboarding-walkthrough-2026-05-02/transcript.md \\
-    --output-dir tmp/onboarding-walkthrough-YYYY-MM-DD-prb/ \\
+    --output-dir tmp/onboarding-walkthrough-YYYY-MM-DD/ \\
     --secrets-file ~/.secrets
+
+Replay corpus: defaults to ``tests/fixtures/walkthrough/corpus_transcript.md``
+(an in-repo fictional persona). Override with ``--replay-from <path>`` if
+re-baselining or experimenting with a captured transcript. Real operator
+walkthroughs MUST NOT be checked into the repo as the corpus — they
+contain PII; sanitize and re-baseline the in-repo corpus instead. See the
+re-baseline workflow notes at the top of the corpus file.
 
 Secrets file format (one per line, optionally quoted, # = comment):
   FINDAJOB_TEST_USER=myuser
@@ -46,7 +52,13 @@ from typing import Any
 
 # Allow importing from the scripts/ directory for the corpus parser module.
 sys.path.insert(0, str(Path(__file__).parent))
-from walkthrough_replay_corpus import ReplayCorpus, load_corpus
+from walkthrough_replay_corpus import _PHASE_ANCHORS, ReplayCorpus, load_corpus
+
+# Ordered list of phase-end anchor names. Index in this list IS the phase
+# number minus one (i.e. PHASE_ANCHOR_ORDER[0] == "phase_1_end" marks the
+# end of phase 1). Drives the harness's "current phase" state machine and
+# corpus-side phase-range computation.
+PHASE_ANCHOR_ORDER = ["phase_1_end", "phase_2_end", "phase_3_end", "phase_4_end", "phase_5_end"]
 
 # ---------------------------------------------------------------------------
 # Secret loading
@@ -167,28 +179,101 @@ def _keyword_overlap(a: str, b: str) -> float:
     return matches / len(a_words)
 
 
+def compute_phase_ranges(corpus: ReplayCorpus) -> list[tuple[int, int]]:
+    """Convert ``corpus.phase_anchors`` into ordered 0-based half-open
+    ranges over ``corpus.user_messages``, one per phase.
+
+    The result has ``len(PHASE_ANCHOR_ORDER) + 1`` entries — one slot per
+    phase 1..N plus a tail slot. Each fired anchor at 1-based turn ``T``
+    marks ``T - 1`` (0-based) as the FIRST turn of the new phase, because
+    anchors are detected on the assistant turn whose user response is in
+    the new phase. The "tail" slot lands at the index immediately after
+    the last fired anchor — i.e. it represents the phase the corpus
+    ended in. Slots for unfired anchors at the end are empty
+    (``start == end``).
+    """
+    ranges: list[tuple[int, int]] = [(0, 0)] * (len(PHASE_ANCHOR_ORDER) + 1)
+    prev_start = 0
+    last_phase_idx = 0
+    for i, name in enumerate(PHASE_ANCHOR_ORDER):
+        t = corpus.phase_anchors.get(name, 0)
+        if t <= 0:
+            continue
+        next_start = t - 1
+        ranges[i] = (prev_start, next_start)
+        prev_start = next_start
+        last_phase_idx = i + 1
+    ranges[last_phase_idx] = (prev_start, corpus.turn_count)
+    return ranges
+
+
+def advance_phase_idx(assistant_text: str, current_phase_idx: int) -> int:
+    """Detect phase advance from the assistant's text. Monotonically
+    non-decreasing — once we've advanced past phase N we can't go back.
+    A single assistant turn that mentions multiple anchors (e.g.
+    "we just finished phase 2; moving to phase 3") advances by all of
+    them in one call.
+    """
+    lower = assistant_text.lower()
+    new_idx = current_phase_idx
+    for i in range(current_phase_idx, len(PHASE_ANCHOR_ORDER)):
+        anchor_name = PHASE_ANCHOR_ORDER[i]
+        for phrase in _PHASE_ANCHORS[anchor_name]:
+            if phrase in lower:
+                new_idx = i + 1
+                break
+    return new_idx
+
+
 def pick_answer(
     turn_idx: int,
     assistant_text: str,
     corpus: ReplayCorpus,
     intent_map: dict[str, str],
+    *,
+    current_phase_idx: int | None = None,
+    phase_relative_turn: int | None = None,
+    phase_ranges: list[tuple[int, int]] | None = None,
 ) -> tuple[str, str]:
     """Select the best replay answer for the current assistant question.
 
-    Returns (answer_text, match_reason).
-    match_reason is one of: 'positional', 'keyword', 'intent', 'affirmative', 'review'
+    Two modes:
+
+    - **Legacy** (``current_phase_idx is None``): preserved for unit tests
+      and any caller that doesn't track phase. Positional match is by
+      absolute ``turn_idx``; keyword overlap considers all corpus turns.
+
+    - **Phase-scoped** (``current_phase_idx`` provided, plus ``phase_ranges``
+      and ``phase_relative_turn``): positional match is by the
+      within-phase index; keyword overlap is restricted to corpus turns
+      belonging to the same phase. Eliminates cross-phase contamination
+      when the prompt's question shape has shifted between corpus capture
+      and the current run (#405 Issue 2).
+
+    Returns ``(answer_text, match_reason)`` — match_reason is one of
+    ``positional``, ``positional_within_phase``, ``keyword(...)``,
+    ``keyword_within_phase(...)``, ``intent(...)``, ``affirmative``,
+    ``review``, ``review_no_phase_match``.
     """
-    # Rule 4: yes/no readiness questions always get an affirmative
     if _is_affirmative_question(assistant_text):
         return ("yes", "affirmative")
 
-    # Rule 1: positional match — same turn index from prior corpus
+    if current_phase_idx is not None and phase_ranges is not None:
+        return _pick_answer_phase_scoped(
+            assistant_text=assistant_text,
+            corpus=corpus,
+            intent_map=intent_map,
+            current_phase_idx=current_phase_idx,
+            phase_relative_turn=phase_relative_turn or 0,
+            phase_ranges=phase_ranges,
+        )
+
+    # Legacy path: positional by absolute turn_idx, keyword over all corpus.
     if 0 <= turn_idx < len(corpus.user_messages):
         prior = corpus.user_messages[turn_idx]
         if prior.strip():
             return (prior, "positional")
 
-    # Rule 1 (fallback): keyword similarity against all prior user messages
     best_overlap = 0.0
     best_answer = ""
     for prior_asst_idx, prior_asst in enumerate(corpus.assistant_messages):
@@ -203,12 +288,60 @@ def pick_answer(
     if best_overlap >= _KEYWORD_MATCH_THRESHOLD and best_answer.strip():
         return (best_answer, f"keyword(overlap={best_overlap:.2f})")
 
-    # Rule 2: intent map for lettered-list questions (Phase 4 proactive categories)
     for intent_key, letter_choices in intent_map.items():
         if intent_key.lower() in assistant_text.lower():
             return (letter_choices, f"intent({intent_key})")
 
-    # Rule 3: new question — emit sentinel, log as REVIEW
+    return ("Skip — using prior context", "review")
+
+
+def _pick_answer_phase_scoped(
+    *,
+    assistant_text: str,
+    corpus: ReplayCorpus,
+    intent_map: dict[str, str],
+    current_phase_idx: int,
+    phase_relative_turn: int,
+    phase_ranges: list[tuple[int, int]],
+) -> tuple[str, str]:
+    candidate_indices: list[int] = []
+    if 0 <= current_phase_idx < len(phase_ranges):
+        start, end = phase_ranges[current_phase_idx]
+        if start < end:
+            candidate_indices = list(range(start, end))
+
+    if candidate_indices:
+        # Rule 1: positional within phase
+        if 0 <= phase_relative_turn < len(candidate_indices):
+            corpus_idx = candidate_indices[phase_relative_turn]
+            prior = corpus.user_messages[corpus_idx]
+            if prior.strip():
+                return (prior, "positional_within_phase")
+
+        # Rule 2: keyword overlap restricted to phase
+        best_overlap = 0.0
+        best_answer = ""
+        for corpus_idx in candidate_indices:
+            prior_asst = corpus.assistant_messages[corpus_idx]
+            if not prior_asst.strip():
+                continue
+            overlap = _keyword_overlap(assistant_text, prior_asst)
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best_answer = corpus.user_messages[corpus_idx]
+
+        if best_overlap >= _KEYWORD_MATCH_THRESHOLD and best_answer.strip():
+            return (best_answer, f"keyword_within_phase(overlap={best_overlap:.2f})")
+
+    # Rule 3: intent map — phase-independent (a categorical-question detector
+    # that classifies by question shape, not by corpus similarity). Runs
+    # whether or not the corpus has any turns for the current phase.
+    for intent_key, letter_choices in intent_map.items():
+        if intent_key.lower() in assistant_text.lower():
+            return (letter_choices, f"intent({intent_key})")
+
+    if not candidate_indices:
+        return ("Skip — using prior context", "review_no_phase_match")
     return ("Skip — using prior context", "review")
 
 
@@ -398,8 +531,14 @@ def run_walkthrough(
             return snap_path
 
         def read_cost() -> float:
+            # The data attribute lives on the inner <span>, not on the
+            # #progress-row <div> wrapper. The wrong selector returned None
+            # → 0.0 every time; #405 Issue 1.
             try:
-                val = page.get_attribute("#progress-row", "data-cumulative-cost-usd")
+                val = page.get_attribute(
+                    "#progress-row span[data-cumulative-cost-usd]",
+                    "data-cumulative-cost-usd",
+                )
                 return float(val) if val else 0.0
             except Exception:
                 return 0.0
@@ -469,6 +608,14 @@ def run_walkthrough(
         markdown_checked = False
         file_badge_checked = False
         auto_scroll_checked = False
+
+        # Phase scoping state — restricts corpus matching to within-phase
+        # candidates so prompt revisions that reorder/add questions don't
+        # cause cross-phase contamination (#405 Issue 2).
+        current_phase_idx = 0
+        phase_relative_turn = 0
+        phase_ranges = compute_phase_ranges(corpus)
+        print(f"[harness] Corpus phase ranges (0-based, half-open): {phase_ranges}")
 
         def count_assistant_bubbles() -> int:
             return len(page.query_selector_all("[data-role='assistant']"))
@@ -585,8 +732,27 @@ def run_walkthrough(
                 print(f"[harness] Cost ceiling ${cost_ceiling_usd:.2f} exceeded at turn {turn_num}. Stopping.")
                 break
 
-            # Pick answer from corpus
-            answer, reason = pick_answer(turn_idx, assistant_text, corpus, intent_map)
+            # Detect phase advance from this assistant turn before picking
+            # an answer. If we just crossed a phase boundary, reset the
+            # within-phase positional counter so the next user message is
+            # the *first* answer in the new phase.
+            new_phase_idx = advance_phase_idx(assistant_text, current_phase_idx)
+            if new_phase_idx != current_phase_idx:
+                print(f"[harness] Phase advance: {current_phase_idx} → {new_phase_idx} (triggered at turn {turn_num})")
+                current_phase_idx = new_phase_idx
+                phase_relative_turn = 0
+
+            # Pick answer from corpus, restricted to within-phase candidates.
+            answer, reason = pick_answer(
+                turn_idx,
+                assistant_text,
+                corpus,
+                intent_map,
+                current_phase_idx=current_phase_idx,
+                phase_relative_turn=phase_relative_turn,
+                phase_ranges=phase_ranges,
+            )
+            phase_relative_turn += 1
 
             if reason == "review":
                 findings.add(
@@ -695,8 +861,11 @@ def run_walkthrough(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Autonomous Playwright walkthrough harness for findajob onboarding.")
+    repo_root = Path(__file__).resolve().parent.parent
+    default_corpus = repo_root / "tests" / "fixtures" / "walkthrough" / "corpus_transcript.md"
+    default_help = f"Path to replay corpus transcript (default: {default_corpus.relative_to(repo_root)})"
     parser.add_argument("--base-url", required=True, help="Base URL of the findajob instance")
-    parser.add_argument("--replay-from", type=Path, required=True, help="Path to prior transcript.md")
+    parser.add_argument("--replay-from", type=Path, default=default_corpus, help=default_help)
     parser.add_argument("--output-dir", type=Path, required=True, help="Directory for output artifacts")
     parser.add_argument(
         "--secrets-file",

--- a/tests/fixtures/walkthrough/corpus_transcript.md
+++ b/tests/fixtures/walkthrough/corpus_transcript.md
@@ -1,0 +1,326 @@
+# Walkthrough Replay Corpus — Avery Chen (fictional persona)
+
+Generated: synthetic — not from any real walkthrough run.
+
+This corpus drives the harness's replay loop (`scripts/walkthrough_harness.py
+--replay-from <this file>`). Every USER turn is a fictional answer from a
+fictional person; no real candidate has ever submitted any of this content
+to the pipeline. The persona is intentionally **non-tech** (a clinical
+pharmacist transitioning to clinical informatics) so the corpus exercises
+the prompt's field-agnostic claim under stress — if a prompt revision
+narrows the question shape toward tech-only assumptions, replay against
+this corpus will surface mismatches loudly.
+
+## Re-baseline workflow
+
+When the onboarding prompt revisions noticeably shift question shape:
+
+1. Run the harness against the new prompt with this corpus and produce a
+   transcript. The transcript will have `Skip — using prior context` user
+   messages on questions where the corpus drifted.
+2. Hand-edit those `Skip — using prior context` lines in the freshly
+   produced transcript to be substantive answers in Avery Chen's voice.
+3. Save the edited transcript back over this file. The next harness run
+   matches positionally again and the drift is reset.
+
+Do NOT promote a real operator's walkthrough transcript over this file —
+those contain operator PII and should never enter the repo.
+
+---
+
+## Turn 1 — ASSISTANT
+
+Hi — I'm going to help you set up findajob, a tool that triages job postings for you every day so you only look at the ones worth looking at. To get there I need to learn who you are, what you're looking for, and how you talk about your own work. We'll go through five phases. Plan for about 60–90 minutes end to end.
+
+A few ground rules before we start: this is a conversation — push back on any question you find confusing. You can ask "why are you asking this?" at any time. Toward the end I'll review what I've captured in four groups, one at a time.
+
+Ready to move on? Let's get your resume into the picture.
+
+## Turn 1 — USER
+
+Ready when you are.
+
+## Turn 2 — ASSISTANT
+
+Great — let's move to Phase 2. Paste your resume into the chat — copy it from the source document (Word, Google Docs, PDF, LinkedIn export, plain text — whatever you've got) and drop it in here. If you have performance reviews, 360s, or self-assessments where someone has described your work in their own words, paste those too in follow-up messages.
+
+## Turn 2 — USER
+
+Avery Chen, Pharm.D., BCPS — Minneapolis, MN
+avery.chen.pharmd@example.com  •  555-0142  •  linkedin.com/in/avery-chen-pharmd-example
+
+Summary
+Hospital clinical pharmacist with eight years of acute-care practice and a residency-trained background in medication safety. Recent focus on the seam between pharmacy practice and the EHR — built order-set governance and CPOE rule logic for a 600-bed academic medical center, partnered with informatics on alert-fatigue reduction projects. Looking to move full-time into clinical informatics where pharmacy expertise translates to system design rather than dispensing throughput.
+
+Experience
+
+Senior Clinical Pharmacist — Lakefront Medical Center, Minneapolis MN — 2022–present
+- Lead pharmacist for the inpatient antimicrobial stewardship program; reduced broad-spectrum DOT (days of therapy) by 14% across two service lines through provider education and order-set redesign.
+- Co-chair of the Pharmacy & Therapeutics order-set subcommittee; rewrote 40+ legacy order sets to incorporate weight-based dosing and renal-function logic in CPOE.
+- Project lead on the 2024 alert-fatigue reduction initiative — partnered with informatics analysts to retire 1,200 low-yield interruptive alerts; clinician override rate fell from 91% to 67% on the remaining set.
+- Precept PGY-1 residents on a clinical informatics elective rotation (2 residents/year).
+
+Clinical Pharmacist — Lakefront Medical Center, Minneapolis MN — 2018–2022
+- Front-line acute-care coverage across general medicine, ICU, and oncology service lines.
+- Served on the medication-error review committee; co-authored a workflow change that eliminated a class of pediatric heparin dosing errors traced to a unit-conversion ambiguity.
+
+PGY-1 Pharmacy Practice Resident — Saint Aldhelm Hospital, Madison WI — 2017–2018
+- Standard ASHP-accredited residency with required and elective rotations across acute care, ambulatory care, and informatics.
+
+Education
+Doctor of Pharmacy (Pharm.D.) — University of Minnesota — 2017
+B.S. Biochemistry — Carleton College — 2013
+
+Credentials
+Board Certified Pharmacotherapy Specialist (BCPS) — 2020
+Active pharmacist license in Minnesota and Wisconsin
+Epic Willow Inpatient — proficiency self-attested; no formal Epic certification yet
+
+## Turn 3 — ASSISTANT
+
+Thanks for that. Do you have any performance reviews, 360s, or self-assessments where someone has described your work in their own words? Paste them as follow-ups if so — they're invaluable for capturing your voice. If not, no problem — we can move on.
+
+## Turn 3 — USER
+
+Two paste-backs, both from my 2024 annual review.
+
+From my director: "Avery is the person other pharmacists go to when something is unclear in CPOE. She bridges the gap between what bedside clinicians need and what the EHR enforces, and she does it without making either side feel talked down to. Her work on the alert-fatigue project this year was the most important non-clinical contribution from the pharmacy department. She has earned the trust of informatics and physician colleagues to a degree that's unusual for a staff pharmacist."
+
+From a peer (an informatics analyst): "Avery doesn't speak to me like I'm an outsider — she explains the clinical reasoning behind every change request, which makes my own work better. She's the rare clinician who actually wants to understand why the system behaves the way it does, and she's patient about it. I would hire her into my team if she had the title, no hesitation."
+
+## Turn 4 — ASSISTANT
+
+This is great context. Let me read it back to make sure I have the picture right:
+
+You're a senior clinical pharmacist with eight years of hospital-based practice, including a residency, board certification, and a recent move toward the clinical-informatics seam — order-set governance, CPOE rule design, and a successful alert-fatigue reduction effort that visibly shifted clinician behavior. The reviews call out that you bridge the pharmacy / informatics divide without condescension and that informatics colleagues already see you as functionally on their team.
+
+You're now looking to make that pivot formal — informatics title, informatics scope, less direct dispensing.
+
+Does that summary feel accurate? Tell me what I got right, what I got wrong, and anything important I missed.
+
+## Turn 4 — USER
+
+That's accurate, with one addition: please make sure my Epic Willow note stays in. I haven't done formal Epic certification yet because my employer wouldn't pay for it without an informatics title, but I'm self-taught proficient. If you frame me as Epic-naive, that misrepresents me — informatics roles often require Epic certification within 12 months and I want recruiters to know I'd take that on day one.
+
+## Turn 5 — ASSISTANT
+
+Got it — I'll preserve the Epic Willow self-attestation language and add framing that you're certification-ready on hire. Now let's move to Phase 3 — gap-fill interview. Starting with the basics: what's your name and what should I put on your resume?
+
+## Turn 5 — USER
+
+Name as on resume: Avery Chen, Pharm.D., BCPS. Email is avery.chen.pharmd@example.com — please use that one for outreach, not the personal one. Phone 555-0142. LinkedIn URL is linkedin.com/in/avery-chen-pharmd-example. Based in Minneapolis, MN — open to remote, hybrid in the Twin Cities, or willing to relocate within the Upper Midwest for the right informatics role.
+
+## Turn 6 — ASSISTANT
+
+Now your target role — what shape of informatics role are you looking for? Pharmacy informatics specifically (Pharmacist Informaticist titles), broader clinical informatics, application analyst roles, or something else? And what level — staff, lead, manager?
+
+## Turn 6 — USER
+
+Primary target: Pharmacy Informaticist or Clinical Informatics Pharmacist (those titles vary by health system). Open to broader Clinical Informatics Specialist titles when the role is pharmacy-adjacent and would still let me use my clinical license. Level: senior individual contributor or first-line lead — I'm not chasing director titles yet. Not interested in pure application-analyst roles where the clinical license is decorative; I want my Pharm.D. to be load-bearing.
+
+## Turn 7 — ASSISTANT
+
+Helpful. Target employers — any specific health systems, vendors, or types of organizations you're focused on? And the inverse — anywhere you definitely don't want to apply?
+
+## Turn 7 — USER
+
+Target organizations:
+- Academic medical centers in the Upper Midwest (Mayo, M Health Fairview, Allina, Hennepin, Essentia, Marshfield, UW Health)
+- Large regional integrated systems (Sanford, Avera, Children's Minnesota)
+- EHR vendor health-system partnerships, especially Epic-shop systems
+- Open to: VA hospitals, IHS facilities, health-system-owned ACOs
+
+NOT interested in:
+- Retail pharmacy chains
+- PBMs (pharmacy benefit managers) — different work entirely
+- Pharma manufacturers — wrong direction from my pivot
+- Roles framed as "clinical pharmacist who also does informatics on the side" — that's my current job
+
+## Turn 8 — ASSISTANT
+
+What about gaps in your work history, breaks, or anything else a recruiter might ask about that's not on the resume? Anything you'd want me to frame proactively rather than have come up as a question?
+
+## Turn 8 — USER
+
+No employment gaps. The thing recruiters sometimes pattern-match on with a pharmacy-to-informatics pivot is "are you really sure you don't want to stay clinical?" — and I am sure. I've been doing the informatics-adjacent work without the title for two years; this is not a pivot I'm trying on, it's a pivot I've already half-completed and need to formalize.
+
+## Turn 9 — ASSISTANT
+
+Last few formatting questions before we move on. Resume length preference — single page, two pages, or whatever fits? Cover letter style — formal, conversational, or a third option? Anything specific about your voice you want preserved?
+
+## Turn 9 — USER
+
+Resume: two pages is fine — I'd rather have one slightly long resume than one that buries the alert-fatigue project in a single bullet. Cover letter: conversational but substantive — I read a lot of formal cover letters that say nothing and I write better than that. Voice: avoid the word "passionate." Avoid "leverage" as a verb. Don't pile up action verbs at the start of every bullet — vary the sentence structure. Use specific numbers when I gave you specific numbers (don't round 14% to "around 15%"). When in doubt, sound like a thoughtful clinician, not like an MBA application.
+
+## Turn 10 — ASSISTANT
+
+Excellent. Now let's move on to Phase 4 — translation and review. I'll walk through some categories of jobs that often turn up in the daily triage that I want to get your read on, one at a time. First: hospital staff-pharmacist openings — straight bedside clinical pharmacy work, no informatics scope. These will keyword-match your background since you've been doing the work for years. Should I keep them, relax to only "Senior" or "Lead" titles, or drop them entirely?
+
+## Turn 10 — USER
+
+Drop them entirely. Even Senior Staff Pharmacist roles — those are lateral or backward. Anything titled "Pharmacist" without "Informatics", "Clinical Informatics", "CMIO support", "Order set", or "EHR" in it should be excluded.
+
+## Turn 11 — ASSISTANT
+
+Got it. Next: PBM and managed-care-pharmacist roles — UnitedHealthcare, CVS Health, Caremark, Express Scripts, Optum. These will surface because they hit "pharmacist" + "remote" + "Minneapolis" filters. Keep, relax, or drop?
+
+## Turn 11 — USER
+
+Drop. PBM work is a different career and I have zero interest. Add explicit exclusion patterns for the company names so they don't keep appearing.
+
+## Turn 12 — ASSISTANT
+
+Pharmaceutical industry roles — Medical Science Liaison, Medical Affairs, Pharmacovigilance. These match Pharm.D. + BCPS but go in the opposite direction from informatics. Keep, relax, or drop?
+
+## Turn 12 — USER
+
+Drop. Same reasoning — wrong direction.
+
+## Turn 13 — ASSISTANT
+
+Now the inverse — patterns I should keep that the title-only filter might miss. What positive patterns should I treat as in-domain even when the title isn't an exact match?
+
+## Turn 13 — USER
+
+In-domain title patterns I want to KEEP even when "pharmacist" is missing from the title:
+- Clinical Informaticist, Clinical Informatics Specialist, Clinical Informatics Lead
+- CPOE Analyst (when it's a clinical role, not pure IT)
+- Medication Safety Officer
+- Order Set Lead, Order Set Governance Lead
+- Epic Willow Application Analyst (with clinical-license-preferred language)
+- CMIO support roles, Physician Informatics support roles where pharmacy is in scope
+- Antimicrobial stewardship coordinator with EHR-system component
+
+Plus any title with "informatics" + a clinical specialty word.
+
+## Turn 14 — ASSISTANT
+
+Excellent — that's exactly the shape I needed. Anything about ntfy notifications I should set up? You'll get a daily summary push notification when triage finishes; what topic name do you want?
+
+## Turn 14 — USER
+
+Topic: avery-pharmd-informatics-2026
+
+## Turn 15 — ASSISTANT
+
+And confirm timezone — I'll use America/Chicago for Minneapolis unless you tell me otherwise.
+
+## Turn 15 — USER
+
+Confirmed — America/Chicago.
+
+## Turn 16 — ASSISTANT
+
+Now Phase 5 — self-check and emission. I'll review what I've captured in four groups (identity, targeting, filters, writing voice), one at a time. Reply **next** to continue, or **redo {a|b|c|d}** to fix something in that group.
+
+Group **a — Identity**:
+- Name: Avery Chen, Pharm.D., BCPS
+- Email: avery.chen.pharmd@example.com
+- Phone: 555-0142
+- LinkedIn: linkedin.com/in/avery-chen-pharmd-example
+- Location: Minneapolis, MN
+- Timezone: America/Chicago
+- ntfy topic: avery-pharmd-informatics-2026
+
+Sound good?
+
+## Turn 16 — USER
+
+next
+
+## Turn 17 — ASSISTANT
+
+Group **b — Targeting**:
+- Target roles: Pharmacy Informaticist / Clinical Informatics Pharmacist; broader Clinical Informatics Specialist titles when pharmacy license is load-bearing; senior IC or first-line lead level
+- Target organizations: Mayo Clinic, M Health Fairview, Allina Health, Hennepin Healthcare, Essentia Health, Marshfield Clinic, UW Health, Sanford Health, Avera Health, Children's Minnesota; VA hospitals, IHS facilities, health-system-owned ACOs
+- Target geographies: Remote (US), hybrid in Twin Cities, willing to relocate within Upper Midwest
+- Excluded: retail pharmacy chains, PBMs (UnitedHealthcare/CVS/Caremark/Express Scripts/Optum), pharma manufacturers, "clinical pharmacist who also does informatics" reframings of the current role
+
+Sound good?
+
+## Turn 17 — USER
+
+next
+
+## Turn 18 — ASSISTANT
+
+Group **c — Filters**:
+- Hard reject titles matching: Staff Pharmacist (without informatics qualifier), Senior Staff Pharmacist, Retail Pharmacist, Pharmacy Manager (retail), Medical Science Liaison, Medical Affairs Director, Pharmacovigilance Specialist
+- Hard reject employers matching: CVS, Walgreens, Rite Aid, Optum Rx, Express Scripts, Caremark
+- In-domain positive patterns: any title containing "informatics" plus clinical specialty word; CPOE Analyst; Medication Safety Officer; Order Set Lead; Epic Willow Application Analyst; CMIO/Physician Informatics support; Antimicrobial Stewardship Coordinator (with EHR/system scope)
+
+Sound good?
+
+## Turn 18 — USER
+
+next
+
+## Turn 19 — ASSISTANT
+
+Group **d — Writing voice**:
+- Avoid the word "passionate"
+- Avoid "leverage" as a verb
+- Vary sentence structure — don't pile up action-verb starts on every bullet
+- Use specific numbers when given (don't round 14% to "around 15%")
+- Sound like a thoughtful clinician, not an MBA application
+- Resume: two pages is fine; cover letters: conversational but substantive
+
+Sound good?
+
+## Turn 19 — USER
+
+next
+
+## Turn 20 — ASSISTANT
+
+Great — I'm ready to emit the configuration files. I'll do them in four groups, pausing after each. Reply **next** to continue or **redo {a|b|c|d}** to fix a group.
+
+Group a — Identity files coming up.
+
+[Emits profile.md, master_resume.md, display_name.txt, timezone.txt, ntfy_topic.txt with FILE block delimiters]
+
+That's group **a — Identity**. Reply **next** to continue.
+
+## Turn 20 — USER
+
+next
+
+## Turn 21 — ASSISTANT
+
+Group b — Targeting files.
+
+[Emits target_companies.md, business_sector_employers_reference.md, jsearch_queries.txt]
+
+That's group **b — Targeting**. Reply **next** to continue.
+
+## Turn 21 — USER
+
+next
+
+## Turn 22 — ASSISTANT
+
+Group c — Filters.
+
+[Emits prefilter_rules.yaml, in_domain_patterns.yaml]
+
+That's group **c — Filters**. Reply **next** to continue.
+
+## Turn 22 — USER
+
+next
+
+## Turn 23 — ASSISTANT
+
+Group d — Writing voice. Did you have any voice samples — published writing, blog posts, reviews you've authored, or anything else where I can see your unedited voice — to paste in? Optional but helpful for cover letter calibration.
+
+## Turn 23 — USER
+
+Skip — I'd rather have my cover letters drafted from the resume + the framing notes than risk over-fitting to a small sample. We can revisit later if the cover letters don't sound right.
+
+## Turn 24 — ASSISTANT
+
+Understood — I'll skip the voice samples block. That's all four groups complete. The "Finalize" button at the top of the page should now be active. Click it when you're ready and findajob will write all the files into your stack and start running the pipeline.
+
+## Turn 24 — USER
+
+Done — clicking Finalize now.

--- a/tests/test_walkthrough_harness.py
+++ b/tests/test_walkthrough_harness.py
@@ -22,8 +22,11 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from walkthrough_harness import (  # noqa: E402
+    PHASE_ANCHOR_ORDER,
     _is_affirmative_question,
     _keyword_overlap,
+    advance_phase_idx,
+    compute_phase_ranges,
     load_secrets,
     pick_answer,
     redact_dom_snapshot,
@@ -335,3 +338,306 @@ class TestHelpers:
     def test_is_affirmative_question_no(self) -> None:
         assert not _is_affirmative_question("What is your target role?")
         assert not _is_affirmative_question("Please share your resume.")
+
+
+# ---------------------------------------------------------------------------
+# Phase scoping (#405 Issue 2)
+# ---------------------------------------------------------------------------
+
+
+def _multi_phase_transcript() -> str:
+    """Transcript with three detectable phase boundaries plus tail.
+
+    Phase boundaries are detected from anchor PHRASES on assistant turns —
+    "phase 2" → phase_1_end, "phase 3" → phase_2_end, "phase 4" →
+    phase_3_end. Each phase has 2 turns of substantive content.
+    """
+    return textwrap.dedent("""\
+        ## Turn 1 — ASSISTANT
+        What's your name?
+        ## Turn 1 — USER
+        Avery Chen.
+
+        ## Turn 2 — ASSISTANT
+        Tell me your role.
+        ## Turn 2 — USER
+        Clinical pharmacist.
+
+        ## Turn 3 — ASSISTANT
+        Now let's move to Phase 2 — please share your resume.
+        ## Turn 3 — USER
+        [resume body here]
+
+        ## Turn 4 — ASSISTANT
+        Any performance reviews to share?
+        ## Turn 4 — USER
+        Yes — pasted above.
+
+        ## Turn 5 — ASSISTANT
+        Great. Moving on to Phase 3 — let's set up ntfy notifications. What topic?
+        ## Turn 5 — USER
+        avery-job-2026-q2
+
+        ## Turn 6 — ASSISTANT
+        Confirm timezone — I'll use America/Chicago.
+        ## Turn 6 — USER
+        Confirmed.
+
+        ## Turn 7 — ASSISTANT
+        Now Phase 4 — what categories do you want to exclude?
+        ## Turn 7 — USER
+        Sales, marketing.
+        """)
+
+
+@pytest.fixture
+def multi_phase_corpus(tmp_path: Path) -> ReplayCorpus:
+    p = tmp_path / "multi.md"
+    p.write_text(_multi_phase_transcript(), encoding="utf-8")
+    return load_corpus(p)
+
+
+class TestPhaseRanges:
+    def test_compute_phase_ranges_returns_one_per_anchor_plus_tail(self, multi_phase_corpus: ReplayCorpus) -> None:
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        # 5 anchor slots + 1 tail = 6 entries always (regardless of how many
+        # anchors actually fired).
+        assert len(ranges) == len(PHASE_ANCHOR_ORDER) + 1
+
+    def test_compute_phase_ranges_phase_1_ends_before_phase_2_announcement(
+        self, multi_phase_corpus: ReplayCorpus
+    ) -> None:
+        """phase_1_end fires at turn 3 (the assistant turn that announces
+        Phase 2). Turn 3's user response IS in Phase 2 — so Phase 1
+        covers only turns 1..2, ending at 0-based index 2 (exclusive)."""
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        assert ranges[0] == (0, 2)
+
+    def test_compute_phase_ranges_middle_phases_advance_correctly(self, multi_phase_corpus: ReplayCorpus) -> None:
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        # phase_2_end at turn 5 → phase 2 covers [2, 4) = turns 3..4
+        assert ranges[1] == (2, 4)
+        # phase_3_end at turn 7 → phase 3 covers [4, 6) = turns 5..6
+        assert ranges[2] == (4, 6)
+
+    def test_compute_phase_ranges_tail_lands_at_post_last_anchor_slot(self, multi_phase_corpus: ReplayCorpus) -> None:
+        """The tail (= the phase the corpus ENDED in) lands at the slot
+        immediately after the last fired anchor — not always at the end
+        of the array. multi_phase has 3 anchors (phase_1/2/3_end) so the
+        tail is at index 3 (phase 4) and covers [6, 7) = turn 7."""
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        assert ranges[3] == (6, multi_phase_corpus.turn_count)
+
+    def test_compute_phase_ranges_unfired_trailing_slots_are_empty(self, multi_phase_corpus: ReplayCorpus) -> None:
+        """Slots for anchors that never fired AND that lie past the tail
+        are empty. multi_phase has 3 fired anchors → tail at idx 3, then
+        idx 4 and 5 are unused empty slots."""
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        assert ranges[4][0] == ranges[4][1]
+        assert ranges[5][0] == ranges[5][1]
+
+    def test_compute_phase_ranges_no_anchors_collapses_to_phase_1(self, tmp_path: Path) -> None:
+        """Corpus with no phase-anchor language → tail at idx 0 covering
+        the entire corpus, all other slots empty."""
+        bare = tmp_path / "bare.md"
+        bare.write_text(
+            "## Turn 1 — ASSISTANT\nQ\n## Turn 1 — USER\nA\n## Turn 2 — ASSISTANT\nQ2\n## Turn 2 — USER\nA2\n",
+            encoding="utf-8",
+        )
+        c = load_corpus(bare)
+        ranges = compute_phase_ranges(c)
+        assert ranges[0] == (0, c.turn_count)
+        for r in ranges[1:]:
+            assert r[0] == r[1]
+
+
+class TestAdvancePhaseIdx:
+    def test_no_anchor_means_no_advance(self) -> None:
+        assert advance_phase_idx("Just a regular question, no phase mention.", 0) == 0
+
+    def test_phase_2_anchor_advances_from_0_to_1(self) -> None:
+        assert advance_phase_idx("Now let's move to Phase 2.", 0) == 1
+
+    def test_phase_3_anchor_advances_from_1_to_2(self) -> None:
+        assert advance_phase_idx("Moving on to phase 3.", 1) == 2
+
+    def test_monotonically_non_decreasing(self) -> None:
+        # Once we've advanced to phase_idx 3, a phase 2 mention does NOT
+        # send us backward.
+        assert advance_phase_idx("Now let's move to Phase 2.", 3) == 3
+
+    def test_multiple_anchors_in_one_turn_advance_to_furthest(self) -> None:
+        # "we just finished phase 2, moving to phase 3" — advance by both
+        text = "Great, that wraps phase 2 — moving on to phase 3 now."
+        # The text contains both "phase 2" (phase_1_end) and "phase 3" (phase_2_end)
+        assert advance_phase_idx(text, 0) == 2
+
+
+class TestPickAnswerPhaseScoped:
+    def test_positional_within_phase_picks_first_phase_turn(self, multi_phase_corpus: ReplayCorpus) -> None:
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        answer, reason = pick_answer(
+            999,  # legacy turn_idx is irrelevant in phase-scoped mode
+            "What's your name?",
+            multi_phase_corpus,
+            {},
+            current_phase_idx=0,
+            phase_relative_turn=0,
+            phase_ranges=ranges,
+        )
+        assert reason == "positional_within_phase"
+        assert "Avery Chen" in answer
+
+    def test_keyword_within_phase_does_not_leak_across_phases(self, multi_phase_corpus: ReplayCorpus) -> None:
+        """Phase 1 corpus contains 'name' / 'role' questions. If the new
+        run is in *Phase 3* and the assistant asks something
+        keyword-similar to a Phase 1 question, the phase-scoped matcher
+        must NOT pull the Phase 1 answer — that's the cross-phase
+        contamination this fix prevents."""
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        # Phase 3 (idx 2) covers turns 5..6 — ntfy + timezone, no
+        # name/role content. A name/role-keyword query should fall
+        # through to keyword overlap within phase 3 (which has weak
+        # overlap → no match) and emit "review", not pull Phase 1's
+        # "Avery Chen" answer.
+        answer, reason = pick_answer(
+            999,
+            "What's your name and role?",
+            multi_phase_corpus,
+            {},
+            current_phase_idx=2,
+            phase_relative_turn=5,  # past phase 3's 2-turn span
+            phase_ranges=ranges,
+        )
+        assert "Avery Chen" not in answer
+        assert "Clinical pharmacist" not in answer
+        assert reason in {"review", "review_no_phase_match"}
+
+    def test_empty_phase_range_returns_review_no_phase_match(self, multi_phase_corpus: ReplayCorpus) -> None:
+        """If the new run claims to be in a phase the corpus never
+        recorded (e.g. prompt added a new phase), the matcher emits a
+        distinct review reason rather than silently grabbing the wrong
+        answer. multi_phase has 3 fired anchors → tail at idx 3; idx 4
+        and 5 are empty unused slots."""
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        answer, reason = pick_answer(
+            999,
+            "Anything question whatsoever.",
+            multi_phase_corpus,
+            {},
+            current_phase_idx=4,
+            phase_relative_turn=0,
+            phase_ranges=ranges,
+        )
+        assert reason == "review_no_phase_match"
+        assert "prior context" in answer.lower()
+
+    def test_affirmative_still_wins_in_phase_scoped_mode(self, multi_phase_corpus: ReplayCorpus) -> None:
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        answer, reason = pick_answer(
+            0,
+            "Ready to move on?",
+            multi_phase_corpus,
+            {},
+            current_phase_idx=0,
+            phase_relative_turn=0,
+            phase_ranges=ranges,
+        )
+        assert answer == "yes"
+        assert reason == "affirmative"
+
+    def test_intent_map_still_works_in_phase_scoped_mode_with_empty_range(
+        self, multi_phase_corpus: ReplayCorpus
+    ) -> None:
+        """Intent map fires even when the current phase has no corpus
+        candidates — intent classifies by question shape, not by
+        corpus similarity, so it should be phase-independent."""
+        ranges = compute_phase_ranges(multi_phase_corpus)
+        answer, reason = pick_answer(
+            999,
+            "Which categories do you want to exclude? Sales, marketing...",
+            multi_phase_corpus,
+            {"sales": "a, b"},
+            current_phase_idx=4,  # empty range in this fixture
+            phase_relative_turn=0,
+            phase_ranges=ranges,
+        )
+        assert reason.startswith("intent")
+        assert "a, b" in answer
+
+    def test_legacy_mode_unchanged_when_phase_kwargs_omitted(self, multi_phase_corpus: ReplayCorpus) -> None:
+        """Existing callers (tests above) pass no phase kwargs and must
+        get legacy behavior — positional by absolute turn_idx."""
+        answer, reason = pick_answer(0, "What's your name?", multi_phase_corpus, {})
+        assert reason == "positional"
+        assert "Avery Chen" in answer
+
+
+# ---------------------------------------------------------------------------
+# End-to-end corpus replay simulation (#405 contract test)
+# ---------------------------------------------------------------------------
+
+
+class TestRealCorpusReplay:
+    """Walks the in-repo corpus through a simulated harness loop without
+    touching Playwright. Confirms that for the corpus's own assistant
+    text at every turn, the phase-scoped matcher picks the corpus's own
+    user response at that turn — i.e. replaying against an exact-match
+    corpus is a perfect positional match, no ``review`` reasons.
+
+    This is the "is the corpus self-consistent with the matcher" gate.
+    If it fails, either the corpus was edited in a way that breaks
+    phase-anchor detection, or the matcher's phase logic regressed.
+    """
+
+    @pytest.fixture
+    def real_corpus(self) -> ReplayCorpus:
+        path = Path(__file__).parent / "fixtures" / "walkthrough" / "corpus_transcript.md"
+        return load_corpus(path)
+
+    def test_corpus_parses_with_all_five_phase_anchors(self, real_corpus: ReplayCorpus) -> None:
+        for name in PHASE_ANCHOR_ORDER:
+            assert name in real_corpus.phase_anchors, (
+                f"Corpus missing {name} — the in-repo corpus must exercise all five "
+                "phase boundaries so the harness can validate phase-scoped matching "
+                "across the whole onboarding flow."
+            )
+
+    def test_corpus_self_replay_has_no_review_turns(self, real_corpus: ReplayCorpus) -> None:
+        """Simulate the harness loop against the corpus's own transcript.
+        Every turn should match positionally within phase — the corpus
+        IS its own perfect replay source."""
+        ranges = compute_phase_ranges(real_corpus)
+        current_phase_idx = 0
+        phase_relative_turn = 0
+        review_turns: list[int] = []
+
+        for turn_num_1based in range(1, real_corpus.turn_count + 1):
+            turn_idx = turn_num_1based - 1
+            assistant_text = real_corpus.assistant_messages[turn_idx]
+            if not assistant_text.strip():
+                continue
+
+            new_phase_idx = advance_phase_idx(assistant_text, current_phase_idx)
+            if new_phase_idx != current_phase_idx:
+                current_phase_idx = new_phase_idx
+                phase_relative_turn = 0
+
+            _, reason = pick_answer(
+                turn_idx,
+                assistant_text,
+                real_corpus,
+                {},
+                current_phase_idx=current_phase_idx,
+                phase_relative_turn=phase_relative_turn,
+                phase_ranges=ranges,
+            )
+            if reason.startswith("review"):
+                review_turns.append(turn_num_1based)
+            phase_relative_turn += 1
+
+        assert not review_turns, (
+            f"Corpus self-replay produced REVIEW turns at: {review_turns}. "
+            "Either the corpus has user-message gaps in those turns, or the "
+            "matcher's phase-scoping has regressed. Spot-check the named turns."
+        )


### PR DESCRIPTION
## Summary

Closes #405. Two diagnostic limitations in `scripts/walkthrough_harness.py` that surfaced during the #401 PR B verification cycle, plus an in-repo fictional corpus that replaces the operator-PII transcripts that had been used as the de facto corpus in `tmp/`.

Surfaced during pre-#283 board scan — fixing #405 first so the next $5 walkthrough produces high-signal output to verify #283's prompt revisions against.

## Changes

### Cost reader (Issue 1)
`read_cost()` was reading `data-cumulative-cost-usd` from `#progress-row` (a `<div>`), but the attribute lives on the inner `<span>`. Wrong selector → `None` → `0.0` every time, masking the real ~\$5/run cost. Fixed selector targets `#progress-row span[data-cumulative-cost-usd]`.

### Corpus drift (Issue 2 — option b: phase-anchor scoping)
Cross-phase contamination was the worst failure mode: a Phase 4 question keyword-matching a Phase 2 corpus answer.

New helpers:
- \`compute_phase_ranges(corpus)\` — converts \`phase_anchors\` into ordered half-open corpus-index ranges, one slot per phase.
- \`advance_phase_idx(assistant_text, current)\` — monotonically non-decreasing phase advance based on anchor-phrase detection.
- \`pick_answer(...)\` gains keyword-only \`current_phase_idx\`, \`phase_relative_turn\`, \`phase_ranges\` params. Legacy mode (no kwargs) preserved for existing tests.

Semantic chosen: the boundary turn IS the FIRST turn of the new phase, since anchors are detected on the assistant turn whose user response is in the new phase.

### In-repo fictional corpus
Before this PR, the harness was being run against \`tmp/onboarding-walkthrough-*/transcript.md\` — operator walkthrough artifacts that contain PII (real name, employer history, gap-period narrative) and should never be committed.

New canonical corpus at \`tests/fixtures/walkthrough/corpus_transcript.md\` is a fictional persona — Avery Chen, clinical pharmacist transitioning to clinical informatics. Intentionally non-tech to stress-test the prompt's field-agnostic claim. 24 turns; covers all 5 phase boundaries.

\`--replay-from\` defaults to the in-repo corpus. Re-baseline workflow documented at top of corpus file; real operator walkthrough content must never be promoted into the repo.

## Test plan
- [x] \`uv run pytest tests/test_walkthrough_harness.py\` — 52 passed (19 new for phase scoping + corpus contract)
- [x] \`uv run pytest\` (full suite) — 1586 passed, 1 skipped
- [x] \`uv run ruff check\` + \`ruff format --check\` — clean
- [x] \`uv run mypy scripts/walkthrough_harness.py\` — clean
- [x] Corpus parses: 24 turns, all 5 phase anchors detected
- [x] Corpus self-replay produces zero REVIEW turns (contract test \`TestRealCorpusReplay::test_corpus_self_replay_has_no_review_turns\`)
- [ ] Live harness run against findajob-test (deferred — next walkthrough naturally exercises this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)