### PR TITLE
feat(web): #440 in-app notification dashboard + history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+- **In-app notification dashboard + history (#440).** Pipeline notifications (daily stats, apply reminders, health checks, scoreboard, feedback reviews, CI alerts, discovery runs, gmail-auth failures, manual sends) now persist to a new `notifications` table. New `/notifications/` page renders a reverse-chronological list with filters by kind + read/unread state; bell icon + HTMX-polled unread badge in the top nav (every 60s); `POST /notifications/{id}/read` and `/notifications/mark-all-read` for triage. `scripts/notify.py:send()` now writes the row BEFORE the ntfy.sh POST so ntfy outages don't lose the audit trail (`delivery_status='failed'` + `delivery_error` populated when curl exits non-zero). Operator-mode `/admin/stacks/` table gains an "Unread notifs" column. Generalizes the ntfy fire-and-forget surface and lays the foundation for the rejection-detection signal coming in #362.
+
+### Migration required
+- **New `notifications` table (#440).** `docker compose pull && docker compose up -d` is the entire migration path — `scripts/init_db.py` runs at container start and creates the table idempotently (`CREATE TABLE IF NOT EXISTS`). Existing notification call sites continue working unchanged; their rows start landing in the new table on the first cron firing post-restart. No backfill — historical notifications (pre-restart) are not reconstructable from `pipeline.jsonl` and stay absent from the dashboard.
+
 ## [0.16.0] — 2026-05-04
 
 Minor bump shipping the Google Sheets sync retirement (#331, closes #209) plus the aichat-ng config/catalog cleanup (#67). User-visible: the Sheet at the previously-synced ID stops updating — use the web UI at `/board/*` instead. Operator's stack and `findajob-test` track `:latest`; tester stacks (alice, papa, dave, judy, tango) currently on `:v0.15` stay on `:v0.15` until the next cohort wave.

--- a/docs/architecture/file-map.md
+++ b/docs/architecture/file-map.md
@@ -30,6 +30,7 @@ When this map drifts from the actual code (renamed file, new route module, retir
 <repo>/src/findajob/web/routes/onboarding_feed_config.py # GET/POST /onboarding/feed-config/{sid} — per-adapter signup walkthrough (#408)
 <repo>/src/findajob/web/routes/onboarding_gmail_config.py # GET/POST /onboarding/gmail-config/{sid}/{,skip,finish} — universal terminal gate; writes the sentinel after IMAP verify or explicit skip (#407)
 <repo>/src/findajob/web/routes/feedback.py    # POST /feedback/ — in-app feedback widget; files GitHub issues. Env: GITHUB_FEEDBACK_PAT, FEEDBACK_STACK_LABEL, FEEDBACK_REPO (#227)
+<repo>/src/findajob/web/routes/notifications.py # GET /notifications/, POST /notifications/{id}/read, POST /notifications/mark-all-read, GET /notifications/badge — in-app notification dashboard (#440)
 <repo>/src/findajob/onboarding/parser.py    # parse interview emission into files to inject
 <repo>/src/findajob/onboarding/injector.py  # atomic write + backup + Tier-1 derivation + sentinel
 <repo>/src/findajob/onboarding/session_store.py # onboarding_sessions CRUD (history/captured_blocks/find_active)

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -165,6 +165,26 @@ CREATE TABLE IF NOT EXISTS onboarding_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_onboarding_sessions_completed ON onboarding_sessions(completed_at);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+    kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL,
+    priority TEXT NOT NULL DEFAULT 'default',
+    tags TEXT,
+    delivery_status TEXT NOT NULL DEFAULT 'sent' CHECK(delivery_status IN (
+        'sent', 'failed', 'in_app_only'
+    )),
+    delivery_error TEXT,
+    cta_url TEXT,
+    read_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_sent_at ON notifications(sent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_unread ON notifications(read_at) WHERE read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_notifications_kind ON notifications(kind);
 """)
 conn.close()
 print("Database initialized:", DB_PATH)

--- a/scripts/notify.py
+++ b/scripts/notify.py
@@ -46,8 +46,70 @@ NTFY_URL = f"https://ntfy.sh/{NTFY_TOPIC}"
 WEB_BASE_URL = (_env.get("FINDAJOB_WEB_URL") or os.environ.get("FINDAJOB_WEB_URL", "http://localhost:8090")).rstrip("/")
 
 
-def send(title, body, priority="default", tags=None):
-    """Send a push notification via ntfy.sh."""
+# Closed-set kind taxonomy (#440). Adding a new kind = update this tuple AND
+# the per-kind color/label in templates/notifications/_kind.html.
+NOTIFICATION_KINDS: tuple[str, ...] = (
+    "daily_stats",
+    "apply_reminder",
+    "feedback_review",
+    "scoreboard",
+    "health_check",
+    "issues_ping",
+    "ci_check",
+    "send_raw",
+    "discovery_run",
+    "gmail_auth_failure",
+    "rejection_detected",  # consumed by #362 when it lands
+)
+
+
+def _persist_notification(
+    kind: str,
+    title: str,
+    body: str,
+    priority: str,
+    tags: str | None,
+    delivery_status: str,
+    delivery_error: str | None,
+    cta_url: str | None,
+) -> int | None:
+    """Insert a row into the notifications table. Returns row id, or None on error.
+
+    Persistence failures must NOT crash the caller — ntfy delivery and audit
+    persistence are independent. A missing table on a brand-new stack with no
+    init_db run is the only realistic failure; in that case we skip silently.
+    """
+    try:
+        conn = db_connect()
+        try:
+            cur = conn.execute(
+                """
+                INSERT INTO notifications
+                    (kind, title, body, priority, tags, delivery_status, delivery_error, cta_url)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (kind, title, body, priority, tags, delivery_status, delivery_error, cta_url),
+            )
+            conn.commit()
+            return cur.lastrowid
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+
+
+def send(title, body, priority="default", tags=None, kind="send_raw", cta_url=None):
+    """Persist a notification row, then push via ntfy.sh.
+
+    The DB row is the source of truth for the in-app notification dashboard
+    (#440). We insert FIRST so the audit trail captures even ntfy outages,
+    then attempt delivery. If ntfy.sh fails (network, 5xx), the row stays
+    with `delivery_status='failed'` and `delivery_error` populated — never
+    deleted. Returns the row id (or None if persistence itself failed).
+
+    `kind` should match one of NOTIFICATION_KINDS; arbitrary strings are
+    accepted but render as plain badges in the UI.
+    """
     headers = [
         "-H",
         f"Title: {title}",
@@ -56,10 +118,26 @@ def send(title, body, priority="default", tags=None):
     ]
     if tags:
         headers += ["-H", f"Tags: {tags}"]
-    subprocess.run(
+    result = subprocess.run(
         ["curl", "-s", "-X", "POST", NTFY_URL, "-H", "Content-Type: text/plain; charset=utf-8", *headers, "-d", body],
         check=False,
         capture_output=True,
+    )
+    if result.returncode == 0:
+        delivery_status = "sent"
+        delivery_error = None
+    else:
+        delivery_status = "failed"
+        delivery_error = (result.stderr or b"").decode("utf-8", errors="replace")[:500] or "curl exited non-zero"
+    return _persist_notification(
+        kind=kind,
+        title=title,
+        body=body,
+        priority=priority,
+        tags=tags,
+        delivery_status=delivery_status,
+        delivery_error=delivery_error,
+        cta_url=cta_url,
     )
 
 
@@ -190,7 +268,7 @@ def cmd_daily_stats():
         f"  {_p(total, 'job')} tracked in total",
     ]
     body = "\n".join(lines)
-    send("💼 findajob — good morning!", body, priority="default", tags="bar_chart")
+    send("💼 findajob — good morning!", body, priority="default", tags="bar_chart", kind="daily_stats")
 
 
 REVIEW_BACKLOG_WARN = 100  # warn if manual_review backlog exceeds this
@@ -418,7 +496,7 @@ def cmd_health_check():
         priority = "high" if any("ERROR" in i for i in issues) else "default"
         tags = "warning"
 
-    send("💼 findajob — health check", body, priority=priority, tags=tags)
+    send("💼 findajob — health check", body, priority=priority, tags=tags, kind="health_check")
 
 
 def cmd_issues_ping():
@@ -432,7 +510,7 @@ def cmd_issues_ping():
             lines.append(f"{i}. {iss}")
         body = "\n".join(lines)
         tags = "memo"
-    send("💼 findajob — open issues", body, priority="default", tags=tags)
+    send("💼 findajob — open issues", body, priority="default", tags=tags, kind="issues_ping")
 
 
 def cmd_apply_reminder():
@@ -482,7 +560,13 @@ def cmd_apply_reminder():
         f"Set aside for later: {n_waitlisted}"
     )
 
-    send("💼 findajob — apply to something today!", quip + checklist, priority="default", tags="rocket")
+    send(
+        "💼 findajob — apply to something today!",
+        quip + checklist,
+        priority="default",
+        tags="rocket",
+        kind="apply_reminder",
+    )
 
 
 def cmd_feedback_review():
@@ -529,15 +613,29 @@ def cmd_feedback_review():
     else:
         body = f"You've passed on {count} jobs so far.\nSee the trends: {WEB_BASE_URL}/stats/feedback"
 
-    send("💼 findajob — feedback check", body, priority="default", tags="magnifying")
+    send("💼 findajob — feedback check", body, priority="default", tags="magnifying", kind="feedback_review")
 
 
 def cmd_send_raw():
-    """Send a raw notification. Usage: notify.py send-raw <title> <body>"""
+    """Send a raw notification.
+
+    Usage:
+        notify.py send-raw <title> <body> [--kind <kind>]
+
+    `--kind` defaults to 'send_raw' — pass through one of NOTIFICATION_KINDS
+    when calling from a known internal site (e.g. discoverer, fetchers).
+    """
     if len(sys.argv) < 4:
-        print("Usage: notify.py send-raw <title> <body>")
+        print("Usage: notify.py send-raw <title> <body> [--kind <kind>]")
         sys.exit(1)
-    send(sys.argv[2], sys.argv[3], priority="default", tags="hourglass_flowing_sand")
+    title = sys.argv[2]
+    body = sys.argv[3]
+    kind = "send_raw"
+    if "--kind" in sys.argv:
+        idx = sys.argv.index("--kind")
+        if idx + 1 < len(sys.argv):
+            kind = sys.argv[idx + 1]
+    send(title, body, priority="default", tags="hourglass_flowing_sand", kind=kind)
 
 
 def cmd_ci_check():
@@ -553,7 +651,13 @@ def cmd_ci_check():
         timeout=30,
     )
     if result.returncode != 0:
-        send("💼 findajob — CI check", f"gh run list failed: {result.stderr[:200]}", priority="default", tags="warning")
+        send(
+            "💼 findajob — CI check",
+            f"gh run list failed: {result.stderr[:200]}",
+            priority="default",
+            tags="warning",
+            kind="ci_check",
+        )
         return
 
     import json as _json
@@ -576,7 +680,7 @@ def cmd_ci_check():
         f"  {latest.get('displayTitle', '?')}",
         f"  {latest.get('url', '')}",
     ]
