### PR TITLE
fix(roles): #431 speculative_roles_synth model id 4-6 → 4.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ file. If you're refactoring an old hardcoded section, add a note to `docs/GENERA
 | `recruiter_critic` | `openrouter:anthropic/claude-opus-4.7`, `max_tokens: 1024` — sees company, title, JD, tailored resume, cover; NOT profile/briefing/fit |
 | `interview_prep` | `openrouter:anthropic/claude-opus-4.7`, `max_tokens: 4096` — fires on `applied → interview` transition; expands briefing's interview-questions + stories sections. |
 | `candidate_led_briefing` | `openrouter:perplexity/sonar-deep-research` — async (1–5 min); drives the speculative briefing pass via `scripts/run_speculative_research.py`. |
-| `speculative_roles_synth` | `openrouter:anthropic/claude-sonnet-4-6`, `max_tokens: 4096` — synthesizes 1–5 candidate-tailored role cards from the briefing. |
+| `speculative_roles_synth` | `openrouter:anthropic/claude-sonnet-4.6`, `max_tokens: 4096` — synthesizes 1–5 candidate-tailored role cards from the briefing. |
 | Job ingestion | Pluggable via `JobSourceAdapter` (`src/findajob/fetchers/adapters/`); jobs-api14 + JSearch ship in v0.14; per-stack active list in `config/active_sources.txt`. Greenhouse / Ashby / Lever / Gmail still function-style — migration tracked in #410. v0.15 adds `JobsApi14IndeedAdapter` (Indeed via jobs-api14 with sortType=date + post-filter, restoring pre-#408 coverage) and consolidates RapidAPI credentials to a shared `RAPIDAPI_KEY` env var (legacy `JOBS_API14_KEY` / `JSEARCH_API_KEY` work as fallbacks) (#414). |
 | Package manager | `uv sync` for dev deps; `uv run` prefix for pytest/ruff/mypy/uvicorn |
 | Path resolution | `src/findajob/paths.py` — reads `config/paths.env`; BASE derived from `__file__` |

--- a/config/roles/speculative_roles_synth.md
+++ b/config/roles/speculative_roles_synth.md
@@ -1,5 +1,5 @@
 ---
-model: openrouter:anthropic/claude-sonnet-4-6
+model: openrouter:anthropic/claude-sonnet-4.6
 max_tokens: 4096
 temperature: 0.4
 ---


### PR DESCRIPTION
## Summary

`config/roles/speculative_roles_synth.md:2` declared `model: openrouter:anthropic/claude-sonnet-4-6`. `aichat-ng v0.31.0` strictly resolves model ids against `ops/aichat-ng/models-override.yaml`, which only contains `anthropic/claude-sonnet-4.6` (dot, not dash). The dash form has been silently 404'ing on every speculative-ingest invocation, leaving role-cards artifacts empty or missing.

## Diff

- `config/roles/speculative_roles_synth.md:2` — `claude-sonnet-4-6` → `claude-sonnet-4.6`
- `CLAUDE.md:94` — Pipeline Context Table cross-reference updated to match

Two characters changed; both files.

## Acceptance criteria

- [x] `config/roles/speculative_roles_synth.md` updated to `claude-sonnet-4.6`.
- [x] `CLAUDE.md` Pipeline Context Table updated.
- [ ] One end-to-end speculative ingest run on a real input verifies role-cards artifact is non-empty — **post-merge verification on docker.lan** (requires real input + OpenRouter spend; not feasible in PR CI).

## Test plan

- [x] 41 existing speculative-related pytest tests pass locally
- [x] ruff clean
- [ ] Post-merge: `docker compose pull` on operator's stack → submit a speculative request via `/ingest/` → confirm `companies/{Company}_SPECULATIVE_*/` folder gets a non-empty role-cards artifact.

## Out of scope

`src/findajob/onboarding/interview_runner.py:22` also uses the dash form (`anthropic/claude-sonnet-4-6`) but posts directly to OpenRouter's HTTP API. OpenRouter empirically tolerates dash-or-dot — testers (alice, papa, dave, judy, tango) have onboarded successfully on the dash form. Different resolver (HTTP API vs aichat-ng catalog), different tolerance. Out of scope for this fix; can be re-evaluated if onboarding ever exhibits unexplained model-resolution issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)