### PR TITLE
feat(adapters): #414 shared RAPIDAPI_KEY + JobsApi14IndeedAdapter restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+- `JobsApi14IndeedAdapter` — Indeed coverage via jobs-api14 `/v2/indeed/search`. Restores pre-#408 Indeed pulls, tuned with `sortType=date` + adapter-side title-allowlist regex to compensate for the missing recency / experience-level / employment-type filters. 20 jobs/page (2× LinkedIn), inline JD ingestion. `source_label='jobsapi_indeed'` preserves DB row continuity. Active when `'jobs-api14-indeed'` is listed in `config/active_sources.txt` (#414)
+- Shared `RAPIDAPI_KEY` env var as the canonical RapidAPI credential. Both `JobsApi14Adapter` and `JSearchAdapter` (and the new Indeed adapter) read it first, falling back to the legacy per-adapter vars (`JOBS_API14_KEY`, `JSEARCH_API_KEY`) if unset. Reflects the reality that RapidAPI uses one account-level key per user, not per-API (#414)
+
+### Migration required
+- **Existing stacks pulling next minor:** legacy `JOBS_API14_KEY` / `JSEARCH_API_KEY` continue to work — no action required to keep current adapter configs running. To start using `RAPIDAPI_KEY` as the canonical name, copy the existing legacy var's value to `RAPIDAPI_KEY=` in `data/.env` (operators can also remove the legacy vars once migrated, but they're harmless if left).
+- **To enable the new Indeed adapter:** add `jobs-api14-indeed` as a new line in `config/active_sources.txt` and restart the stack. No new credentials needed (shares jobs-api14's account).
+
 ## [0.14.0] — 2026-05-02
 
 Minor bump shipping #408 pluggable `JobSourceAdapter` framework + JSearch adapter (#310) + onboarding picker (Section 3h). Operator's stack and `findajob-test` already track `:latest`; tester stacks (alice, papa, dave, judy, tango) currently on `:v0.13` should bump to `:v0.14` in the cohort wave.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ file. If you're refactoring an old hardcoded section, add a note to `docs/GENERA
 | `interview_prep` | `openrouter:anthropic/claude-opus-4.7`, `max_tokens: 4096` — fires on `applied → interview` transition; expands briefing's interview-questions + stories sections. |
 | `candidate_led_briefing` | `openrouter:perplexity/sonar-deep-research` — async (1–5 min); drives the speculative briefing pass via `scripts/run_speculative_research.py`. |
 | `speculative_roles_synth` | `openrouter:anthropic/claude-sonnet-4-6`, `max_tokens: 4096` — synthesizes 1–5 candidate-tailored role cards from the briefing. |
-| Job ingestion | Pluggable via `JobSourceAdapter` (`src/findajob/fetchers/adapters/`); jobs-api14 + JSearch ship in v0.14; per-stack active list in `config/active_sources.txt`. Greenhouse / Ashby / Lever / Gmail still function-style — migration tracked in #410. |
+| Job ingestion | Pluggable via `JobSourceAdapter` (`src/findajob/fetchers/adapters/`); jobs-api14 + JSearch ship in v0.14; per-stack active list in `config/active_sources.txt`. Greenhouse / Ashby / Lever / Gmail still function-style — migration tracked in #410. v0.15 adds `JobsApi14IndeedAdapter` (Indeed via jobs-api14 with sortType=date + post-filter, restoring pre-#408 coverage) and consolidates RapidAPI credentials to a shared `RAPIDAPI_KEY` env var (legacy `JOBS_API14_KEY` / `JSEARCH_API_KEY` work as fallbacks) (#414). |
 | Package manager | `uv sync` for dev deps; `uv run` prefix for pytest/ruff/mypy/uvicorn |
 | Path resolution | `src/findajob/paths.py` — reads `config/paths.env`; BASE derived from `__file__` |
 | Roles dir | `config/roles/` |
@@ -289,9 +289,11 @@ RAG indexes `candidate_context/` but is used only in REPL mode.
 Every RapidAPI-flavored job source implements `JobSourceAdapter`
 (`src/findajob/fetchers/adapters/base.py`). Adding a new feed = one new
 adapter file + one entry in `REGISTERED_ADAPTERS`. `triage.py` iterates
-the registry; no per-source code paths in triage. Each adapter declares
-its own env var (`JOBS_API14_KEY`, `JSEARCH_API_KEY`, etc.) — there is no
-global `RAPIDAPI_KEY`. The `JobSourceAdapter` Protocol is source-agnostic
+the registry; no per-source code paths in triage. Adapters share a canonical
+`RAPIDAPI_KEY` env var (#414); per-adapter env vars (`JOBS_API14_KEY`,
+`JSEARCH_API_KEY`) remain valid as fallbacks for legacy stacks. Stacks pick
+which adapters to run via `config/active_sources.txt` (default: `['jobs-api14']`
+if missing). The `JobSourceAdapter` Protocol is source-agnostic
 by design — direct fetchers (Workday CXS #248, Gem GraphQL #249) implement
 the same contract.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ When the pipeline runs inside the `ghcr.io/brockamer/findajob` image, paths shif
 <repo>/src/findajob/cleaning.py             # normalize, fingerprint, clean_title, clean_company
 <repo>/src/findajob/ingest.py               # ingest_manual_job() — shared entry point for the /ingest/ web form
 <repo>/src/findajob/fetchers/                 # Greenhouse, Gmail job fetching; RapidAPI feeds via adapters/
-<repo>/src/findajob/fetchers/adapters/      # JobSourceAdapter Protocol + REGISTERED_ADAPTERS + JobsApi14Adapter + JSearchAdapter
+<repo>/src/findajob/fetchers/adapters/      # JobSourceAdapter Protocol + REGISTERED_ADAPTERS + JobsApi14Adapter + JobsApi14IndeedAdapter + JSearchAdapter
 <repo>/src/findajob/scoring.py              # score_job(), _build_feedback_block()
 <repo>/src/findajob/scorer_prefilter.py     # deterministic pre-filter (Stage 1 + 2)
 <repo>/src/findajob/web/app.py               # FastAPI app factory (create_app)

--- a/data/.env.example
+++ b/data/.env.example
@@ -12,15 +12,16 @@ GROQ_API_KEY=your_key_here             # Optional
 XAI_API_KEY=your_key_here              # Optional
 
 # ── Job Data APIs ─────────────────────────────────────────────────────────────
-# Per-adapter API keys (#408). Each registered adapter declares its
-# own env var. Set the one(s) that match the active feed(s) listed
-# in config/active_sources.txt. Adapters with blank env vars are
-# silently skipped at triage time.
+# RapidAPI account-level key. ONE key authorizes every API you've subscribed
+# to under your RapidAPI account (jobs-api14, JSearch, etc). New stacks set
+# only this; legacy stacks may still set the per-adapter vars below as
+# fallback (#414).
+RAPIDAPI_KEY=
 
-# Jobs API (jobs-api14) — LinkedIn-skewed; default for v0.14+
-JOBS_API14_KEY=
-
-# JSearch — multi-board aggregator (LinkedIn + Indeed + Glassdoor + ZipRecruiter)
+# Legacy per-adapter env vars (#408). Still read as fallback when
+# RAPIDAPI_KEY is unset. Don't set these unless you genuinely have separate
+# RapidAPI accounts for different APIs (rare).
+# JOBS_API14_KEY=
 # JSEARCH_API_KEY=
 
 # ── Notifications ─────────────────────────────────────────────────────────────

--- a/docs/setup/api-keys.md
+++ b/docs/setup/api-keys.md
@@ -89,11 +89,23 @@ right feed for your field from the operator-curated `config/rapidapi_feeds.yaml`
 table; the `/onboarding/feed-config/` form walks you through signup and runs a
 live connection test.
 
-| Feed | Env var | What it searches | Free tier |
-|---|---|---|---|
-| **jobs-api14** | `RAPIDAPI_KEY` (canonical) or `JOBS_API14_KEY` (legacy fallback, #414) | LinkedIn — broad coverage, LinkedIn-heavy | 150 req/month |
-| **jobs-api14 (Indeed)** | `RAPIDAPI_KEY` (canonical) or `JOBS_API14_KEY` (legacy fallback, #414) | Indeed — broad US coverage, inline JD | shares jobs-api14 quota (150 req/month free) |
-| **JSearch** | `RAPIDAPI_KEY` (canonical) or `JSEARCH_API_KEY` (legacy fallback, #414) | LinkedIn + Indeed + Glassdoor + ZipRecruiter | 200 req/month |
+| Feed | Adapter name (in `active_sources.txt`) | Env var | What it searches | Free tier |
+|---|---|---|---|---|
+| **jobs-api14** | `jobs-api14` | `RAPIDAPI_KEY` (canonical) or `JOBS_API14_KEY` (legacy fallback, #414) | LinkedIn — broad coverage, LinkedIn-heavy | 150 req/month (BASIC); 20,000 req/month (PRO) |
+| **jobs-api14 (Indeed)** | `jobs-api14-indeed` | `RAPIDAPI_KEY` (canonical) or `JOBS_API14_KEY` (legacy fallback, #414) | Indeed — broad US coverage, inline JD | shares per-account quota with jobs-api14 |
+| **JSearch** | `jsearch` | `RAPIDAPI_KEY` (canonical) or `JSEARCH_API_KEY` (legacy fallback, #414) | LinkedIn + Indeed + Glassdoor + ZipRecruiter | 200 req/month (BASIC); 20,000 req/month (PRO) |
+
+> **Adapter names matter.** The values in the "Adapter name" column above are what you must put in `config/active_sources.txt` — one per line. Stacks without `config/active_sources.txt` default to `jobs-api14` (LinkedIn-only); the file is written by the onboarding picker for new stacks.
+
+> **Indeed is opt-in.** To activate it, add `jobs-api14-indeed` to `config/active_sources.txt`. The onboarding picker handles this for new stacks; existing stacks need to add the line manually. Example `config/active_sources.txt` with both feeds:
+> ```
+> jobs-api14
+> jobs-api14-indeed
+> ```
+
+> **PRO/ULTRA/MEGA tiers:** Indeed and LinkedIn share the same per-account quota — upgrading your RapidAPI plan raises the limit for both feeds together (PRO: 20,000 req/month shared).
+
+> **Note (Indeed title allowlist):** The `jobs-api14-indeed` adapter applies a hardcoded title allowlist tuned for engineering / operations / program-management / hardware / data-center families. Non-engineering candidates may see sparse Indeed pulls until a follow-up issue lifts this to a config file. See `_TITLE_ALLOW_PATTERN` in `src/findajob/fetchers/adapters/jobs_api14_indeed.py` for the full regex.
 
 If you skip the RapidAPI key, findajob will:
 

--- a/docs/setup/api-keys.md
+++ b/docs/setup/api-keys.md
@@ -12,7 +12,7 @@ credit card to get started.
 | Key | What findajob uses it for | Cost on free tier | Required? |
 |---|---|---|---|
 | **OpenRouter** | All LLM calls (scoring, briefings, resume tailoring, cover letters, outreach drafts, in-app interview) | Pay-as-you-go from $0; no monthly minimum. ~$0.50/day triage-only; $1.50–3.00 per fully-prepped job (Claude Opus dominates that bill). | **Yes** — pipeline cannot score or generate materials without it |
-| **RapidAPI feed** (jobs-api14 or JSearch) | LinkedIn + Indeed job search ingestion | BASIC plan: 150–250 requests/month free | Optional — Gmail LinkedIn-alert ingestion still works without it |
+| **RapidAPI feed** (jobs-api14, JSearch, or jobs-api14 Indeed) | LinkedIn + Indeed job search ingestion | BASIC plan: 150–250 requests/month free | Optional — Gmail LinkedIn-alert ingestion still works without it |
 | **Google AI Studio (Gemini)** | Embeddings for the optional RAG index over your candidate context (REPL-only feature) | Free tier on Gemini embeddings; no billing setup needed | Optional — only used by the REPL workflow; pipeline is fully functional without it |
 
 You can leave RapidAPI and Google blank during onboarding and add them
@@ -82,19 +82,20 @@ OpenRouter shows you a live spend breakdown at <https://openrouter.ai/activity>.
 > onboarding via `/onboarding/?mode=rerun` if you want to revisit the
 > source-strategy decision.
 
-findajob supports multiple RapidAPI-flavored job feeds. Each feed has its
-own env var and its own BASIC-tier quota. The onboarding interview's
-Section 3h recommends the right feed for your field from the
-operator-curated `config/rapidapi_feeds.yaml` table; the
-`/onboarding/feed-config/` form walks you through signup and runs a live
-connection test.
+findajob supports multiple RapidAPI-flavored job feeds. All feeds share the
+canonical `RAPIDAPI_KEY` env var — one RapidAPI account key covers every API
+you've subscribed to. The onboarding interview's Section 3h recommends the
+right feed for your field from the operator-curated `config/rapidapi_feeds.yaml`
+table; the `/onboarding/feed-config/` form walks you through signup and runs a
+live connection test.
 
 | Feed | Env var | What it searches | Free tier |
 |---|---|---|---|
-| **jobs-api14** | `JOBS_API14_KEY` | LinkedIn — broad coverage, LinkedIn-heavy | 150 req/month |
-| **JSearch** | `JSEARCH_API_KEY` | LinkedIn + Indeed + Glassdoor + ZipRecruiter | 200 req/month |
+| **jobs-api14** | `RAPIDAPI_KEY` (canonical) or `JOBS_API14_KEY` (legacy fallback, #414) | LinkedIn — broad coverage, LinkedIn-heavy | 150 req/month |
+| **jobs-api14 (Indeed)** | `RAPIDAPI_KEY` (canonical) or `JOBS_API14_KEY` (legacy fallback, #414) | Indeed — broad US coverage, inline JD | shares jobs-api14 quota (150 req/month free) |
+| **JSearch** | `RAPIDAPI_KEY` (canonical) or `JSEARCH_API_KEY` (legacy fallback, #414) | LinkedIn + Indeed + Glassdoor + ZipRecruiter | 200 req/month |
 
-If you skip both keys, findajob will:
+If you skip the RapidAPI key, findajob will:
 
 - still ingest jobs from Greenhouse / Ashby / Lever ATS feeds (configured
   in `config/feed_urls.txt`)
@@ -116,7 +117,7 @@ running the picker again.
    in the right-hand pane as the `X-RapidAPI-Key` header value.
 5. The onboarding `/onboarding/feed-config/` form accepts the key and
    runs a live connection test before writing it to `data/.env` as
-   `JOBS_API14_KEY`.
+   `RAPIDAPI_KEY` — the canonical name covers every RapidAPI feed (#414).
 
 ### Sign up for JSearch
 
@@ -127,7 +128,7 @@ running the picker again.
 4. After subscribing, your API key appears in the right-hand pane as the
    `X-RapidAPI-Key` header value.
 5. The onboarding `/onboarding/feed-config/` form accepts the key and
-   writes it to `data/.env` as `JSEARCH_API_KEY`.
+   writes it to `data/.env` as `RAPIDAPI_KEY` — the canonical name covers every RapidAPI feed (#414).
 
 ### Quota guidance
 

--- a/docs/setup/configure.md
+++ b/docs/setup/configure.md
@@ -134,8 +134,9 @@ API keys and secrets. See `data/.env.example` for the full list.
 ```bash
 OPENROUTER_API_KEY=sk-or-...
 GOOGLE_API_KEY=AIza...
-JOBS_API14_KEY=...      # jobs-api14 adapter (optional; set by onboarding picker)
-JSEARCH_API_KEY=...     # JSearch adapter (optional; set by onboarding picker)
+RAPIDAPI_KEY=...        # canonical key for all RapidAPI feeds (optional; set by onboarding picker)
+# JOBS_API14_KEY=...   # legacy per-adapter fallback — still works; RAPIDAPI_KEY preferred (#414)
+# JSEARCH_API_KEY=...  # legacy per-adapter fallback — still works; RAPIDAPI_KEY preferred (#414)
 NTFY_TOPIC=your-topic-name
 ```
 

--- a/docs/setup/install-docker.md
+++ b/docs/setup/install-docker.md
@@ -321,8 +321,7 @@ SQLite reads use `mode=ro` URI; `/opt/stacks` is mounted read-only.
 
 ### Rotating an API key
 
-To replace the OpenRouter, RapidAPI feed (`JOBS_API14_KEY` / `JSEARCH_API_KEY`), or
-Google API key on an already-onboarded stack, you have two options:
+To replace the OpenRouter, RapidAPI feed (`RAPIDAPI_KEY` — canonical; or legacy per-adapter vars `JOBS_API14_KEY` / `JSEARCH_API_KEY`, #414), or Google API key on an already-onboarded stack, you have two options:
 
 **Option A — Web UI (recommended):**
 
@@ -349,7 +348,9 @@ sudo docker compose restart scheduler
 
 Per the project memory `feedback_never_print_secrets`, never `cat` or
 echo the `.env` to your terminal — copy + edit server-side only.
-Repeat for `JOBS_API14_KEY` / `JSEARCH_API_KEY` / `GOOGLE_API_KEY` as needed.
+Repeat for `RAPIDAPI_KEY` / `GOOGLE_API_KEY` as needed. Stacks with legacy
+per-adapter vars (`JOBS_API14_KEY` / `JSEARCH_API_KEY`) can rotate those
+the same way — both still work as fallback (#414).
 
 ### Adding the `.backups` bind mount (for stacks deployed before `:v0.10.0`)
 

--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -28,7 +28,7 @@ Used by: LinkedIn and Indeed job search in `triage.py` (via pluggable adapter)
 - Sign up at https://rapidapi.com
 - The onboarding interview's Section 3h recommends the right feed for your field
 - Subscribe to your chosen feed (both have a free tier)
-- Add API key to `data/.env` as `JOBS_API14_KEY` or `JSEARCH_API_KEY`
+- Add API key to `data/.env` as `RAPIDAPI_KEY` (canonical, covers all RapidAPI feeds) — legacy per-adapter vars `JOBS_API14_KEY` / `JSEARCH_API_KEY` still work as fallback (#414)
 - See `docs/setup/api-keys.md` for per-feed sign-up walkthroughs
 
 ### 4. Google Cloud — Sheets API + Gmail API

--- a/src/findajob/fetchers/__init__.py
+++ b/src/findajob/fetchers/__init__.py
@@ -8,6 +8,7 @@ import sys
 import time
 
 from findajob.cleaning import clean_company, clean_title, extract_linkedin_job_id
+from findajob.fetchers.adapters._keys import resolve_rapidapi_key
 from findajob.paths import BASE, PANDOC
 from findajob.utils import JD_MAX_CHARS, log_event, strip_jd_boilerplate
 
@@ -49,7 +50,7 @@ def fetch_linkedin_job_data(job_id):
     """
     import requests as req
 
-    api_key = os.environ.get("RAPIDAPI_KEY", "")
+    api_key = resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY")
     if not api_key or not job_id:
         return {"description": None, "company": None}
     time.sleep(_LINKEDIN_GET_THROTTLE_SEC)
@@ -399,9 +400,9 @@ def fetch_jobsapi_jobs(queries_path):
     """
     import requests as req
 
-    api_key = os.environ.get("RAPIDAPI_KEY", "")
+    api_key = resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY")
     if not api_key:
-        log_event("jobsapi_error", error="RAPIDAPI_KEY not set in .env")
+        log_event("jobsapi_error", error="No RAPIDAPI_KEY or JOBS_API14_KEY set in .env")
         return []
 
     try:

--- a/src/findajob/fetchers/adapters/_keys.py
+++ b/src/findajob/fetchers/adapters/_keys.py
@@ -1,0 +1,29 @@
+"""Shared RapidAPI key resolver (#414).
+
+Both `JobsApi14Adapter` and `JSearchAdapter` (and any future RapidAPI-flavored
+adapter) accept the SAME account-level X-RapidAPI-Key — the per-adapter env
+var separation in #408 was based on a wrong premise (that each API has its
+own credential). This helper looks up a list of candidate env vars and
+returns the first non-empty value, treating whitespace-only as unset.
+
+Convention: callers pass the canonical name (`RAPIDAPI_KEY`) first, then any
+legacy per-adapter names as fallbacks (e.g. `JOBS_API14_KEY`). New
+onboardings write only the canonical; existing tester stacks keep working
+via fallback without code-side migration.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_rapidapi_key(*candidate_env_vars: str) -> str:
+    """Return the first non-empty value among the candidate env vars.
+
+    Whitespace-only values are treated as unset. Returns "" if none set.
+    """
+    for var in candidate_env_vars:
+        value = os.environ.get(var, "").strip()
+        if value:
+            return value
+    return ""

--- a/src/findajob/fetchers/adapters/jobs_api14.py
+++ b/src/findajob/fetchers/adapters/jobs_api14.py
@@ -24,7 +24,7 @@ class JobsApi14Adapter:
     name: ClassVar[str] = "jobs-api14"
     display_name: ClassVar[str] = "Jobs API (jobs-api14)"
     source_label: ClassVar[str] = "jobsapi_linkedin"
-    required_env_vars: ClassVar[tuple[str, ...]] = ("JOBS_API14_KEY",)
+    required_env_vars: ClassVar[tuple[str, ...]] = ("RAPIDAPI_KEY", "JOBS_API14_KEY")
 
     _ENDPOINT: ClassVar[str] = "https://jobs-api14.p.rapidapi.com/v2/linkedin/search"
     _HOST: ClassVar[str] = "jobs-api14.p.rapidapi.com"

--- a/src/findajob/fetchers/adapters/jobs_api14.py
+++ b/src/findajob/fetchers/adapters/jobs_api14.py
@@ -11,6 +11,7 @@ import requests
 from findajob.cleaning import clean_company, clean_title
 from findajob.utils import log_event
 
+from ._keys import resolve_rapidapi_key
 from .base import LiveTestResult, QueryResult
 
 # Bind module-level imports so tests can patch them via the public path
@@ -29,12 +30,15 @@ class JobsApi14Adapter:
     _HOST: ClassVar[str] = "jobs-api14.p.rapidapi.com"
 
     def is_configured(self) -> bool:
-        return bool(os.environ.get("JOBS_API14_KEY", ""))
+        return bool(self._api_key())
+
+    def _api_key(self) -> str:
+        return resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY")
 
     def fetch(self, queries: list[str]) -> list[dict]:
-        api_key = os.environ.get("JOBS_API14_KEY", "")
+        api_key = self._api_key()
         if not api_key:
-            log_event("jobsapi_error", error="JOBS_API14_KEY not set in .env")
+            log_event("jobsapi_error", error="No RAPIDAPI_KEY or JOBS_API14_KEY set in .env")
             return []
 
         date_posted = _date_posted_for_install()
@@ -57,7 +61,7 @@ class JobsApi14Adapter:
         return rows
 
     def live_test(self, queries: list[str]) -> LiveTestResult:
-        api_key = os.environ.get("JOBS_API14_KEY", "")
+        api_key = self._api_key()
         if not api_key:
             return LiveTestResult(
                 ok=False,

--- a/src/findajob/fetchers/adapters/jobs_api14_indeed.py
+++ b/src/findajob/fetchers/adapters/jobs_api14_indeed.py
@@ -37,6 +37,8 @@ __all__ = ("JobsApi14IndeedAdapter",)
 # program-mgmt / NPI / hardware / data-center title families. Tighter than
 # scorer_prefilter Stage 1's REJECT pattern; this is INCLUSION, applied
 # pre-storage to compensate for Indeed's missing server-side filters.
+# Hardcoded here in PR1 (#414); a follow-up issue will lift this to a config file
+# once the right shape is clear from real ingest data.
 _TITLE_ALLOW_PATTERN: re.Pattern[str] = re.compile(
     r"\b("
     r"engineer|manager|director|lead|architect|analyst|program|"
@@ -218,6 +220,10 @@ class JobsApi14IndeedAdapter:
             if not _TITLE_ALLOW_PATTERN.search(title):
                 continue
 
+            url = job.get("applyUrl", "")
+            if not url:
+                continue
+
             raw_company = job.get("company", {})
             if isinstance(raw_company, dict):
                 raw_company = raw_company.get("name", "")
@@ -225,10 +231,6 @@ class JobsApi14IndeedAdapter:
 
             loc = job.get("location", "")
             location = loc.get("location", "") if isinstance(loc, dict) else loc
-
-            url = job.get("applyUrl", "")
-            if not url:
-                continue
 
             rows.append(
                 {

--- a/src/findajob/fetchers/adapters/jobs_api14_indeed.py
+++ b/src/findajob/fetchers/adapters/jobs_api14_indeed.py
@@ -1,0 +1,245 @@
+"""JobsApi14IndeedAdapter — restored Indeed coverage via jobs-api14 (#414).
+
+Indeed endpoint exposes no recency / experience-level / employment-type
+filters (unlike LinkedIn), so the legacy fetcher (retired pre-#408) returned
+~89% off-target rows. This adapter compensates with three knobs:
+
+1. sortType=date — most-recent first, daily triage captures fresh jobs.
+2. countryCode=us + location="United States" — geo-narrow.
+3. Adapter-side title regex post-filter — inclusion allowlist before storing.
+
+Per-page count is 20 (vs LinkedIn's 10). Description is inline in the
+search response, so no separate /v2/linkedin/get-equivalent call needed.
+
+Shares JOBS_API14_KEY / RAPIDAPI_KEY with `JobsApi14Adapter` via the
+shared resolver (#414); both adapters are subscriptions on the same
+RapidAPI account.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import ClassVar
+
+import requests
+
+from findajob.cleaning import clean_company, clean_title
+from findajob.utils import log_event
+
+from ._keys import resolve_rapidapi_key
+from .base import LiveTestResult, QueryResult
+
+__all__ = ("JobsApi14IndeedAdapter",)
+
+
+# Title-allowlist regex — case-insensitive. Tuned for ops / infrastructure /
+# program-mgmt / NPI / hardware / data-center title families. Tighter than
+# scorer_prefilter Stage 1's REJECT pattern; this is INCLUSION, applied
+# pre-storage to compensate for Indeed's missing server-side filters.
+_TITLE_ALLOW_PATTERN: re.Pattern[str] = re.compile(
+    r"\b("
+    r"engineer|manager|director|lead|architect|analyst|program|"
+    r"operations|infrastructure|data\s*center|hardware|npi|"
+    r"technician|specialist|coordinator|supervisor|administrator"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+class JobsApi14IndeedAdapter:
+    """jobs-api14 /v2/indeed/search adapter, tuned for the missing-filter problem."""
+
+    name: ClassVar[str] = "jobs-api14-indeed"
+    display_name: ClassVar[str] = "Jobs API — Indeed (jobs-api14)"
+    source_label: ClassVar[str] = "jobsapi_indeed"  # preserves DB row continuity
+    required_env_vars: ClassVar[tuple[str, ...]] = ("RAPIDAPI_KEY", "JOBS_API14_KEY")
+
+    _ENDPOINT: ClassVar[str] = "https://jobs-api14.p.rapidapi.com/v2/indeed/search"
+    _HOST: ClassVar[str] = "jobs-api14.p.rapidapi.com"
+
+    def is_configured(self) -> bool:
+        return bool(self._api_key())
+
+    def _api_key(self) -> str:
+        return resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY")
+
+    def fetch(self, queries: list[str]) -> list[dict]:
+        api_key = self._api_key()
+        if not api_key:
+            log_event("jobsapi_indeed_error", error="No RAPIDAPI_KEY or JOBS_API14_KEY set in .env")
+            return []
+
+        headers = self._headers(api_key)
+        rows: list[dict] = []
+        last_idx = len(queries) - 1
+        for i, query in enumerate(queries):
+            data = self._call_with_retry(headers, self._params(query), query)
+            if data is None:
+                continue
+            new_rows = self._parse_rows(data, query)
+            rows.extend(new_rows)
+            log_event("jobsapi_indeed_fetched", query=query, count=len(new_rows))
+            if i < last_idx:
+                time.sleep(0.6)
+        return rows
+
+    def live_test(self, queries: list[str]) -> LiveTestResult:
+        api_key = self._api_key()
+        if not api_key:
+            return LiveTestResult(
+                ok=False,
+                bucket="auth",
+                per_query=[],
+                auth_error="No API key configured.",
+            )
+
+        headers = self._headers(api_key)
+        per_query: list[QueryResult] = []
+        rate_limited = False
+        for i, query in enumerate(queries):
+            try:
+                response = requests.get(self._ENDPOINT, headers=headers, params=self._params(query), timeout=30)
+            except requests.RequestException as e:
+                if i == 0:
+                    return LiveTestResult(ok=False, bucket="network", per_query=[], auth_error=str(e))
+                rate_limited = True
+                break
+
+            if response.status_code in (401, 403):
+                return LiveTestResult(
+                    ok=False,
+                    bucket="auth",
+                    per_query=[],
+                    auth_error=f"HTTP {response.status_code}: invalid key or subscription not active.",
+                )
+            if response.status_code == 429:
+                if i == 0:
+                    return LiveTestResult(
+                        ok=False,
+                        bucket="rate_limit",
+                        per_query=[],
+                        auth_error="Rate limited on first call.",
+                    )
+                rate_limited = True
+                break
+            if 500 <= response.status_code < 600:
+                return LiveTestResult(
+                    ok=False,
+                    bucket="server",
+                    per_query=[],
+                    auth_error=f"HTTP {response.status_code}: server error.",
+                )
+
+            try:
+                data = response.json()
+            except ValueError:
+                return LiveTestResult(
+                    ok=False,
+                    bucket="server",
+                    per_query=[],
+                    auth_error="Invalid JSON response.",
+                )
+
+            if data.get("hasError"):
+                return LiveTestResult(
+                    ok=False,
+                    bucket="auth",
+                    per_query=[],
+                    auth_error=f"API reported error: {data.get('errors')}.",
+                )
+
+            # Apply the same post-filter so live-test counts reflect what would actually ingest
+            parsed = self._parse_rows(data, query)
+            per_query.append(QueryResult(query=query, count=len(parsed)))
+
+        if rate_limited:
+            return LiveTestResult(ok=True, bucket="rate_limit", per_query=per_query, auth_error=None)
+
+        total = sum(qr.count for qr in per_query)
+        if total == 0:
+            return LiveTestResult(ok=True, bucket="zero_rows", per_query=per_query, auth_error=None)
+        if any(qr.count == 0 for qr in per_query):
+            return LiveTestResult(ok=True, bucket="mixed", per_query=per_query, auth_error=None)
+        return LiveTestResult(ok=True, bucket="success", per_query=per_query, auth_error=None)
+
+    # ------------------------- internal helpers -------------------------
+
+    def _headers(self, api_key: str) -> dict[str, str]:
+        return {
+            "x-rapidapi-host": self._HOST,
+            "x-rapidapi-key": api_key,
+            "Content-Type": "application/json",
+        }
+
+    def _params(self, query: str) -> dict[str, str]:
+        # Indeed has no datePosted / experienceLevels / employmentTypes filters.
+        # Compensating: sortType=date (recency-as-filter) + countryCode=us +
+        # location filter. The remaining off-target rows are dropped by the
+        # title regex post-filter in _parse_rows.
+        return {
+            "query": query,
+            "location": "United States",
+            "countryCode": "us",
+            "sortType": "date",
+        }
+
+    def _call_with_retry(
+        self,
+        headers: dict[str, str],
+        params: dict[str, str],
+        query: str,
+    ) -> dict | None:
+        try:
+            response = requests.get(self._ENDPOINT, headers=headers, params=params, timeout=30)
+            if response.status_code == 429:
+                wait = min(int(response.headers.get("Retry-After", "10")), 60)
+                log_event("rapidapi_rate_limit", source=self.name, query=query, wait=wait)
+                time.sleep(wait)
+                response = requests.get(self._ENDPOINT, headers=headers, params=params, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            if data.get("hasError"):
+                log_event("jobsapi_indeed_error", query=query, errors=data.get("errors"))
+                return None
+            return data
+        except requests.RequestException as e:
+            log_event("jobsapi_indeed_error", query=query, error=str(e))
+            return None
+
+    def _parse_rows(self, data: dict, query: str) -> list[dict]:
+        rows: list[dict] = []
+        for job in data.get("data", []) or []:
+            raw_title = job.get("title", "")
+            title = clean_title(raw_title)
+            if not title:
+                continue
+            # Inclusion post-filter — drop titles outside the allowlist
+            if not _TITLE_ALLOW_PATTERN.search(title):
+                continue
+
+            raw_company = job.get("company", {})
+            if isinstance(raw_company, dict):
+                raw_company = raw_company.get("name", "")
+            company = clean_company(raw_company)
+
+            loc = job.get("location", "")
+            location = loc.get("location", "") if isinstance(loc, dict) else loc
+
+            url = job.get("applyUrl", "")
+            if not url:
+                continue
+
+            rows.append(
+                {
+                    "title": title,
+                    "company": company,
+                    "location": location,
+                    "url": url,
+                    "api_id": str(job.get("id", "")),
+                    "source": self.source_label,
+                    "query": query,
+                    "description": job.get("description", ""),  # inline JD
+                }
+            )
+        return rows

--- a/src/findajob/fetchers/adapters/jsearch.py
+++ b/src/findajob/fetchers/adapters/jsearch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import time
 from typing import ClassVar
 
@@ -11,6 +10,7 @@ import requests
 from findajob.cleaning import clean_company, clean_title
 from findajob.utils import log_event
 
+from ._keys import resolve_rapidapi_key
 from .base import LiveTestResult, QueryResult
 
 __all__ = ("JSearchAdapter",)
@@ -22,18 +22,21 @@ class JSearchAdapter:
     name: ClassVar[str] = "jsearch"
     display_name: ClassVar[str] = "JSearch"
     source_label: ClassVar[str] = "jsearch"
-    required_env_vars: ClassVar[tuple[str, ...]] = ("JSEARCH_API_KEY",)
+    required_env_vars: ClassVar[tuple[str, ...]] = ("RAPIDAPI_KEY", "JSEARCH_API_KEY")
 
     _ENDPOINT: ClassVar[str] = "https://jsearch.p.rapidapi.com/search"
     _HOST: ClassVar[str] = "jsearch.p.rapidapi.com"
 
     def is_configured(self) -> bool:
-        return bool(os.environ.get("JSEARCH_API_KEY", ""))
+        return bool(self._api_key())
+
+    def _api_key(self) -> str:
+        return resolve_rapidapi_key("RAPIDAPI_KEY", "JSEARCH_API_KEY")
 
     def fetch(self, queries: list[str]) -> list[dict]:
-        api_key = os.environ.get("JSEARCH_API_KEY", "")
+        api_key = self._api_key()
         if not api_key:
-            log_event("jsearch_error", error="JSEARCH_API_KEY not set in .env")
+            log_event("jsearch_error", error="No RAPIDAPI_KEY or JSEARCH_API_KEY set in .env")
             return []
 
         headers = self._headers(api_key)
@@ -73,7 +76,7 @@ class JSearchAdapter:
         return rows
 
     def live_test(self, queries: list[str]) -> LiveTestResult:
-        api_key = os.environ.get("JSEARCH_API_KEY", "")
+        api_key = self._api_key()
         if not api_key:
             return LiveTestResult(
                 ok=False,

--- a/src/findajob/fetchers/adapters/registry.py
+++ b/src/findajob/fetchers/adapters/registry.py
@@ -10,10 +10,12 @@ from findajob.utils import log_event
 
 from .base import JobSourceAdapter
 from .jobs_api14 import JobsApi14Adapter
+from .jobs_api14_indeed import JobsApi14IndeedAdapter
 from .jsearch import JSearchAdapter
 
 REGISTERED_ADAPTERS: list[type[JobSourceAdapter]] = [
     JobsApi14Adapter,  # type: ignore[list-item]
+    JobsApi14IndeedAdapter,  # type: ignore[list-item]
     JSearchAdapter,  # type: ignore[list-item]
 ]
 

--- a/tests/test_adapter_registry.py
+++ b/tests/test_adapter_registry.py
@@ -54,3 +54,11 @@ def test_iter_configured_adapters_default_when_file_missing(tmp_path: Path, monk
     with patch("findajob.fetchers.adapters.registry._active_sources_path", return_value=nonexistent):
         names = [a.name for a in iter_configured_adapters()]
     assert names == ["jobs-api14"]
+
+
+def test_jobs_api14_indeed_adapter_is_registered() -> None:
+    """JobsApi14IndeedAdapter (#414) ships in the registry alongside its sibling."""
+    from findajob.fetchers.adapters.jobs_api14_indeed import JobsApi14IndeedAdapter
+    from findajob.fetchers.adapters.registry import REGISTERED_ADAPTERS
+
+    assert JobsApi14IndeedAdapter in REGISTERED_ADAPTERS

--- a/tests/test_adapter_shared_key.py
+++ b/tests/test_adapter_shared_key.py
@@ -1,0 +1,52 @@
+"""Tests for the shared RapidAPI key resolver (#414)."""
+
+from __future__ import annotations
+
+import pytest
+
+from findajob.fetchers.adapters._keys import resolve_rapidapi_key
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("RAPIDAPI_KEY", "JOBS_API14_KEY", "JSEARCH_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_returns_empty_when_no_vars_set() -> None:
+    assert resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY") == ""
+
+
+def test_returns_canonical_when_only_canonical_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    assert resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY") == "shared-1234"
+
+
+def test_returns_dedicated_when_only_dedicated_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    assert resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY") == "legacy-1234"
+
+
+def test_canonical_wins_over_dedicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    assert resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY") == "shared-1234"
+
+
+def test_treats_empty_string_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDAPI_KEY", "")
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    assert resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY") == "legacy-1234"
+
+
+def test_treats_whitespace_only_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDAPI_KEY", "   ")
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    assert resolve_rapidapi_key("RAPIDAPI_KEY", "JOBS_API14_KEY") == "legacy-1234"
+
+
+def test_argument_order_defines_priority(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    # Reversed order: dedicated first should win
+    assert resolve_rapidapi_key("JOBS_API14_KEY", "RAPIDAPI_KEY") == "legacy-1234"

--- a/tests/test_fetchers_legacy_key_resolution.py
+++ b/tests/test_fetchers_legacy_key_resolution.py
@@ -1,0 +1,61 @@
+"""Tests that legacy fetcher paths in fetchers/__init__.py route through the
+shared RapidAPI key resolver (#414)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from findajob.fetchers import fetch_linkedin_job_data
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("RAPIDAPI_KEY", "JOBS_API14_KEY", "JSEARCH_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_fake_resp(description: str = "D", company_name: str = "C") -> MagicMock:
+    """Build a minimal fake requests.Response for the LinkedIn get endpoint."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.json.return_value = {"data": {"description": description, "companyName": company_name}}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_fetch_linkedin_job_data_returns_none_when_no_key() -> None:
+    """No key set under any name → returns sentinel without HTTP call."""
+    result = fetch_linkedin_job_data("12345")
+    assert result == {"description": None, "company": None}
+
+
+def test_fetch_linkedin_job_data_uses_canonical_rapidapi_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Canonical RAPIDAPI_KEY is honored (#414)."""
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    # fetch_linkedin_job_data does `import requests as req` inside the function;
+    # patching `requests.get` at the module level intercepts req.get calls.
+    with patch("requests.get", return_value=_make_fake_resp()) as mock_get, patch("findajob.fetchers.time.sleep"):
+        result = fetch_linkedin_job_data("12345")
+    assert result == {"description": "D", "company": "C"}
+    assert mock_get.call_args.kwargs["headers"]["x-rapidapi-key"] == "shared-1234"
+
+
+def test_fetch_linkedin_job_data_falls_back_to_jobs_api14_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy JOBS_API14_KEY-only stacks continue to work (#414 fallback)."""
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    with patch("requests.get", return_value=_make_fake_resp()) as mock_get, patch("findajob.fetchers.time.sleep"):
+        result = fetch_linkedin_job_data("12345")
+    assert result == {"description": "D", "company": "C"}
+    assert mock_get.call_args.kwargs["headers"]["x-rapidapi-key"] == "legacy-1234"
+
+
+def test_fetch_linkedin_job_data_canonical_wins_over_dedicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If both are set, canonical wins (matches adapter behavior)."""
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    with patch("requests.get", return_value=_make_fake_resp()) as mock_get, patch("findajob.fetchers.time.sleep"):
+        fetch_linkedin_job_data("12345")
+    assert mock_get.call_args.kwargs["headers"]["x-rapidapi-key"] == "shared-1234"

--- a/tests/test_jobs_api14_adapter.py
+++ b/tests/test_jobs_api14_adapter.py
@@ -32,10 +32,18 @@ def test_is_configured_true_when_env_set(monkeypatch: pytest.MonkeyPatch) -> Non
     assert JobsApi14Adapter().is_configured() is True
 
 
-def test_is_configured_does_not_fall_back_to_rapidapi_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """No production-code fallback. Migration handles RAPIDAPI_KEY at entrypoint."""
-    monkeypatch.setenv("RAPIDAPI_KEY", "old-key-1234")
-    assert JobsApi14Adapter().is_configured() is False
+def test_is_configured_falls_back_to_rapidapi_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shared RAPIDAPI_KEY backs JobsApi14Adapter when JOBS_API14_KEY is unset (#414)."""
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    assert JobsApi14Adapter().is_configured() is True
+
+
+def test_is_configured_canonical_wins_over_dedicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RAPIDAPI_KEY is canonical; when both are set, canonical wins (#414)."""
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    # Both adapters use canonical-first lookup; canonical wins
+    assert JobsApi14Adapter().is_configured() is True
 
 
 def test_fetch_returns_empty_when_unconfigured() -> None:

--- a/tests/test_jobs_api14_adapter.py
+++ b/tests/test_jobs_api14_adapter.py
@@ -20,7 +20,7 @@ def test_class_attributes() -> None:
     assert adapter.name == "jobs-api14"
     assert adapter.display_name == "Jobs API (jobs-api14)"
     assert adapter.source_label == "jobsapi_linkedin"  # preserves existing DB rows
-    assert adapter.required_env_vars == ("JOBS_API14_KEY",)
+    assert adapter.required_env_vars == ("RAPIDAPI_KEY", "JOBS_API14_KEY")
 
 
 def test_is_configured_false_when_env_unset() -> None:

--- a/tests/test_jobs_api14_indeed_adapter.py
+++ b/tests/test_jobs_api14_indeed_adapter.py
@@ -1,0 +1,202 @@
+"""Tests for JobsApi14IndeedAdapter — restored Indeed coverage (#414)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from findajob.fetchers.adapters.jobs_api14_indeed import JobsApi14IndeedAdapter
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("RAPIDAPI_KEY", "JOBS_API14_KEY", "JSEARCH_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_class_attributes() -> None:
+    adapter = JobsApi14IndeedAdapter()
+    assert adapter.name == "jobs-api14-indeed"
+    assert adapter.display_name == "Jobs API — Indeed (jobs-api14)"
+    assert adapter.source_label == "jobsapi_indeed"  # matches retired-but-not-purged DB rows
+    assert adapter.required_env_vars == ("RAPIDAPI_KEY", "JOBS_API14_KEY")
+
+
+def test_is_configured_with_canonical_rapidapi_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    assert JobsApi14IndeedAdapter().is_configured() is True
+
+
+def test_is_configured_with_dedicated_jobs_api14_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "legacy-1234")
+    assert JobsApi14IndeedAdapter().is_configured() is True
+
+
+def test_is_configured_false_when_unset() -> None:
+    assert JobsApi14IndeedAdapter().is_configured() is False
+
+
+def test_fetch_returns_empty_when_unconfigured() -> None:
+    assert JobsApi14IndeedAdapter().fetch(["data center engineer"]) == []
+
+
+def test_fetch_hits_indeed_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"hasError": False, "data": []}
+    fake_response.raise_for_status.return_value = None
+
+    with patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", return_value=fake_response) as mock_get:
+        JobsApi14IndeedAdapter().fetch(["data center engineer"])
+
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://jobs-api14.p.rapidapi.com/v2/indeed/search"
+    assert kwargs["headers"]["x-rapidapi-host"] == "jobs-api14.p.rapidapi.com"
+    assert kwargs["headers"]["x-rapidapi-key"] == "test-key"
+    assert kwargs["params"]["query"] == "data center engineer"
+    assert kwargs["params"]["sortType"] == "date"
+    assert kwargs["params"]["countryCode"] == "us"
+    assert kwargs["params"]["location"] == "United States"
+
+
+def test_fetch_parses_indeed_response_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.raise_for_status.return_value = None
+    fake_response.json.return_value = {
+        "hasError": False,
+        "data": [
+            {
+                "id": "abc123",
+                "title": "Data Center Engineer",
+                "company": {"name": "Acme Corp", "addresses": [], "image": ""},
+                "location": {"country": "United States", "countryCode": "US", "location": "Reston, VA"},
+                "applyUrl": "https://example.com/apply/abc123",
+                "description": "Job description body...",
+            },
+        ],
+        "meta": {"count": 1, "nextToken": "tok456", "position": 0},
+    }
+
+    with patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", return_value=fake_response):
+        rows = JobsApi14IndeedAdapter().fetch(["data center"])
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["title"] == "Data Center Engineer"
+    assert row["company"] == "Acme Corp"
+    assert row["location"] == "Reston, VA"
+    assert row["url"] == "https://example.com/apply/abc123"
+    assert row["api_id"] == "abc123"
+    assert row["source"] == "jobsapi_indeed"
+    assert row["query"] == "data center"
+    assert row["description"] == "Job description body..."  # inline JD
+
+
+def test_fetch_drops_rows_with_no_title_or_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.raise_for_status.return_value = None
+    fake_response.json.return_value = {
+        "hasError": False,
+        "data": [
+            {"id": "x", "title": "", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u", "description": "d"},
+            {"id": "y", "title": "Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "", "description": "d"},
+            {"id": "z", "title": "Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u", "description": "d"},
+        ],
+        "meta": {"count": 3},
+    }
+
+    with patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", return_value=fake_response):
+        rows = JobsApi14IndeedAdapter().fetch(["q"])
+
+    # Only the third row should survive (has both title and url)
+    assert len(rows) == 1
+    assert rows[0]["api_id"] == "z"
+
+
+def test_fetch_post_filter_drops_titles_outside_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.raise_for_status.return_value = None
+    fake_response.json.return_value = {
+        "hasError": False,
+        "data": [
+            {"id": "1", "title": "Cashier", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u1", "description": "d"},
+            {"id": "2", "title": "Senior Data Center Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u2", "description": "d"},
+            {"id": "3", "title": "Operations Manager", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u3", "description": "d"},
+            {"id": "4", "title": "Bartender", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u4", "description": "d"},
+        ],
+        "meta": {"count": 4},
+    }
+
+    with patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", return_value=fake_response):
+        rows = JobsApi14IndeedAdapter().fetch(["q"])
+
+    titles = [r["title"] for r in rows]
+    assert "Senior Data Center Engineer" in titles
+    assert "Operations Manager" in titles
+    assert "Cashier" not in titles
+    assert "Bartender" not in titles
+
+
+def test_fetch_handles_429_with_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    rate_limited = MagicMock(status_code=429, headers={"Retry-After": "1"})
+    rate_limited.json.return_value = {"hasError": False, "data": []}
+    success = MagicMock(status_code=200, headers={})
+    success.json.return_value = {"hasError": False, "data": []}
+    success.raise_for_status.return_value = None
+
+    with (
+        patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", side_effect=[rate_limited, success]) as mock_get,
+        patch("findajob.fetchers.adapters.jobs_api14_indeed.time.sleep") as mock_sleep,
+    ):
+        JobsApi14IndeedAdapter().fetch(["engineer"])
+
+    assert mock_get.call_count == 2
+    assert mock_sleep.called
+
+
+def test_fetch_handles_haserror_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.raise_for_status.return_value = None
+    fake_response.json.return_value = {"hasError": True, "errors": [{"message": "boom"}], "data": []}
+
+    with patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", return_value=fake_response):
+        rows = JobsApi14IndeedAdapter().fetch(["engineer"])
+
+    assert rows == []
+
+
+def test_live_test_auth_failure_with_no_key() -> None:
+    result = JobsApi14IndeedAdapter().live_test(["engineer"])
+    assert result.ok is False
+    assert result.bucket == "auth"
+
+
+def test_live_test_success_returns_per_query_counts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {
+        "hasError": False,
+        "data": [
+            {"id": "1", "title": "Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u", "description": "d"},
+        ],
+    }
+
+    with patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", return_value=fake_response):
+        result = JobsApi14IndeedAdapter().live_test(["engineer"])
+
+    assert result.ok is True
+    assert result.bucket == "success"
+    assert len(result.per_query) == 1
+    assert result.per_query[0].count == 1

--- a/tests/test_jobs_api14_indeed_adapter.py
+++ b/tests/test_jobs_api14_indeed_adapter.py
@@ -104,9 +104,30 @@ def test_fetch_drops_rows_with_no_title_or_url(monkeypatch: pytest.MonkeyPatch) 
     fake_response.json.return_value = {
         "hasError": False,
         "data": [
-            {"id": "x", "title": "", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u", "description": "d"},
-            {"id": "y", "title": "Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "", "description": "d"},
-            {"id": "z", "title": "Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u", "description": "d"},
+            {
+                "id": "x",
+                "title": "",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "u",
+                "description": "d",
+            },
+            {
+                "id": "y",
+                "title": "Engineer",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "",
+                "description": "d",
+            },
+            {
+                "id": "z",
+                "title": "Engineer",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "u",
+                "description": "d",
+            },
         ],
         "meta": {"count": 3},
     }
@@ -127,10 +148,38 @@ def test_fetch_post_filter_drops_titles_outside_allowlist(monkeypatch: pytest.Mo
     fake_response.json.return_value = {
         "hasError": False,
         "data": [
-            {"id": "1", "title": "Cashier", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u1", "description": "d"},
-            {"id": "2", "title": "Senior Data Center Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u2", "description": "d"},
-            {"id": "3", "title": "Operations Manager", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u3", "description": "d"},
-            {"id": "4", "title": "Bartender", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u4", "description": "d"},
+            {
+                "id": "1",
+                "title": "Cashier",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "u1",
+                "description": "d",
+            },
+            {
+                "id": "2",
+                "title": "Senior Data Center Engineer",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "u2",
+                "description": "d",
+            },
+            {
+                "id": "3",
+                "title": "Operations Manager",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "u3",
+                "description": "d",
+            },
+            {
+                "id": "4",
+                "title": "Bartender",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "u4",
+                "description": "d",
+            },
         ],
         "meta": {"count": 4},
     }
@@ -153,9 +202,10 @@ def test_fetch_handles_429_with_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     success.json.return_value = {"hasError": False, "data": []}
     success.raise_for_status.return_value = None
 
+    _mod = "findajob.fetchers.adapters.jobs_api14_indeed"
     with (
-        patch("findajob.fetchers.adapters.jobs_api14_indeed.requests.get", side_effect=[rate_limited, success]) as mock_get,
-        patch("findajob.fetchers.adapters.jobs_api14_indeed.time.sleep") as mock_sleep,
+        patch(f"{_mod}.requests.get", side_effect=[rate_limited, success]) as mock_get,
+        patch(f"{_mod}.time.sleep") as mock_sleep,
     ):
         JobsApi14IndeedAdapter().fetch(["engineer"])
 
@@ -189,7 +239,14 @@ def test_live_test_success_returns_per_query_counts(monkeypatch: pytest.MonkeyPa
     fake_response.json.return_value = {
         "hasError": False,
         "data": [
-            {"id": "1", "title": "Engineer", "company": {"name": "A"}, "location": {"location": "X"}, "applyUrl": "u", "description": "d"},
+            {
+                "id": "1",
+                "title": "Engineer",
+                "company": {"name": "A"},
+                "location": {"location": "X"},
+                "applyUrl": "u",
+                "description": "d",
+            },
         ],
     }
 

--- a/tests/test_jsearch_adapter.py
+++ b/tests/test_jsearch_adapter.py
@@ -13,6 +13,7 @@ from findajob.fetchers.adapters.jsearch import JSearchAdapter
 @pytest.fixture(autouse=True)
 def _scrub_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("JSEARCH_API_KEY", raising=False)
+    monkeypatch.delenv("RAPIDAPI_KEY", raising=False)
 
 
 def test_class_attributes() -> None:
@@ -20,7 +21,7 @@ def test_class_attributes() -> None:
     assert adapter.name == "jsearch"
     assert adapter.display_name == "JSearch"
     assert adapter.source_label == "jsearch"
-    assert adapter.required_env_vars == ("JSEARCH_API_KEY",)
+    assert adapter.required_env_vars == ("RAPIDAPI_KEY", "JSEARCH_API_KEY")
 
 
 def test_is_configured(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -214,3 +215,17 @@ def test_fetch_paces_between_queries(monkeypatch: pytest.MonkeyPatch) -> None:
 
     sleep_calls = [c.args for c in mock_sleep.call_args_list]
     assert (0.6,) in sleep_calls or any(c[0] == 0.6 for c in sleep_calls)
+
+
+def test_is_configured_falls_back_to_rapidapi_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shared RAPIDAPI_KEY backs JSearchAdapter when JSEARCH_API_KEY is unset (#414)."""
+    monkeypatch.delenv("JSEARCH_API_KEY", raising=False)
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    assert JSearchAdapter().is_configured() is True
+
+
+def test_is_configured_canonical_wins_over_dedicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RAPIDAPI_KEY is canonical; if both set, RAPIDAPI_KEY wins (#414)."""
+    monkeypatch.setenv("RAPIDAPI_KEY", "shared-1234")
+    monkeypatch.setenv("JSEARCH_API_KEY", "legacy-1234")
+    assert JSearchAdapter().is_configured() is True


### PR DESCRIPTION
## Summary

- Adds shared `RAPIDAPI_KEY` env var as the canonical RapidAPI credential. Both `JobsApi14Adapter` and `JSearchAdapter` now read it first, falling back to legacy `JOBS_API14_KEY` / `JSEARCH_API_KEY` for existing stacks. Reflects the reality that RapidAPI uses one account-level key per user, not per-API.
- Restores `JobsApi14IndeedAdapter` (`source_label='jobsapi_indeed'`, preserving DB row continuity) — Indeed coverage via jobs-api14 `/v2/indeed/search`. Tuned with `sortType=date` + adapter-side title-allowlist regex to compensate for the missing recency/level/type filters that drove the original retirement.

Closes part of #414. Multi-page knobs and JSearch billing-probe follow in subsequent PRs.

## Test plan

- [x] `uv run pytest tests/ -q` — full suite passes (1702 passed, 2 skipped)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — clean (77 files)
- [x] End-to-end registry smoke: with `RAPIDAPI_KEY` set + `active_sources.txt` listing `jobs-api14-indeed` + `jsearch`, `iter_configured_adapters()` yields both
- [ ] Existing tester stacks (alice, papa, dave, judy, tango) — no behavior change required, since `JOBS_API14_KEY` fallback covers them
- [ ] After merge + deploy on operator's stack: write \`config/active_sources.txt\` with \`jobs-api14\`, \`jobs-api14-indeed\`, \`jsearch\`; set \`RAPIDAPI_KEY\` from existing \`JOBS_API14_KEY\` value via \`sudo sed -i\`; restart stack; confirm \`pipeline.jsonl\` shows \`jobsapi_indeed_fetched\` and \`jsearch_fetched\` events on next triage run

## Migration required

- Existing stacks' legacy env vars keep working — no required action to maintain current behavior
- To use new canonical \`RAPIDAPI_KEY\`, copy legacy value into \`RAPIDAPI_KEY=\` line in \`data/.env\`
- To enable Indeed: add \`jobs-api14-indeed\` line to \`config/active_sources.txt\`, restart stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)