-    send("💼 findajob — CI failed", "\n".join(lines), priority="high", tags="x")
+    send("💼 findajob — CI failed", "\n".join(lines), priority="high", tags="x", kind="ci_check")
 
 
 SCOREBOARD_ISSUE = 31
@@ -844,13 +948,14 @@ Cumulative counts — how many jobs ever reached each stage, not just current st
     )
     if rc.returncode == 0:
         msg = f"Pipeline funnel scoreboard (#31) updated for {today}."
-        send("💼 findajob — scoreboard updated", msg, priority="low", tags="bar_chart")
+        send("💼 findajob — scoreboard updated", msg, priority="low", tags="bar_chart", kind="scoreboard")
     else:
         send(
             "💼 findajob — scoreboard update failed",
             f"gh issue edit failed: {rc.stderr[:200]}",
             priority="high",
             tags="warning",
+            kind="scoreboard",
         )
 
 

--- a/src/findajob/actions.py
+++ b/src/findajob/actions.py
@@ -156,7 +156,10 @@ def notify_waitlist_resurface(conn: sqlite3.Connection, company: str) -> None:
     titles = [r["title"] for r in rows]
     title = f"Waitlisted jobs at {company}"
     body = "You just rejected/withdrew from this company. Waitlisted roles:\n" + "\n".join(f"• {t}" for t in titles)
