### PR TITLE
feat(generalization): #429 single source of truth for reject-reason taxonomy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ config/prefilter_rules.yaml
 config/in_domain_patterns.yaml
 config/companies_of_interest.txt
 config/excluded_employers.yaml
+config/reject_reasons.yaml
 .worktrees/
 
 # Gmail integration credentials and state (#330)

--- a/config/reject_reasons.yaml.example
+++ b/config/reject_reasons.yaml.example
@@ -1,0 +1,58 @@
+# reject_reasons.yaml — single source of truth for the reject-reason taxonomy.
+# Copy this file to reject_reasons.yaml and edit. The .yaml file is gitignored.
+#
+# SHAPE:
+#   reasons:                 (required; ordered list of reject-reason labels)
+#     - "<label>"
+#   title_signal_reasons:    (optional; subset of `reasons` that signal the
+#                             SCORER MISSED the title — used by
+#                             `scripts/analyze_feedback.py` to identify
+#                             prefilter candidates)
+#     - "<label>"
+#
+# WHO READS THIS:
+#   - `src/findajob/web/templates/board/_reject_cell.html` — dropdown options
+#   - `src/findajob/web/routes/stats.py` — canonical-order display in the stats page
+#   - `src/findajob/web/filters/registry.py` — dashboard filter chip values
+#   - `scripts/analyze_feedback.py` — subset that signals scorer-miss
+#
+# Missing file → field-agnostic defaults (defined in
+# `src/findajob/config_loader.py:_DEFAULT_REJECT_REASONS`). Loader returns
+# the same defaults for empty `reasons:` lists.
+
+reasons:
+  # The labels you want available when rejecting jobs. Keep them short — they
+  # appear in dropdowns, filter chips, and the stats page. Order matters
+  # (this is the dropdown order). The shipped defaults below are field-
+  # agnostic; tailor them to how YOU think about why a posting isn't right.
+  #
+  # Field examples (pick what fits — don't try to be exhaustive):
+  #   Software / Data / Hardware:
+  #     - "Skills Mismatch"   - "Too Senior"      - "Too Junior"
+  #     - "Wrong Domain"      - "Comp Too Low"    - "Stack Mismatch"
+  #   Healthcare / Social Work / Education:
+  #     - "Caseload Too High" - "Population Mismatch"
+  #     - "Credential Gap"    - "Pay Band Wrong"
+  #   Skilled Trades / Operations:
+  #     - "Shift Wrong"       - "Travel Too High" - "License Mismatch"
+  #
+  - "Skills Mismatch"
+  - "Geography"
+  - "Compensation"
+  - "Company Not a Fit"
+  - "Stale/Closed"
+  - "Already Applied"
+  - "Low Fit Score"
+  - "Other"
+
+title_signal_reasons:
+  # Subset of `reasons` (above) where the rejection cause was the TITLE
+  # itself — i.e. the scorer should have caught this posting before it ever
+  # reached the operator. `scripts/analyze_feedback.py` uses this to mine
+  # for new prefilter candidates: n-grams that recur in title-signal
+  # rejections but never in applied jobs.
+  #
+  # Reasons NOT in this list are excluded from prefilter analysis (e.g.
+  # "Already Applied" or "Stale/Closed" don't indicate a scorer miss).
+  - "Skills Mismatch"
+  - "Low Fit Score"

--- a/scripts/analyze_feedback.py
+++ b/scripts/analyze_feedback.py
@@ -24,6 +24,7 @@ import sys
 from collections import Counter
 from datetime import datetime
 
+from findajob.config_loader import load_reject_reasons
 from findajob.paths import BASE
 from findajob.utils import load_env
 
@@ -234,19 +235,9 @@ def _ngrams(tokens, n):
 # Reject reasons that indicate the TITLE was the problem (not user already
 # applied, not the posting going stale, etc). Only these feed the prefilter
 # candidate analysis — we're looking for patterns the scorer keeps missing.
