### PR TITLE
fix(ci): #438 serialize build-image workflow per-ref to prevent :latest race

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,6 +11,14 @@ permissions:
   contents: read
   packages: write
 
+# Serialize per-ref so two pushes to the same branch / tag never race on
+# `:latest` (or `:pr-{N}`). Earlier runs finish; later runs queue rather than
+# clobber. Without this, two main merges in close succession can publish
+# `:latest` pointing at the second-to-finish push instead of HEAD (#438).
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a per-ref `concurrency:` group to `.github/workflows/build-image.yml` so two pushes to `main` (or two pushes to the same tag / PR branch) can never race on the `:latest` (or `:pr-{N}`) artifact.
- `cancel-in-progress: false` lets earlier runs finish — `:main-{sha}` artifacts remain published for both runs — but the `:latest` *write order* now matches *merge order* instead of *build-finish order*.
- Closes #438.

## Why
This bit during today's v0.16.0 deploy. PR #435 and PR #436 merged seconds apart; both `Build and push image` runs reported success, but `:latest` ended up pointing at PR #435's older digest because PR #436's larger build finished first and PR #435's faster build then overwrote it. Operator's stack pulled `:latest`, recreated the container, and was running PR #435's image — `ImportError` on `load_reject_reasons` because the missing symbol was only invoked at dropdown render time, so `/healthz` stayed green.

Workaround was a manual `docker tag …main-{sha} …:latest` on docker.lan. The fix prevents recurrence.

Keying the group on `${{ github.ref }}` (rather than a hardcoded `build-image-main`):
- Serializes per-PR pushes too (same race exists on `:pr-{N}` if a contributor amends and force-pushes during a build)
- Serializes tag pushes (also vulnerable — tags also publish `:latest`)
- Lets PR builds and main builds run in parallel (different refs → different groups)

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-image.yml'))"` parses cleanly
- [ ] PR's own workflow run succeeds (validates the YAML on the live runner; Concurrency annotation should appear on the run page)
- [ ] After merge, the next push to main shows the concurrency annotation
- [ ] Race repro is impractical (requires two near-simultaneous merges) — relying on the GH Actions concurrency contract being correct, which is well-documented