-    subprocess.Popen([sys.executable, f"{BASE}/scripts/notify.py", "send-raw", title, body], start_new_session=True)
+    subprocess.Popen(
+        [sys.executable, f"{BASE}/scripts/notify.py", "send-raw", title, body, "--kind", "send_raw"],
+        start_new_session=True,
+    )
     log_event("waitlist_resurface", company=company, count=len(titles))
 
 

--- a/src/findajob/admin/stack_health.py
+++ b/src/findajob/admin/stack_health.py
@@ -30,6 +30,7 @@ class StackHealth:
     triage_failure_24h: int = 0
     stage_counts: dict[str, int] = field(default_factory=dict)
     stuck_prep_count: int = 0
+    unread_notifications: int = 0
     db_missing: bool = False
     jsonl_missing: bool = False
     error: str | None = None
@@ -50,6 +51,7 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
     error: str | None = None
     stage_counts: dict[str, int] = {}
     stuck_prep_count = 0
+    unread_notifications = 0
 
     if not db_missing:
         try:
@@ -82,6 +84,14 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
                     "AND stage_updated < ?",
                     (cutoff,),
                 ).fetchone()[0]
+                # Notifications table is post-#440; older stacks may lack it.
+                # Wrap the lookup so a missing table is silently a 0.
+                try:
+                    unread_notifications = conn.execute(
+                        "SELECT COUNT(*) FROM notifications WHERE read_at IS NULL"
+                    ).fetchone()[0]
+                except sqlite3.OperationalError:
+                    unread_notifications = 0
         except sqlite3.Error as e:
             error = f"sqlite: {e}"
         except Exception as e:  # defensive — don't let one stack crash the page
@@ -134,6 +144,7 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
         triage_failure_24h=failure_24h,
         stage_counts=stage_counts,
         stuck_prep_count=stuck_prep_count,
+        unread_notifications=unread_notifications,
         db_missing=db_missing,
         jsonl_missing=jsonl_missing,
         error=error,

--- a/src/findajob/discoverer/runner.py
+++ b/src/findajob/discoverer/runner.py
@@ -49,15 +49,24 @@ def _extract_cost_usd(stderr: str) -> float | None:
     return None
 
 