-_TITLE_SIGNAL_REASONS = frozenset(
-    {
-        "Too Senior",
-        "Too Junior",
-        "Skills Mismatch",
-        "Too TPM-Heavy",
-        "Too Software/Systems",
-        "Too Facilities/MEP",
-        "Too Manufacturing/Test",
-        "Wrong Niche",
-        "Low Fit Score",
-    }
-)
+# Single source of truth: `config/reject_reasons.yaml` (`title_signal_reasons:`
+# subset of `reasons:`).
+_, _TITLE_SIGNAL_REASONS = load_reject_reasons()
 
 
 def _prefilter_candidates(rejected_rows, applied_rows, min_recurrences=3):

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -24,6 +24,22 @@ _RULES_PATH = Path(BASE) / "config" / "prefilter_rules.yaml"
 _IN_DOMAIN_PATH = Path(BASE) / "config" / "in_domain_patterns.yaml"
 _TARGET_COMPANIES_PATH = Path(BASE) / "config" / "target_companies.md"
 _EXCLUDED_EMPLOYERS_PATH = Path(BASE) / "config" / "excluded_employers.yaml"
+_REJECT_REASONS_PATH = Path(BASE) / "config" / "reject_reasons.yaml"
+
+# Field-agnostic fallback used when `config/reject_reasons.yaml` is missing or
+# `reasons:` is empty. Operator stacks override via the file (interview-emitted
+# in a follow-up to #429); fresh installs and tester stacks see this default.
+_DEFAULT_REJECT_REASONS: tuple[str, ...] = (
+    "Skills Mismatch",
+    "Geography",
+    "Compensation",
+    "Company Not a Fit",
+    "Stale/Closed",
+    "Already Applied",
+    "Low Fit Score",
+    "Other",
+)
+_DEFAULT_TITLE_SIGNAL_REASONS: frozenset[str] = frozenset({"Skills Mismatch", "Low Fit Score"})
 
 # Tier 1 parser — moved from findajob.onboarding.injector (#211).
 _TIER1_HEADING_RE = re.compile(r"^##\s+tier\s*1\b[^\n]*", re.IGNORECASE | re.MULTILINE)
@@ -42,6 +58,7 @@ _companies_cache: frozenset[str] | None = None
 _indeed_title_allow_cache: re.Pattern[str] | None = None
 _indeed_title_allow_loaded: bool = False  # distinguishes "cached None" from "not yet loaded"
 _excluded_employers_cache: tuple[frozenset[str], re.Pattern[str] | None] | None = None
+_reject_reasons_cache: tuple[tuple[str, ...], frozenset[str]] | None = None
 
 # Warnings emitted (dedup per process)
 _warned: set[str] = set()
@@ -295,17 +312,66 @@ def load_excluded_employers() -> tuple[frozenset[str], re.Pattern[str] | None]:
     return _excluded_employers_cache
 
 
