### PR TITLE
feat(adapters): #417 lift JobsApi14IndeedAdapter title allowlist to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 - `JOBS_API14_MAX_PAGES` env var — optional per-stack pagination ceiling for `JobsApi14Adapter` (LinkedIn endpoint). Default 1 (unchanged behavior). Loops over `meta.nextToken` up to N pages per query. Each additional page is one billed RapidAPI request (per-call billing — empirically confirmed on operator stack). PRO-tier operators (jobs-api14 PRO = 20k/mo) can safely set 3–5 for additive yield (2.25–3.75% of quota). Clamped to `[1, 20]`. `live_test()` stays single-page regardless of this setting (#414 PR2)
 - `JSEARCH_NUM_PAGES` env var — optional per-stack pagination width for `JSearchAdapter`. Default 1 (unchanged behavior). Sets the `num_pages` API param so JSearch handles pagination server-side (single HTTP request per query, billed as N units). Empirically: N=3 returns ~27 jobs vs ~10 (~2.7x yield). PRO-tier operators (JSearch = 10k/mo) can safely set 3 (4.5% of quota). Clamped to `[1, 10]` (half of jobs-api14's ceiling because JSearch's PRO quota is half). `live_test()` stays at num_pages=1 regardless (#414 PR3)
 
+### Changed
+- `JobsApi14IndeedAdapter` title allowlist lifted from a hardcoded engineering-tuned regex (`_TITLE_ALLOW_PATTERN`) to the optional `indeed_title_allow:` key in `config/prefilter_rules.yaml`. Missing/empty key = no post-filter (allow-all). Field-specific example blocks for engineering, healthcare, social-work, and education candidates included in `prefilter_rules.yaml.example`. Restores domain-neutrality of the pipeline per CLAUDE.md "PII / Domain-Neutrality — HARD RULES" (#417)
+
 ### Removed
 - `findajob.onboarding.env_migrate.migrate_rapidapi_key_env()` and its startup invocation in `findajob.web.app`. The v0.14 helper renamed `RAPIDAPI_KEY` → `JOBS_API14_KEY` on every container boot, which became the inverse of #414's canonical-name direction. Adapter + legacy-fetcher fallback (introduced alongside #414) covers the same compatibility surface without rewriting `data/.env` (#416)
 
@@ -25,6 +28,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 - **To enable the new Indeed adapter:** add `jobs-api14-indeed` as a new line in `config/active_sources.txt` and restart the stack. No new credentials needed (shares jobs-api14's account).
 - **To opt into multi-page LinkedIn fetching:** add `JOBS_API14_MAX_PAGES=3` (or up to 5) to `data/.env` and restart the stack. PRO-tier operators only; BASIC stays at default 1 to avoid quota burn. No action required for default behavior.
 - **To opt into JSearch multi-page fetching:** add `JSEARCH_NUM_PAGES=3` to `data/.env` and restart the stack. PRO-tier operators only; BASIC stays at default 1 to avoid quota burn. No action required for default behavior.
+- **`JobsApi14IndeedAdapter` allowlist lift (#417):** if your stack runs the Indeed adapter (`jobs-api14-indeed` in `config/active_sources.txt`), the engineering-tuned hardcoded title allowlist is gone. Without configuration, the adapter now allows ALL Indeed titles through (89% noise for engineering candidates per pre-#414 measurement). To preserve operator's pre-#417 behavior, add the engineering-default `indeed_title_allow:` block from `config/prefilter_rules.yaml.example` to your `config/prefilter_rules.yaml`. For non-engineering candidates, replace the engineering block with the field-specific example provided. Stacks not running the Indeed adapter are unaffected.
 
 ## [0.14.0] — 2026-05-02
 

--- a/config/prefilter_rules.yaml.example
+++ b/config/prefilter_rules.yaml.example
@@ -55,3 +55,65 @@ hard_rejects:
 # context_suppressors:
 #   - '\bdata\s*center\b'
 #   - '\bdatacenter\b'
+
+# ── JobsApi14IndeedAdapter title allowlist (#417) ────────────────────────────
+# OPTIONAL. Inclusion regexes — only Indeed titles matching at least one of
+# these are stored. The adapter applies this AFTER the API fetch, since
+# jobs-api14's Indeed endpoint exposes no recency / level / employment-type
+# filters and otherwise returns ~89% off-target rows.
+#
+# Missing key OR empty list = no allowlist → all titles pass through to LLM
+# scoring (with the warning surfaced via _safe_load_yaml). Configure the
+# patterns for your role family for best Indeed signal-to-noise.
+#
+# Each entry is a Python regex; case-insensitive matching is applied.
+# Use \b word boundaries to avoid accidental substring matches.
+#
+# Engineering / data center / NPI / hardware default (operator's stack):
+#
+# indeed_title_allow:
+#   - '\bengineer\b'
+#   - '\bmanager\b'
+#   - '\bdirector\b'
+#   - '\blead\b'
+#   - '\barchitect\b'
+#   - '\banalyst\b'
+#   - '\bprogram\b'
+#   - '\boperations\b'
+#   - '\binfrastructure\b'
+#   - '\bdata\s*center\b'
+#   - '\bhardware\b'
+#   - '\bnpi\b'
+#   - '\btechnician\b'
+#   - '\bspecialist\b'
+#   - '\bcoordinator\b'
+#   - '\bsupervisor\b'
+#   - '\badministrator\b'
+#
+# Healthcare / nursing candidate:
+#
+# indeed_title_allow:
+#   - '\bnurs(e|ing)\b'
+#   - '\b(rn|lpn|bsn|np)\b'
+#   - '\bclinical\b'
+#   - '\bpatient\s+care\b'
+#   - '\bhealthcare\b'
+#
+# Social work / human services candidate:
+#
+# indeed_title_allow:
+#   - '\bsocial\s+work(er)?\b'
+#   - '\bcase\s+(manager|worker)\b'
+#   - '\bcommunity\s+outreach\b'
+#   - '\bhomeless(ness)?\b'
+#   - '\bhuman\s+services\b'
+#
+# Education / teaching candidate:
+#
+# indeed_title_allow:
+#   - '\bteacher\b'
+#   - '\binstructor\b'
+#   - '\bprincipal\b'
+#   - '\beducation\b'
+#   - '\bcurriculum\b'
+#   - '\bschool\b'

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -32,6 +32,8 @@ _NEVER_MATCH = re.compile(r"(?!x)x")
 _hard_reject_cache: tuple[re.Pattern[str], re.Pattern[str] | None] | None = None
 _in_domain_cache: tuple[re.Pattern[str], re.Pattern[str] | None] | None = None
 _companies_cache: frozenset[str] | None = None
+_indeed_title_allow_cache: re.Pattern[str] | None = None
+_indeed_title_allow_loaded: bool = False  # distinguishes "cached None" from "not yet loaded"
 
 # Warnings emitted (dedup per process)
 _warned: set[str] = set()
@@ -173,12 +175,58 @@ def _warn_once(msg: str) -> None:
     warnings.warn(msg, UserWarning, stacklevel=3)
 
 
+def load_indeed_title_allow_rules() -> re.Pattern[str] | None:
+    """Compiled inclusion regex for JobsApi14IndeedAdapter, or None if unconfigured.
+
+    Reads the optional `indeed_title_allow` top-level key in
+    `config/prefilter_rules.yaml`. Returns:
+
+    - `None` if the file is missing, the key is absent, or the list is empty.
+      The adapter treats `None` as "allow all titles" (no post-filter).
+    - A compiled case-insensitive alternation regex when one or more patterns
+      are configured.
+
+    Raises ConfigError on shape errors (non-list, non-string entries, invalid
+    regex). #417 lifted this from a hardcoded engineering-tuned regex in
+    `JobsApi14IndeedAdapter` so non-engineering testers can configure their
+    own allowlist via the `/config/` editor or onboarding picker.
+    """
+    global _indeed_title_allow_cache, _indeed_title_allow_loaded
+    if _indeed_title_allow_loaded:
+        return _indeed_title_allow_cache
+
+    data = _safe_load_yaml(_RULES_PATH, "prefilter_rules.yaml")
+    if data is None:
+        _indeed_title_allow_cache = None
+        _indeed_title_allow_loaded = True
+        return None
+
+    patterns = data.get("indeed_title_allow", []) or []
+    if not isinstance(patterns, list):
+        raise ConfigError(f"prefilter_rules.yaml: 'indeed_title_allow' must be a list, got {type(patterns).__name__}")
+    for p in patterns:
+        if not isinstance(p, str):
+            raise ConfigError(f"prefilter_rules.yaml: indeed_title_allow pattern is not a string: {p!r}")
+
+    if not patterns:
+        _indeed_title_allow_cache = None
+        _indeed_title_allow_loaded = True
+        return None
+
+    _indeed_title_allow_cache = _compile_patterns(patterns, _RULES_PATH, "indeed_title_allow")
+    _indeed_title_allow_loaded = True
+    return _indeed_title_allow_cache
+
+
 def _reset_cache() -> None:
     """Test-only. Clears module-level caches and warning dedup."""
     global _hard_reject_cache, _in_domain_cache, _companies_cache
+    global _indeed_title_allow_cache, _indeed_title_allow_loaded
     _hard_reject_cache = None
     _in_domain_cache = None
     _companies_cache = None
+    _indeed_title_allow_cache = None
+    _indeed_title_allow_loaded = False
     _warned.clear()
 
 

--- a/src/findajob/fetchers/adapters/jobs_api14_indeed.py
+++ b/src/findajob/fetchers/adapters/jobs_api14_indeed.py
@@ -7,6 +7,8 @@ filters (unlike LinkedIn), so the legacy fetcher (retired pre-#408) returned
 1. sortType=date — most-recent first, daily triage captures fresh jobs.
 2. countryCode=us + location="United States" — geo-narrow.
 3. Adapter-side title regex post-filter — inclusion allowlist before storing.
+   Configured per-stack via `indeed_title_allow:` in
+   `config/prefilter_rules.yaml` (#417). Missing/empty key = no post-filter.
 
 Per-page count is 20 (vs LinkedIn's 10). Description is inline in the
 search response, so no separate /v2/linkedin/get-equivalent call needed.
@@ -18,35 +20,19 @@ RapidAPI account.
 
 from __future__ import annotations
 
-import re
 import time
 from typing import ClassVar
 
 import requests
 
 from findajob.cleaning import clean_company, clean_title
+from findajob.config_loader import load_indeed_title_allow_rules
 from findajob.utils import log_event
 
 from ._keys import resolve_rapidapi_key
 from .base import LiveTestResult, QueryResult
 
 __all__ = ("JobsApi14IndeedAdapter",)
-
-
-# Title-allowlist regex — case-insensitive. Tuned for ops / infrastructure /
-# program-mgmt / NPI / hardware / data-center title families. Tighter than
-# scorer_prefilter Stage 1's REJECT pattern; this is INCLUSION, applied
-# pre-storage to compensate for Indeed's missing server-side filters.
-# Hardcoded here in PR1 (#414); a follow-up issue will lift this to a config file
-# once the right shape is clear from real ingest data.
-_TITLE_ALLOW_PATTERN: re.Pattern[str] = re.compile(
-    r"\b("
-    r"engineer|manager|director|lead|architect|analyst|program|"
-    r"operations|infrastructure|data\s*center|hardware|npi|"
-    r"technician|specialist|coordinator|supervisor|administrator"
-    r")\b",
-    re.IGNORECASE,
-)
 
 
 class JobsApi14IndeedAdapter:
@@ -210,14 +196,16 @@ class JobsApi14IndeedAdapter:
             return None
 
     def _parse_rows(self, data: dict, query: str) -> list[dict]:
+        allow_pattern = load_indeed_title_allow_rules()
         rows: list[dict] = []
         for job in data.get("data", []) or []:
             raw_title = job.get("title", "")
             title = clean_title(raw_title)
             if not title:
                 continue
-            # Inclusion post-filter — drop titles outside the allowlist
-            if not _TITLE_ALLOW_PATTERN.search(title):
+            # Inclusion post-filter — drop titles outside the allowlist.
+            # Missing/empty config = allow-all (no filter applied).
+            if allow_pattern is not None and not allow_pattern.search(title):
                 continue
 
             url = job.get("applyUrl", "")

--- a/tests/fixtures/config/prefilter_rules.yaml
+++ b/tests/fixtures/config/prefilter_rules.yaml
@@ -98,3 +98,12 @@ context_suppressors:
   - '\bdata\s*center\b'
   - '\bdatacenter\b'
   - '\bdc\s+(ops|operations|site)\b'
+
+# JobsApi14IndeedAdapter title allowlist (#417). Inclusion regexes — only
+# titles matching at least one of these are stored. Missing key = allow-all.
+indeed_title_allow:
+  - '\bengineer\b'
+  - '\bmanager\b'
+  - '\bdirector\b'
+  - '\boperations\b'
+  - '\bdata\s*center\b'

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -194,3 +194,69 @@ class TestMalformedFiles:
         config_loader._reset_cache()
         with pytest.raises(ConfigError, match="'positive' must be a list"):
             config_loader.load_in_domain_rules()
+
+
+class TestLoadIndeedTitleAllowRules:
+    """#417 — JobsApi14IndeedAdapter title allowlist lifted from hardcode to config."""
+
+    def test_returns_pattern_when_configured(self):
+        # Fixture provides indeed_title_allow with engineering patterns
+        pattern = config_loader.load_indeed_title_allow_rules()
+        assert pattern is not None
+        assert pattern.search("Senior Data Center Engineer") is not None
+        assert pattern.search("Operations Manager") is not None
+
+    def test_pattern_does_not_match_unrelated_titles(self):
+        pattern = config_loader.load_indeed_title_allow_rules()
+        assert pattern is not None
+        assert pattern.search("Cashier") is None
+        assert pattern.search("Bartender") is None
+
+    def test_returns_none_when_key_missing(self, monkeypatch, tmp_path):
+        # File exists but has no indeed_title_allow key → None (allow-all semantic)
+        rules = tmp_path / "prefilter_rules.yaml"
+        rules.write_text("hard_rejects:\n  spam:\n    - 'foo'\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", rules)
+        config_loader._reset_cache()
+        assert config_loader.load_indeed_title_allow_rules() is None
+
+    def test_returns_none_when_file_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_RULES_PATH", tmp_path / "missing.yaml")
+        config_loader._reset_cache()
+        assert config_loader.load_indeed_title_allow_rules() is None
+
+    def test_empty_list_returns_none(self, monkeypatch, tmp_path):
+        rules = tmp_path / "prefilter_rules.yaml"
+        rules.write_text("indeed_title_allow: []\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", rules)
+        config_loader._reset_cache()
+        assert config_loader.load_indeed_title_allow_rules() is None
+
+    def test_non_list_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("indeed_title_allow:\n  nested: value\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="'indeed_title_allow' must be a list"):
+            config_loader.load_indeed_title_allow_rules()
+
+    def test_non_string_pattern_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("indeed_title_allow:\n  - 42\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="indeed_title_allow pattern is not a string"):
+            config_loader.load_indeed_title_allow_rules()
+
+    def test_invalid_regex_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "prefilter_rules.yaml"
+        bad.write_text("indeed_title_allow:\n  - '(unclosed'\n")
+        monkeypatch.setattr(config_loader, "_RULES_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match=r"invalid regex.*\(unclosed"):
+            config_loader.load_indeed_title_allow_rules()
+
+    def test_caches_result(self):
+        p1 = config_loader.load_indeed_title_allow_rules()
+        p2 = config_loader.load_indeed_title_allow_rules()
+        assert p1 is p2  # cache hit


### PR DESCRIPTION
## Summary
- Removes hardcoded engineering-tuned `_TITLE_ALLOW_PATTERN` regex from `JobsApi14IndeedAdapter`. Adds optional `indeed_title_allow:` key to `config/prefilter_rules.yaml`, loaded via new `load_indeed_title_allow_rules() -> re.Pattern[str] | None` in `config_loader.py` (None = allow-all, no post-filter).
- Closes #417 — restores domain-neutrality per CLAUDE.md "PII / Domain-Neutrality — HARD RULES" so non-engineering testers (alice — social work, healthcare candidates, education candidates, etc.) can configure their own field-specific allowlist via the `/config/` web editor or onboarding picker without editing tracked code.
- `prefilter_rules.yaml.example` now ships engineering default + commented healthcare / social-work / education example blocks so candidates in any field have a clear copy-paste starting point.

## Behavior matrix
| Config state | Loader returns | Adapter behavior |
|---|---|---|
| File missing | `None` | No post-filter (allow all) |
| File present, key absent | `None` | No post-filter |
| File present, empty list | `None` | No post-filter |
| File present, populated list | Compiled regex | Inclusion filter applied |

## Migration required
Operators running `jobs-api14-indeed` (in `config/active_sources.txt`): must add the engineering-default `indeed_title_allow:` block from `prefilter_rules.yaml.example` to their `config/prefilter_rules.yaml` to preserve pre-#417 filter behavior. Without it, all Indeed titles pass through to LLM scoring (89% noise per pre-#414 measurement). Stacks not running the Indeed adapter are unaffected.

## Test plan
- [x] `uv run pytest -x -q`: 1728 passed, 1 skipped (+9 new tests in `TestLoadIndeedTitleAllowRules`)
- [x] `uv run ruff format --check .`: 231 files already formatted
- [x] `uv run ruff check .`: All checks passed
- [x] `uv run mypy src/`: no issues in 76 source files
- [x] Existing 5 adapter tests still pass — fixture extended with engineering patterns matching the prior hardcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)