-def _send_ntfy(title: str, body: str) -> None:
+def _send_ntfy(title: str, body: str, kind: str = "discovery_run") -> None:
     """Best-effort ntfy via scripts/notify.py send-raw.
 
     Uses subprocess to call the existing notify.py CLI; suppresses any
-    error so a notification failure cannot mask a successful run.
+    error so a notification failure cannot mask a successful run. `kind`
+    flows through to the persisted notifications row (#440).
     """
     try:
         subprocess.run(
-            [sys.executable, str(Path(BASE) / "scripts" / "notify.py"), "send-raw", title, body],
+            [
+                sys.executable,
+                str(Path(BASE) / "scripts" / "notify.py"),
+                "send-raw",
+                title,
+                body,
+                "--kind",
+                kind,
+            ],
             check=False,
             capture_output=True,
             timeout=15,

--- a/src/findajob/fetchers/__init__.py
+++ b/src/findajob/fetchers/__init__.py
@@ -535,10 +535,17 @@ def _normalize_sender_to_source(sender: str, url: str = "") -> str:
     return "gmail_unknown"
 
 
-def notify_send_raw(text: str) -> None:
-    """Thin wrapper for ntfy notifications. Module-level for monkeypatching in tests."""
+def notify_send_raw(text: str, kind: str = "gmail_auth_failure") -> None:
+    """Thin wrapper for ntfy notifications. Module-level for monkeypatching in tests.
+
+    Splits `text` into title + body around the first newline so the existing
+    notify.py CLI contract is satisfied (it requires title+body positional args).
+    """
+    title, _, body = text.partition("\n")
+    if not body:
+        body = title
     subprocess.run(
-        [sys.executable, f"{BASE}/scripts/notify.py", "send-raw", text],
+        [sys.executable, f"{BASE}/scripts/notify.py", "send-raw", title, body, "--kind", kind],
         check=False,
         timeout=10,
     )

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -14,6 +14,7 @@ from findajob.web.routes import (
     ingest,
     landing,
     materials,
+    notifications,
     onboarding,
     onboarding_feed_config,
     onboarding_gmail_config,
@@ -48,3 +49,4 @@ router.include_router(onboarding_feed_config.router)
 router.include_router(onboarding_gmail_config.router)
 router.include_router(docs.router)
 router.include_router(feedback.router)
+router.include_router(notifications.router, dependencies=_guard)

--- a/src/findajob/web/routes/notifications.py
+++ b/src/findajob/web/routes/notifications.py
@@ -1,0 +1,227 @@
+"""In-app notification dashboard + history (#440).
+
+Mirrors what `scripts/notify.py` already pushes to ntfy.sh, but persisted
+server-side so the operator (and testers) can scan recent signals without
+leaving the app. The DB row is written by `scripts/notify.py:send()` BEFORE
+the ntfy POST — so the audit trail captures even ntfy outages.
+
+Routes:
+- ``GET /notifications/`` — reverse-chronological list with kind / read-state filters
+- ``POST /notifications/{id}/read`` — mark a row read (idempotent)
+- ``POST /notifications/mark-all-read`` — bulk mark
+- ``GET /notifications/badge`` — HTMX fragment returning the unread count badge
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from findajob.web.routes.materials import get_db
+
+router = APIRouter()
+
+# Per-row pagination cap. The page is server-rendered so a hard ceiling is
+# safer than streaming — older rows still load via the `?before=<id>` cursor.
+_PAGE_SIZE = 50
+
+# Kinds expected to render with badge styling. Unknown kinds still render,
+# just with the default slate badge (forward-compat for #362's
+# ``rejection_detected`` and any future kinds).
+_KIND_LABELS: dict[str, str] = {
+    "daily_stats": "Daily stats",
+    "apply_reminder": "Apply reminder",
+    "feedback_review": "Feedback review",
+    "scoreboard": "Scoreboard",
+    "health_check": "Health check",
+    "issues_ping": "Issues ping",
+    "ci_check": "CI check",
+    "send_raw": "Manual send",
+    "discovery_run": "Discovery",
+    "gmail_auth_failure": "Gmail auth",
+    "rejection_detected": "Rejection detected",
+}
+
+
+def _humanize_kind(kind: str) -> str:
+    return _KIND_LABELS.get(kind, kind.replace("_", " ").title())
+
+
+def _parse_kinds(raw: str) -> list[str]:
+    return [k.strip() for k in raw.split(",") if k.strip()] if raw else []
+
+
+@router.get("/notifications/", response_class=HTMLResponse)
+def notifications_index(
+    request: Request,
+    kind: str = "",
+    read: str = "",
+    before: int = 0,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Reverse-chronological list of notifications.
+
+    Filters:
+    - ``?kind=a,b,c`` — comma-separated kinds (any-of semantics)
+    - ``?read=unread|read`` — restrict by read state (omit for all)
+    - ``?before=<id>`` — pagination cursor (rows older than this id)
+    """
+    where_clauses: list[str] = []
+    params: list[object] = []
+
+    kinds = _parse_kinds(kind)
+    if kinds:
+        placeholders = ",".join("?" * len(kinds))
+        where_clauses.append(f"kind IN ({placeholders})")
+        params.extend(kinds)
+
+    if read == "unread":
+        where_clauses.append("read_at IS NULL")
+    elif read == "read":
+        where_clauses.append("read_at IS NOT NULL")
+
+    if before > 0:
+        where_clauses.append("id < ?")
+        params.append(before)
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+    rows = db.execute(
+        f"""
+        SELECT id, sent_at, kind, title, body, priority, tags,
+               delivery_status, delivery_error, cta_url, read_at
+        FROM notifications
+        {where_sql}
+        ORDER BY id DESC
+        LIMIT ?
+        """,
+        (*params, _PAGE_SIZE + 1),
+    ).fetchall()
+
+    has_more = len(rows) > _PAGE_SIZE
+    rows = rows[:_PAGE_SIZE]
+
+    next_before = rows[-1]["id"] if has_more and rows else 0
+
+    unread_total = db.execute("SELECT COUNT(*) FROM notifications WHERE read_at IS NULL").fetchone()[0]
+
+    kind_counts = db.execute(
+        """
+        SELECT kind, COUNT(*) AS n
+        FROM notifications
+        GROUP BY kind
+        ORDER BY n DESC
+        """
+    ).fetchall()
+
+    items = [
+        {
+            "id": r["id"],
+            "sent_at": r["sent_at"],
+            "kind": r["kind"],
+            "kind_label": _humanize_kind(r["kind"]),
+            "title": r["title"],
+            "body": r["body"],
+            "priority": r["priority"],
+            "tags": r["tags"],
+            "delivery_status": r["delivery_status"],
+            "delivery_error": r["delivery_error"],
+            "cta_url": r["cta_url"],
+            "read_at": r["read_at"],
+        }
+        for r in rows
+    ]
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="notifications/index.html",
+        context={
+            "items": items,
+            "unread_total": unread_total,
+            "selected_kinds": kinds,
+            "selected_read": read,
+            "kind_counts": [{"kind": r["kind"], "label": _humanize_kind(r["kind"]), "n": r["n"]} for r in kind_counts],
+            "has_more": has_more,
+            "next_before": next_before,
+        },
+    )
+
+
+@router.post("/notifications/{notif_id}/read", response_model=None)
+def mark_read(
+    notif_id: int,
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse | RedirectResponse:
+    """Idempotent mark-as-read. HTMX returns the updated row; full-page POSTs redirect back."""
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    db.execute(
+        "UPDATE notifications SET read_at = ? WHERE id = ? AND read_at IS NULL",
+        (now, notif_id),
+    )
+    db.commit()
+
+    if request.headers.get("HX-Request"):
+        row = db.execute(
+            """
+            SELECT id, sent_at, kind, title, body, priority, tags,
+                   delivery_status, delivery_error, cta_url, read_at
+            FROM notifications WHERE id = ?
+            """,
+            (notif_id,),
+        ).fetchone()
+        if row is None:
+            return HTMLResponse("", status_code=404)
+        item = {
+            "id": row["id"],
+            "sent_at": row["sent_at"],
+            "kind": row["kind"],
+            "kind_label": _humanize_kind(row["kind"]),
+            "title": row["title"],
+            "body": row["body"],
+            "priority": row["priority"],
+            "tags": row["tags"],
+            "delivery_status": row["delivery_status"],
+            "delivery_error": row["delivery_error"],
+            "cta_url": row["cta_url"],
+            "read_at": row["read_at"],
+        }
+        templates = request.app.state.templates
+        return templates.TemplateResponse(
+            request=request,
+            name="notifications/_row.html",
+            context={"item": item},
+        )
+
+    return RedirectResponse(url="/notifications/", status_code=303)
+
+
+@router.post("/notifications/mark-all-read")
+def mark_all_read(
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> RedirectResponse:
+    """Mark every unread notification on this stack as read."""
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    db.execute("UPDATE notifications SET read_at = ? WHERE read_at IS NULL", (now,))
+    db.commit()
+    return RedirectResponse(url="/notifications/", status_code=303)
+
+
+@router.get("/notifications/badge", response_class=HTMLResponse)
+def badge(
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """HTMX-poll endpoint for the bell icon's unread count."""
+    n = db.execute("SELECT COUNT(*) FROM notifications WHERE read_at IS NULL").fetchone()[0]
+    if n == 0:
+        return HTMLResponse('<span id="nav-notif-badge"></span>')
+    return HTMLResponse(
+        f'<span id="nav-notif-badge" '
+        f'class="ml-1 inline-flex items-center justify-center text-xs font-bold '
+        f'rounded-full bg-amber-500 text-slate-900 min-w-[1.25rem] h-5 px-1">{n}</span>'
+    )

--- a/src/findajob/web/templates/_nav.html
+++ b/src/findajob/web/templates/_nav.html
@@ -46,6 +46,20 @@
         </span>
       </li>
     {% endif %}
+    {# Notifications bell — links to /notifications/, polls /notifications/badge
+       every 60s for the unread count. #440 #}
+    <li class="{% if onboarding_lifetime_cost_usd is not defined %}ml-auto{% endif %}">
+      <a href="/notifications/"
+         class="px-2 py-1 rounded inline-flex items-center {% if operator_mode %}hover:bg-rose-800{% else %}hover:bg-slate-700{% endif %}"
+         aria-label="Notifications"
+         title="Notifications">
+        <span aria-hidden="true">🔔</span>
+        <span hx-get="/notifications/badge"
+              hx-trigger="load, every 60s"
+              hx-swap="outerHTML"
+              id="nav-notif-badge"></span>
+      </a>
+    </li>
     {% if operator_mode %}
       {% set admin_active = request.url.path.startswith("/admin/") %}
       <li>

--- a/src/findajob/web/templates/admin/_stack_row.html
+++ b/src/findajob/web/templates/admin/_stack_row.html
@@ -34,6 +34,15 @@
     {% endif %}
   </td>
 
+  {# Unread notifications (#440) #}
+  <td class="py-2 pr-4">
+    {% if h.unread_notifications > 0 %}
+      <span class="font-semibold text-amber-700">{{ h.unread_notifications }}</span>
+    {% else %}
+      0
+    {% endif %}
+  </td>
+
   {# 24h triage success/failure #}
   <td class="py-2 pr-4 whitespace-nowrap">
     <span class="text-emerald-700">{{ h.triage_success_24h }} ✓</span>

--- a/src/findajob/web/templates/admin/stacks_index.html
+++ b/src/findajob/web/templates/admin/stacks_index.html
@@ -25,6 +25,7 @@
           <th class="py-2 pr-4">Last triage</th>
           <th class="py-2 pr-4">Stage distribution</th>
           <th class="py-2 pr-4">Stuck prep</th>
+          <th class="py-2 pr-4">Unread notifs</th>
           <th class="py-2 pr-4">24h triage</th>
           <th class="py-2 pr-4">Last failure</th>
           <th class="py-2 pr-4">Drill-down</th>

--- a/src/findajob/web/templates/notifications/_row.html
+++ b/src/findajob/web/templates/notifications/_row.html
@@ -1,0 +1,71 @@
+{# One notification row. Used by index.html and as the HTMX OOB swap target
+   when /notifications/{id}/read fires. #}
+{% set kind_color_map = {
+  "daily_stats": "bg-sky-100 text-sky-800 border-sky-300",
+  "apply_reminder": "bg-emerald-100 text-emerald-800 border-emerald-300",
+  "feedback_review": "bg-violet-100 text-violet-800 border-violet-300",
+  "scoreboard": "bg-cyan-100 text-cyan-800 border-cyan-300",
+  "health_check": "bg-red-100 text-red-800 border-red-300",
+  "issues_ping": "bg-amber-100 text-amber-800 border-amber-300",
+  "ci_check": "bg-orange-100 text-orange-800 border-orange-300",
+  "send_raw": "bg-slate-100 text-slate-800 border-slate-300",
+  "discovery_run": "bg-teal-100 text-teal-800 border-teal-300",
+  "gmail_auth_failure": "bg-rose-100 text-rose-800 border-rose-300",
+  "rejection_detected": "bg-amber-200 text-amber-900 border-amber-400",
+} %}
+{% set kind_class = kind_color_map.get(item.kind, "bg-slate-100 text-slate-800 border-slate-300") %}
+{% set is_unread = item.read_at is none %}
+
+<li id="notif-row-{{ item.id }}"
+    class="rounded border {% if is_unread %}border-amber-400 bg-amber-50/40{% else %}border-slate-200 bg-white{% endif %} p-3"
+    x-data="{open: false}">
+  <div class="flex items-start gap-3">
+    <span class="shrink-0 inline-flex items-center text-xs font-medium px-2 py-0.5 rounded-full border {{ kind_class }}">
+      {{ item.kind_label }}
+    </span>
+    <div class="flex-1 min-w-0">
+      <div class="flex items-baseline justify-between gap-2">
+        <h3 class="font-semibold {% if is_unread %}text-slate-900{% else %}text-slate-700{% endif %}">
+          {{ item.title }}
+        </h3>
+        <span class="shrink-0 text-xs text-slate-500" title="{{ item.sent_at }} UTC">
+          {{ item.sent_at }}
+        </span>
+      </div>
+      <div class="mt-1 text-sm text-slate-700">
+        {% set body_len = item.body | length %}
+        {% if body_len > 240 %}
+          <pre class="whitespace-pre-wrap font-sans" x-show="!open">{{ item.body[:240] }}...</pre>
+          <pre class="whitespace-pre-wrap font-sans" x-show="open" x-cloak>{{ item.body }}</pre>
+          <button type="button" @click="open = !open"
+                  class="mt-1 text-xs text-blue-700 hover:underline"
+                  x-text="open ? 'collapse' : 'show full'"></button>
+        {% else %}
+          <pre class="whitespace-pre-wrap font-sans">{{ item.body }}</pre>
+        {% endif %}
+      </div>
+      <div class="mt-2 flex items-center gap-3 text-xs">
+        {% if item.delivery_status == 'failed' %}
+          <span class="text-red-700" title="{{ item.delivery_error or '' }}">⚠ ntfy delivery failed</span>
+        {% elif item.delivery_status == 'in_app_only' %}
+          <span class="text-slate-500">in-app only</span>
+        {% endif %}
+        {% if item.cta_url %}
+          <a href="{{ item.cta_url }}" class="text-blue-700 hover:underline">Open →</a>
+        {% endif %}
+        {% if is_unread %}
+          <form hx-post="/notifications/{{ item.id }}/read"
+                hx-target="#notif-row-{{ item.id }}"
+                hx-swap="outerHTML"
+                class="inline">
+            <button type="submit" class="text-slate-600 hover:text-slate-900 hover:underline">
+              Mark read
+            </button>
+          </form>
+        {% else %}
+          <span class="text-slate-400">read {{ item.read_at }}</span>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</li>

--- a/src/findajob/web/templates/notifications/index.html
+++ b/src/findajob/web/templates/notifications/index.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% block title %}Notifications — findajob{% endblock %}
+
+{% block content %}
+<div class="flex items-baseline justify-between mb-4">
+  <h1 class="text-2xl font-semibold">Notifications</h1>
+  <div class="text-sm text-slate-600">
+    {% if unread_total > 0 %}
+      <span class="font-semibold text-amber-700">{{ unread_total }}</span> unread
+      <form action="/notifications/mark-all-read" method="post" class="inline ml-3">
+        <button type="submit"
+                class="text-xs px-2 py-1 rounded border border-slate-300 hover:bg-slate-100">
+          Mark all read
+        </button>
+      </form>
+    {% else %}
+      All caught up.
+    {% endif %}
+  </div>
+</div>
+
+<form method="get" action="/notifications/" class="mb-4 flex flex-wrap gap-2 items-center text-sm">
+  <span class="text-slate-500">Filter:</span>
+  <select name="read" class="border border-slate-300 rounded px-2 py-1">
+    <option value="" {% if not selected_read %}selected{% endif %}>All states</option>
+    <option value="unread" {% if selected_read == 'unread' %}selected{% endif %}>Unread</option>
+    <option value="read" {% if selected_read == 'read' %}selected{% endif %}>Read</option>
+  </select>
+
+  {% if kind_counts %}
+  <select name="kind" class="border border-slate-300 rounded px-2 py-1">
+    <option value="">All kinds</option>
+    {% for k in kind_counts %}
+      {% set selected = k.kind in selected_kinds %}
+      <option value="{{ k.kind }}" {% if selected %}selected{% endif %}>
+        {{ k.label }} ({{ k.n }})
+      </option>
+    {% endfor %}
+  </select>
+  {% endif %}
+
+  <button type="submit"
+          class="px-2 py-1 rounded bg-slate-700 text-white hover:bg-slate-800">
+    Apply
+  </button>
+  {% if selected_kinds or selected_read %}
+    <a href="/notifications/" class="text-slate-500 hover:underline">clear</a>
+  {% endif %}
+</form>
+
+{% if not items %}
+  <div class="bg-slate-100 border border-slate-200 rounded p-6 text-center text-slate-600">
+    {% if selected_kinds or selected_read %}
+      <p>No notifications match those filters.</p>
+      <p class="mt-2"><a href="/notifications/" class="text-blue-700 hover:underline">Clear filters</a></p>
+    {% else %}
+      <p class="font-medium">No notifications yet.</p>
+      <p class="mt-2 text-sm">
+        Pipeline events get persisted here once they fire — daily stats at 6am, health checks,
+        feedback reviews, and more. Make sure
+        <code class="bg-slate-200 rounded px-1">NTFY_TOPIC</code> is set in
+        <a href="/config/" class="text-blue-700 hover:underline">/config/</a>
+        if you also want phone push notifications.
+      </p>
+    {% endif %}
+  </div>
+{% else %}
+  <ul class="space-y-2">
+    {% for item in items %}
+      {% include "notifications/_row.html" %}
+    {% endfor %}
+  </ul>
+
+  {% if has_more %}
+    <div class="mt-4 text-center">
+      <a href="/notifications/?before={{ next_before }}{% if selected_kinds %}&kind={{ selected_kinds | join(',') }}{% endif %}{% if selected_read %}&read={{ selected_read }}{% endif %}"
+         class="px-3 py-1 border border-slate-300 rounded hover:bg-slate-100 text-sm">
+        Older →
+      </a>
+    </div>
+  {% endif %}
+{% endif %}
+{% endblock %}

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -390,7 +390,10 @@ class TestNotifyWaitlistResurface:
 
         actions.notify_waitlist_resurface(db, "Acme Corp")
 
-        body = popen_calls[0][-1]  # last arg is the body
+        # Args: [python, notify.py, send-raw, <title>, <body>, --kind, send_raw]
+        # Find the body via its position relative to send-raw.
+        args = popen_calls[0]
+        body = args[args.index("send-raw") + 2]
         assert "Site Lead" in body
         assert "Ops Manager" in body
 

--- a/tests/test_notify_persistence.py
+++ b/tests/test_notify_persistence.py
@@ -1,0 +1,165 @@
+"""notify.py:send() persists notifications rows before/after ntfy POST (#440)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+NOTIFY_PATH = REPO / "scripts" / "notify.py"
+
+
+def _load_notify_module(db_path: Path):
+    spec = importlib.util.spec_from_file_location("notify_persistence_under_test", NOTIFY_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["notify_persistence_under_test"] = mod
+    spec.loader.exec_module(mod)
+    mod.DB_PATH = str(db_path)
+    return mod
+
+
+def _build_notifications_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+            kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            priority TEXT NOT NULL DEFAULT 'default',
+            tags TEXT,
+            delivery_status TEXT NOT NULL DEFAULT 'sent',
+            delivery_error TEXT,
+            cta_url TEXT,
+            read_at TEXT
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def notify(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    db = tmp_path / "pipeline.db"
+    _build_notifications_db(db)
+    mod = _load_notify_module(db)
+    return mod
+
+
+def _read_rows(db_path) -> list[sqlite3.Row]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT * FROM notifications ORDER BY id ASC").fetchall()
+    conn.close()
+    return rows
+
+
+def test_send_persists_row_with_kind(notify, monkeypatch):
+    """A successful ntfy POST persists a row tagged with kind + status='sent'."""
+
+    class _Result:
+        returncode = 0
+        stderr = b""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _Result())
+
+    notify.send("hello", "world", priority="low", tags="bell", kind="daily_stats")
+
+    rows = _read_rows(notify.DB_PATH)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["kind"] == "daily_stats"
+    assert r["title"] == "hello"
+    assert r["body"] == "world"
+    assert r["priority"] == "low"
+    assert r["tags"] == "bell"
+    assert r["delivery_status"] == "sent"
+    assert r["delivery_error"] is None
+
+
+def test_send_persists_row_when_ntfy_fails(notify, monkeypatch):
+    """ntfy.sh outage MUST NOT delete the audit row — it flips delivery_status."""
+
+    class _Result:
+        returncode = 7  # curl: failed to connect
+        stderr = b"curl: (7) Failed to connect to ntfy.sh"
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _Result())
+
+    notify.send("alert", "the thing happened", kind="health_check")
+
+    rows = _read_rows(notify.DB_PATH)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["delivery_status"] == "failed"
+    assert r["delivery_error"] is not None
+    assert "Failed to connect" in r["delivery_error"]
+
+
+def test_send_default_kind_is_send_raw(notify, monkeypatch):
+    class _Result:
+        returncode = 0
+        stderr = b""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _Result())
+
+    notify.send("title", "body")
+
+    rows = _read_rows(notify.DB_PATH)
+    assert rows[0]["kind"] == "send_raw"
+
+
+def test_send_returns_row_id(notify, monkeypatch):
+    class _Result:
+        returncode = 0
+        stderr = b""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _Result())
+
+    rid1 = notify.send("a", "b", kind="daily_stats")
+    rid2 = notify.send("c", "d", kind="health_check")
+    assert rid1 == 1
+    assert rid2 == 2
+
+
+def test_send_does_not_crash_when_table_missing(tmp_path, monkeypatch):
+    """Brand-new stack with no init_db run yet: send() should not crash."""
+    db = tmp_path / "pipeline.db"
+    sqlite3.connect(db).close()  # empty DB, no tables
+    mod = _load_notify_module(db)
+
+    class _Result:
+        returncode = 0
+        stderr = b""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _Result())
+
+    rid = mod.send("title", "body", kind="daily_stats")
+    assert rid is None  # silent skip, no exception
+
+
+def test_taxonomy_constant_includes_known_kinds(notify):
+    """The closed-set taxonomy must list every kind referenced in production."""
+    expected = {
+        "daily_stats",
+        "apply_reminder",
+        "feedback_review",
+        "scoreboard",
+        "health_check",
+        "issues_ping",
+        "ci_check",
+        "send_raw",
+        "discovery_run",
+        "gmail_auth_failure",
+        "rejection_detected",
+    }
+    assert set(notify.NOTIFICATION_KINDS) >= expected

--- a/tests/test_web_notifications.py
+++ b/tests/test_web_notifications.py
@@ -1,0 +1,198 @@
+"""/notifications/ page + /notifications/{id}/read + /notifications/badge (#440)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+
+
+def _build_db(db_path: Path) -> sqlite3.Connection:
+    """Build a minimal pipeline.db with the notifications schema #440 ships.
+
+    Mirrors the relevant part of `scripts/init_db.py` — kept in sync because
+    web tests must hit the same shape the production DB has.
+    """
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE jobs (id TEXT PRIMARY KEY, stage TEXT);
+        CREATE TABLE notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+            kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            priority TEXT NOT NULL DEFAULT 'default',
+            tags TEXT,
+            delivery_status TEXT NOT NULL DEFAULT 'sent',
+            delivery_error TEXT,
+            cta_url TEXT,
+            read_at TEXT
+        );
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _seed(conn: sqlite3.Connection, rows: list[dict]) -> None:
+    for r in rows:
+        conn.execute(
+            """
+            INSERT INTO notifications
+                (sent_at, kind, title, body, priority, tags, delivery_status,
+                 delivery_error, cta_url, read_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                r.get("sent_at", "2026-05-04 12:00:00"),
+                r["kind"],
+                r["title"],
+                r["body"],
+                r.get("priority", "default"),
+                r.get("tags"),
+                r.get("delivery_status", "sent"),
+                r.get("delivery_error"),
+                r.get("cta_url"),
+                r.get("read_at"),
+            ),
+        )
+    conn.commit()
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = _build_db(db)
+    _seed(
+        conn,
+        [
+            {"kind": "daily_stats", "title": "Morning summary", "body": "5 new ranked"},
+            {"kind": "apply_reminder", "title": "Apply!", "body": "today's nudge"},
+            {
+                "kind": "health_check",
+                "title": "Health",
+                "body": "warning",
+                "delivery_status": "failed",
+                "delivery_error": "ntfy 503",
+            },
+            {"kind": "scoreboard", "title": "Scoreboard", "body": "weekly", "read_at": "2026-05-04 12:30:00"},
+        ],
+    )
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+def test_index_renders_recent_first(client: TestClient) -> None:
+    r = client.get("/notifications/")
+    assert r.status_code == 200
+    assert "Notifications" in r.text
+    assert "Morning summary" in r.text
+    assert "Apply!" in r.text
+    # Read row still appears (default = all states)
+    assert "Scoreboard" in r.text
+    # 3 unread out of 4 → header shows count
+    assert "3</span> unread" in r.text or "3 unread" in r.text or ">3<" in r.text
+
+
+def test_index_filter_unread(client: TestClient) -> None:
+    r = client.get("/notifications/?read=unread")
+    assert r.status_code == 200
+    assert "Morning summary" in r.text
+    # The read row's body ("weekly") shouldn't appear in the unread list — but
+    # "Scoreboard" itself shows up in the kind filter dropdown, so test on body.
+    assert "weekly" not in r.text
+
+
+def test_index_filter_by_kind(client: TestClient) -> None:
+    r = client.get("/notifications/?kind=health_check")
+    assert r.status_code == 200
+    assert "Health" in r.text
+    assert "Morning summary" not in r.text
+
+
+def test_failed_delivery_renders_warning(client: TestClient) -> None:
+    r = client.get("/notifications/?kind=health_check")
+    assert "ntfy delivery failed" in r.text
+
+
+def test_mark_read_idempotent(client: TestClient) -> None:
+    # First mark — flips read_at
+    r1 = client.post("/notifications/1/read", follow_redirects=False)
+    assert r1.status_code == 303
+
+    # Badge now shows 2 unread (was 3)
+    r_badge = client.get("/notifications/badge")
+    assert ">2<" in r_badge.text
+
+    # Second mark on same id — still 200/303, badge unchanged
+    r2 = client.post("/notifications/1/read", follow_redirects=False)
+    assert r2.status_code == 303
+    r_badge2 = client.get("/notifications/badge")
+    assert ">2<" in r_badge2.text
+
+
+def test_mark_read_htmx_returns_row_fragment(client: TestClient) -> None:
+    r = client.post("/notifications/2/read", headers={"HX-Request": "true"})
+    assert r.status_code == 200
+    assert 'id="notif-row-2"' in r.text
+    # The "Mark read" button is gone for read rows
+    assert "Mark read" not in r.text or "read 20" in r.text
+
+
+def test_mark_all_read(client: TestClient) -> None:
+    r = client.post("/notifications/mark-all-read", follow_redirects=False)
+    assert r.status_code == 303
+
+    r_badge = client.get("/notifications/badge")
+    assert ">0<" not in r_badge.text  # badge collapses to empty span at 0
+    assert "nav-notif-badge" in r_badge.text
+
+
+def test_badge_empty_when_no_unread(tmp_path: Path) -> None:
+    db = tmp_path / "pipeline.db"
+    conn = _build_db(db)
+    _seed(conn, [{"kind": "daily_stats", "title": "x", "body": "y", "read_at": "2026-05-04 12:30:00"}])
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    c = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = c.get("/notifications/badge")
+    assert r.status_code == 200
+    # Empty badge = no number rendered
+    assert "<span" in r.text  # span shell for HTMX swap target
+    assert ">0<" not in r.text
+
+
+def test_empty_state_with_no_rows(tmp_path: Path) -> None:
+    db = tmp_path / "pipeline.db"
+    _build_db(db).close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    c = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = c.get("/notifications/")
+    assert r.status_code == 200
+    assert "No notifications yet" in r.text
+    # Empty state points to /config/ (#440 AC)
+    assert "/config/" in r.text
+
+
+def test_nav_includes_bell_icon(client: TestClient) -> None:
+    """The bell + badge surface on every page that includes _nav.html."""
+    r = client.get("/notifications/")
+    assert "🔔" in r.text
+    assert 'id="nav-notif-badge"' in r.text
+    assert "/notifications/badge" in r.text


### PR DESCRIPTION
## Summary

Closes #440. Generalizes the ntfy.sh fire-and-forget surface into a persisted in-app notification dashboard. Pipeline notifications (daily stats, apply reminders, health checks, scoreboard, feedback reviews, CI alerts, discovery runs, gmail-auth failures, manual sends) write a row to a new `notifications` table BEFORE the ntfy POST — so audit trail survives ntfy outages. New `/notifications/` page renders reverse-chronological with kind + read-state filters; bell icon + HTMX-polled badge in the top nav; operator-mode `/admin/stacks/` gets an "Unread notifs" column.

Lays the foundation for the rejection-detection signal coming in #362 — `rejection_detected` kind is reserved in the taxonomy.

## Open design decisions (issue body §)

All defaults accepted:
- Retention: forever (rows are tiny, indexed)
- Mark-all-read: surfaced as a button + per-row mark-read
- In-app-only kinds: `delivery_status='in_app_only'` field exists; not used by current call sites (reserved for #362's rejection_detected default)
- Toast-on-arrival: deferred — HTMX badge poll is sufficient v1
- Failed-send retry: no — row persists with `delivery_status='failed'` for audit; ntfy outages are rare

## Test plan

- [x] `uv run pytest` (1739 passed, 1 skipped)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] New tests: 6 persistence + 10 route/UI cases
- [ ] Deploy to `findajob-test`: `docker compose pull && up -d`, browse to `/notifications/`, trigger a manual `notify.py send-raw "test" "body"` from inside the container, verify the row lands and the badge increments without page reload.

### Migration required

`docker compose pull && docker compose up -d` is the entire migration path — `scripts/init_db.py` runs at container start and creates the `notifications` table idempotently. Existing notification call sites continue working unchanged. No backfill — historical notifications (pre-restart) are not present in the dashboard, only those fired after the new table exists.