+def load_reject_reasons() -> tuple[tuple[str, ...], frozenset[str]]:
+    """`(reasons, title_signal_reasons)` from `config/reject_reasons.yaml`.
+
+    `reasons` is the ordered tuple of reject-reason labels — powers the
+    dropdown in `_reject_cell.html`, the canonical-order display in
+    `routes/stats.py`, and the filter-chip values in `web/filters/registry.py`.
+    Single source of truth: same values everywhere fixes the silent-filtering
+    drift bug surfaced by the #301 audit (§2.1).
+
+    `title_signal_reasons` is the subset of `reasons` that signals the SCORER
+    MISSED the title — used by `scripts/analyze_feedback.py` to identify
+    prefilter candidates. Reasons not in this set are excluded from that
+    analysis. May be empty (analysis becomes a no-op).
+
+    Missing file or empty `reasons:` → returns the field-agnostic defaults
+    (`_DEFAULT_REJECT_REASONS` / `_DEFAULT_TITLE_SIGNAL_REASONS`). Malformed
+    entries raise `ConfigError`.
+    """
+    global _reject_reasons_cache
+    if _reject_reasons_cache is not None:
+        return _reject_reasons_cache
+
+    data = _safe_load_yaml(_REJECT_REASONS_PATH, "reject_reasons.yaml")
+    if data is None:
+        _reject_reasons_cache = (_DEFAULT_REJECT_REASONS, _DEFAULT_TITLE_SIGNAL_REASONS)
+        return _reject_reasons_cache
+
+    raw_reasons = data.get("reasons", [])
+    if not isinstance(raw_reasons, list):
+        raise ConfigError(f"reject_reasons.yaml: 'reasons' must be a list, got {type(raw_reasons).__name__}")
+    for r in raw_reasons:
+        if not isinstance(r, str):
+            raise ConfigError(f"reject_reasons.yaml: reasons entry is not a string: {r!r}")
+    if not raw_reasons:
+        _reject_reasons_cache = (_DEFAULT_REJECT_REASONS, _DEFAULT_TITLE_SIGNAL_REASONS)
+        return _reject_reasons_cache
+
+    raw_title = data.get("title_signal_reasons", []) or []
+    if not isinstance(raw_title, list):
+        raise ConfigError(f"reject_reasons.yaml: 'title_signal_reasons' must be a list, got {type(raw_title).__name__}")
+    for t in raw_title:
+        if not isinstance(t, str):
+            raise ConfigError(f"reject_reasons.yaml: title_signal_reasons entry is not a string: {t!r}")
+
+    _reject_reasons_cache = (tuple(raw_reasons), frozenset(raw_title))
+    return _reject_reasons_cache
+
+
 def _reset_cache() -> None:
     """Test-only. Clears module-level caches and warning dedup."""
     global _hard_reject_cache, _in_domain_cache, _companies_cache
     global _indeed_title_allow_cache, _indeed_title_allow_loaded
-    global _excluded_employers_cache
+    global _excluded_employers_cache, _reject_reasons_cache
     _hard_reject_cache = None
     _in_domain_cache = None
     _companies_cache = None
     _indeed_title_allow_cache = None
     _indeed_title_allow_loaded = False
     _excluded_employers_cache = None
