### PR TITLE
fix(entrypoint): #439 remove dangling refs to seed_companies_of_interest.py + env_migrate

### DIFF
--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -112,23 +112,7 @@ if [ -w /app/data ]; then
     gosu "$PUID:$PGID" python3 /app/scripts/init_db.py >/dev/null
 fi
 
-# --- 3d. Backfill derived companies_of_interest.txt (issue #222) ----------
-# Pre-#148 stacks have target_companies.md but lack the derived
-# companies_of_interest.txt; the onboarding injector only derives it on a
-# fresh paste-back. Derive here so config_loader stops warning and the
-# notify mis-score check it gates lights back up. Idempotent: no-op when
-# the destination already exists.
-gosu "$PUID:$PGID" python3 /app/scripts/seed_companies_of_interest.py >/dev/null || true
-
-# --- 3e-pre. Idempotent migration: RAPIDAPI_KEY → JOBS_API14_KEY (#408) ------
-# Runs synchronously BEFORE uvicorn and supercronic so that triage cannot
-# observe pre-migration data/.env on the first v0.13→v0.14 container boot.
-# The call in web/app.py:create_app() stays as redundancy for native installs.
-if [ -f /app/data/.env ]; then
-    gosu "$PUID:$PGID" python3 -c "from pathlib import Path; from findajob.onboarding.env_migrate import migrate_rapidapi_key_env; migrate_rapidapi_key_env(Path('/app/data/.env'))" || true
-fi
-
-# --- 3e. Render supercronic crontab from ops/scheduled-jobs.yaml (#344) ---
+# --- 3d. Render supercronic crontab from ops/scheduled-jobs.yaml (#344) ---
 # YAML at /app/scheduled-jobs.yaml is the source of truth. Per-job env-var
 # overrides (FINDAJOB_<JOB>_SCHEDULE / _ENABLED) let multi-tenant hosts
 # stagger schedules without forking the YAML. Fail-fast: a malformed YAML


### PR DESCRIPTION
## Summary
- Removes two dead stanzas from `ops/entrypoint.sh` that referenced symbols retired in earlier work (#211, #416). Both were wrapped in `|| true` so they didn't fail the entrypoint, but produced `ModuleNotFoundError` / `can't open file` noise on every container boot.
- Closes #439.

## Why
Per CHANGELOG: `seed_companies_of_interest.py` was retired in #211 (Tier 1 parsing moved to `findajob.config_loader.parse_target_companies_tier1()`). `findajob.onboarding.env_migrate.migrate_rapidapi_key_env` was retired in #416 (the v0.14 helper renamed `RAPIDAPI_KEY` → `JOBS_API14_KEY` on every boot, which became inverse to #414's canonical-name direction).

The startup noise:
1. Confuses anyone tail-ing logs during a deploy
2. Hides genuine startup failures
3. Wastes a few seconds on container boot doing nothing

## Test plan
- [x] `bash -n ops/entrypoint.sh` passes locally
- [ ] After merge + `:latest` repull, `sudo docker logs findajob-test-scheduler-1 --tail 50` shows no `ModuleNotFoundError` or `can't open file` lines

## Out of scope
Auditing the rest of `ops/entrypoint.sh` for similar dangling refs (per #439 body).