+    _reject_reasons_cache = None
     _warned.clear()
 
 

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -43,6 +43,14 @@ def create_app(
     templates.env.globals["filter_qs_with"] = filter_qs_with
     templates.env.globals["operator_mode"] = os.environ.get("FINDAJOB_OPERATOR_MODE") == "1"
 
+    def _reject_reason_options() -> tuple[str, ...]:
+        from findajob.config_loader import load_reject_reasons
+
+        reasons, _title_signal = load_reject_reasons()
+        return reasons
+
+    templates.env.globals["reject_reason_options"] = _reject_reason_options
+
     # Helper exposed to base.html so the nav bar can render a lifetime
     # onboarding-cost badge on every page. Wrapped in a function (not a
     # static value) so each request reads fresh DB state without us having

--- a/src/findajob/web/filters/registry.py
+++ b/src/findajob/web/filters/registry.py
@@ -8,6 +8,7 @@ tab — see docs/superpowers/specs/2026-04-25-board-filter-framework-design.md
 
 from __future__ import annotations
 
+from findajob.config_loader import load_reject_reasons
 from findajob.web.filters.spec import ColumnSpec, Kind, validate_specs
 
 # Source / stage / remote_status / reject_reason vocabularies. Single source of
@@ -38,19 +39,9 @@ _STAGE_VALUES = (
     "withdrew",
 )
 _REMOTE_VALUES = ("Remote", "Hybrid", "On-site", "Unknown")
-_REJECT_REASON_VALUES = (
-    "Low Fit Score",
-    "Not Interested",
-    "Compensation",
-    "Location",
-    "Company Culture",
-    "Role Mismatch",
-    "Already Applied",
-    "Stage Too Early",
-    "Stage Too Late",
-    "Recruiter Outreach",
-    "Other",
-)
+# Filter chip values come from the same source as the dropdown — fixes the
+# silent-filtering drift bug surfaced by the #301 audit (§2.1).
+_REJECT_REASON_VALUES, _ = load_reject_reasons()
 
 # ─── Dashboard ────────────────────────────────────────────────────────────────
 DASHBOARD_COLUMNS: tuple[ColumnSpec, ...] = (

--- a/src/findajob/web/routes/stats.py
+++ b/src/findajob/web/routes/stats.py
@@ -24,6 +24,7 @@ from datetime import UTC, date, datetime, timedelta
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from findajob.config_loader import load_reject_reasons
 from findajob.web.routes.materials import get_db
 
 router = APIRouter()
@@ -45,22 +46,12 @@ ALL_STAGES: tuple[str, ...] = FUNNEL_STAGES + TERMINAL_STAGES
 
 _FUNNEL_WINDOW_DAYS = 30
 
-# Canonical reject reason options — mirrors the dropdown in
-# board/_reject_cell.html. Reasons seen in feedback_log but not listed here
-# render after the canonical set (legacy / free-text entries).
-REJECT_REASONS: tuple[str, ...] = (
-    "Too Senior",
-    "Too Junior",
-    "Skills Mismatch",
-    "Too TPM-Heavy",
-    "Geography/Onsite",
-    "Company Not a Fit",
-    "Comp Too Low",
-    "Low Fit Score",
-    "Stale/Closed",
-    "Already Applied",
-    "Other",
-)
+# Canonical reject reason options now come from `config/reject_reasons.yaml`
+# via `findajob.config_loader.load_reject_reasons()` — single source of truth
+# shared with the dropdown in `board/_reject_cell.html`, the filter chips in
+# `web/filters/registry.py`, and the prefilter analyzer in
+# `scripts/analyze_feedback.py`. Reasons seen in feedback_log but not in the
+# config render after the canonical set (legacy / free-text entries).
 
 _FEEDBACK_WINDOW_DAYS = 28
 _FEEDBACK_WEEK_DAYS = 7
@@ -192,12 +183,13 @@ def feedback(
     ).fetchall()
 
     # Merge canonical reasons with anything else found in the window; stable order.
+    canonical_reasons, _title_signal = load_reject_reasons()
     extras: list[str] = []
     for row in daily_rows:
         reason = row["reason"] if isinstance(row, sqlite3.Row) else row[1]
-        if reason and reason not in REJECT_REASONS and reason not in extras:
+        if reason and reason not in canonical_reasons and reason not in extras:
             extras.append(reason)
-    reasons: tuple[str, ...] = REJECT_REASONS + tuple(sorted(extras))
+    reasons: tuple[str, ...] = canonical_reasons + tuple(sorted(extras))
 
     daily = _build_reason_matrix(daily_rows, reasons, window_start, today)
     window_totals = {r: sum(daily[d][r] for d in daily) for r in reasons}

--- a/src/findajob/web/templates/board/_reject_cell.html
+++ b/src/findajob/web/templates/board/_reject_cell.html
@@ -27,17 +27,9 @@
       this.value='';
     }">
     <option value="">— No reason —</option>
-    <option value="Too Senior">Too Senior</option>
-    <option value="Too Junior">Too Junior</option>
-    <option value="Skills Mismatch">Skills Mismatch</option>
-    <option value="Too TPM-Heavy">Too TPM-Heavy</option>
-    <option value="Geography/Onsite">Geography/Onsite</option>
-    <option value="Company Not a Fit">Company Not a Fit</option>
-    <option value="Comp Too Low">Comp Too Low</option>
-    <option value="Low Fit Score">Low Fit Score</option>
-    <option value="Stale/Closed">Stale/Closed</option>
-    <option value="Already Applied">Already Applied</option>
-    <option value="Other">Other</option>
+    {% for reason in reject_reason_options() %}
+    <option value="{{ reason }}">{{ reason }}</option>
+    {% endfor %}
   </select>
   {% endif %}
 </td>

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -382,3 +382,79 @@ class TestLoadExcludedEmployers:
         p1 = config_loader.load_indeed_title_allow_rules()
         p2 = config_loader.load_indeed_title_allow_rules()
         assert p1 is p2  # cache hit
+
+
+class TestLoadRejectReasons:
+    """#429 — single source of truth for the reject-reason taxonomy."""
+
+    def test_returns_defaults_when_file_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", tmp_path / "missing.yaml")
+        config_loader._reset_cache()
+        reasons, title_signal = config_loader.load_reject_reasons()
+        assert reasons == config_loader._DEFAULT_REJECT_REASONS
+        assert title_signal == config_loader._DEFAULT_TITLE_SIGNAL_REASONS
+        # Defaults must be field-agnostic: no operator-domain tokens.
+        assert "Too TPM-Heavy" not in reasons
+        assert "Too Senior" not in reasons
+
+    def test_reads_configured_values(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        f.write_text(
+            'reasons:\n  - "Skills Gap"\n  - "Wrong Shift"\n  - "Other"\ntitle_signal_reasons:\n  - "Skills Gap"\n'
+        )
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        config_loader._reset_cache()
+        reasons, title_signal = config_loader.load_reject_reasons()
+        assert reasons == ("Skills Gap", "Wrong Shift", "Other")
+        assert title_signal == frozenset({"Skills Gap"})
+
+    def test_empty_reasons_returns_defaults(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        f.write_text("reasons: []\n")
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        config_loader._reset_cache()
+        reasons, title_signal = config_loader.load_reject_reasons()
+        assert reasons == config_loader._DEFAULT_REJECT_REASONS
+        assert title_signal == config_loader._DEFAULT_TITLE_SIGNAL_REASONS
+
+    def test_missing_title_signal_returns_empty_frozenset(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        f.write_text('reasons:\n  - "Skills Mismatch"\n')
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        config_loader._reset_cache()
+        reasons, title_signal = config_loader.load_reject_reasons()
+        assert reasons == ("Skills Mismatch",)
+        assert title_signal == frozenset()
+
+    def test_reasons_as_dict_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "reject_reasons.yaml"
+        bad.write_text("reasons:\n  nested: value\n")
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="'reasons' must be a list"):
+            config_loader.load_reject_reasons()
+
+    def test_title_signal_as_dict_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "reject_reasons.yaml"
+        bad.write_text('reasons:\n  - "x"\ntitle_signal_reasons:\n  nested: value\n')
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="'title_signal_reasons' must be a list"):
+            config_loader.load_reject_reasons()
+
+    def test_non_string_reason_raises(self, monkeypatch, tmp_path):
+        bad = tmp_path / "reject_reasons.yaml"
+        bad.write_text("reasons:\n  - 42\n")
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", bad)
+        config_loader._reset_cache()
+        with pytest.raises(ConfigError, match="reasons entry is not a string"):
+            config_loader.load_reject_reasons()
+
+    def test_caches_result(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        f.write_text('reasons:\n  - "x"\n')
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        config_loader._reset_cache()
+        r1 = config_loader.load_reject_reasons()
+        r2 = config_loader.load_reject_reasons()
+        assert r1 is r2  # cache hit

--- a/tests/test_web_stats_feedback.py
+++ b/tests/test_web_stats_feedback.py
@@ -24,7 +24,31 @@ def _ts(days_ago: int, hour: int = 12) -> str:
 
 
 @pytest.fixture
-def client(tmp_path: Path) -> TestClient:
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # Pin the canonical reject-reason taxonomy so legacy/extra ordering
+    # assertions remain stable. Mirrors what the operator's stack ships
+    # post-#429 migration; the loader's field-agnostic shipped default doesn't
+    # include "Too Senior" / "Comp Too Low" / etc.
+    from findajob import config_loader
+
+    reject_yaml = tmp_path / "reject_reasons.yaml"
+    reject_yaml.write_text(
+        "reasons:\n"
+        '  - "Too Senior"\n'
+        '  - "Too Junior"\n'
+        '  - "Skills Mismatch"\n'
+        '  - "Too TPM-Heavy"\n'
+        '  - "Geography/Onsite"\n'
+        '  - "Company Not a Fit"\n'
+        '  - "Comp Too Low"\n'
+        '  - "Low Fit Score"\n'
+        '  - "Stale/Closed"\n'
+        '  - "Already Applied"\n'
+        '  - "Other"\n'
+    )
+    monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", reject_yaml)
+    config_loader._reset_cache()
+
     db = tmp_path / "pipeline.db"
     conn = sqlite3.connect(db)
     # jobs + audit_log exist because get_db is shared with funnel; feedback_log


### PR DESCRIPTION
## Summary

Moves the reject-reason taxonomy out of four hardcoded tracked-code sites into one `config/reject_reasons.yaml` (gitignored; `.example` template ships with field-agnostic defaults). Fixes both the **vocabulary leak** and the **silent-filtering drift bug** surfaced by the #301 audit (§2.1).

**Drift bug:** `web/filters/registry.py:_REJECT_REASON_VALUES` had diverged into a generic taxonomy ("Not Interested", "Compensation", "Stage Too Early"...) that didn't match the dropdown options ("Too Senior", "Skills Mismatch", "Too TPM-Heavy"...). Filtering the Dashboard by `reject_reason` matched values that don't exist in the data; chips for actual rejections were missing. Both sites now read from one loader → consistent vocabulary everywhere.

**Vocabulary leak:** "Too TPM-Heavy" / "Too Software/Systems" etc. were operator-domain tokens visible to every tester. The shipped `.example` default is field-agnostic ("Skills Mismatch", "Geography", "Compensation", ...). Operator stacks override via the gitignored file.

## Files touched

- `config/reject_reasons.yaml.example` (NEW; tracked, generic default)
- `src/findajob/config_loader.py` — `load_reject_reasons()` + defaults
- `src/findajob/web/app.py` — Jinja global `reject_reason_options()`
- `src/findajob/web/templates/board/_reject_cell.html` — dropdown reads loader
- `src/findajob/web/routes/stats.py` — `REJECT_REASONS` removed → loader call
- `src/findajob/web/filters/registry.py` — chips read loader at module init
- `scripts/analyze_feedback.py` — `_TITLE_SIGNAL_REASONS` reads loader
- `.gitignore` — `config/reject_reasons.yaml`
- `tests/test_config_loader.py` — 8 new `TestLoadRejectReasons` cases
- `tests/test_web_stats_feedback.py` — fixture pins canonical taxonomy

## Migration required

The shipped `.example` default is field-agnostic. The operator's stack (`findajob-brock`) currently uses an operator-flavored dropdown ("Too Senior", "Too TPM-Heavy", "Comp Too Low" etc) — to preserve those at deploy time, write the operator's taxonomy into the gitignored file before pulling the new image:

\`\`\`bash
cat > /opt/stacks/findajob-brock/state/config/reject_reasons.yaml <<'YAML'
reasons:
  - "Too Senior"
  - "Too Junior"
  - "Skills Mismatch"
  - "Too TPM-Heavy"
  - "Geography/Onsite"
  - "Company Not a Fit"
  - "Comp Too Low"
  - "Low Fit Score"
  - "Stale/Closed"
  - "Already Applied"
  - "Other"
title_signal_reasons:
  - "Too Senior"
  - "Too Junior"
  - "Skills Mismatch"
  - "Too TPM-Heavy"
  - "Low Fit Score"
YAML
\`\`\`

Tester stacks (alice, papa, dave, judy, tango) — no migration needed; field-agnostic defaults are appropriate for their first weeks.

## Out of scope (split-outs)

- **Onboarding interviewer prompt update** — \`config/roles/onboarding_interviewer.md\` is 1224 lines; adding a new sub-phase + emission section deserves its own focused PR. Filed as a follow-up issue.
- **Migration script** — Operator-side migration above is a one-liner; a generic migration script was deferred since only one operator stack today has custom dropdown values.

## Test plan

- [x] 1723 tests pass (1 was tied to old hardcoded canonical list — fixed via fixture monkeypatch)
- [x] 8 new `TestLoadRejectReasons` cases cover defaults, configured values, empty list, missing title_signal, malformed shapes, caching
- [x] ruff check + format clean
- [x] mypy clean on all 4 touched source files
- [ ] Post-merge: write the operator's migration yaml on docker.lan + verify dropdown + filter chips render the operator's taxonomy

## Audit context

Full leak detail in \`docs/superpowers/specs/2026-05-03-301-data-model-audit.md\` §2.1 (operator-private spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)