### PR TITLE
fix(admin): #359 harden findajob.admin error paths for bind-mount edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Changed
+- **Operator-mode dashboard hardened against bind-mount edge cases (#359).** `findajob.admin.jsonl_tail.tail_events` now catches `OSError` (covers `PermissionError`, not just `FileNotFoundError`) at both `os.path.getsize` and `open()`, so a chmod-stripped or mid-remount log file degrades to "no events" rather than 500-ing the page. `findajob.admin.stack_discovery.discover_stacks` catches `OSError` on `iterdir()` and returns `[]` with a logger warning rather than letting a restrictive `stacks_root` blank the dashboard. `findajob.admin.stack_health._parse_ts` coerces naïve ISO timestamps to UTC so a hand-edited or older log entry can't crash the render with a TypeError. The 24h-window event count now uses strict `>` (matching `_freshness`'s strict `<` — exactly-24h-ago is OUT of both windows) instead of mismatched `>=`. Operator-only impact; no schema or config changes.
+
 ## [0.18.0] — 2026-05-05
 
 Minor bump shipping per-tenant geography filtering for the three RapidAPI adapters (#372 / #450) plus two observability/correctness fixes: gmail per-sender logging + diagnostic override (#449) and the notify dead-feed detector false-positive correction. User-visible: each tenant can now write `config/target_locations.txt` to scope `jobs-api14`, `jobs-api14-indeed`, and `jsearch` queries to specific cities/regions instead of the hardcoded `United States`. Existing stacks without the file continue fetching `United States`-wide — no breaking change. Operator's stack and `findajob-test` track `:latest`; tester stacks (alice, papa, dave, judy, tango) currently on `:v0.17` bump to `:v0.18` in this cohort wave.

--- a/src/findajob/admin/jsonl_tail.py
+++ b/src/findajob/admin/jsonl_tail.py
@@ -19,22 +19,33 @@ def tail_events(path: Path, *, max_bytes: int = 1_048_576) -> Iterator[dict]:
     """Yield decoded JSON events from the last ~`max_bytes` of `path`,
     newest first.
 
-    Returns an empty iterator when the file is missing or empty. Skips
-    malformed lines with a single WARNING log per occurrence. When the
-    tail buffer cuts mid-line, the partial first line is discarded so
-    every yielded value is valid JSON.
+    Returns an empty iterator when the file is missing, empty, or
+    unreadable (e.g. a bind mount mid-remount, or a stack whose log
+    file landed at a restrictive mode). Skips malformed lines with a
+    single WARNING log per occurrence. When the tail buffer cuts
+    mid-line, the partial first line is discarded so every yielded
+    value is valid JSON.
     """
+    # Catch OSError (parent of FileNotFoundError AND PermissionError) so
+    # a foreign-uid / chmod-stripped log file degrades to "no events"
+    # rather than 500-ing the operator dashboard. The bounded-tail
+    # design exists exactly to keep this path defensive.
     try:
         size = os.path.getsize(path)
-    except FileNotFoundError:
+    except OSError:
+        logger.warning("admin_stacks.jsonl_tail: cannot stat %s", path)
         return
     if size == 0:
         return
 
     read_len = min(size, max_bytes)
-    with open(path, "rb") as f:
-        f.seek(size - read_len)
-        chunk = f.read(read_len)
+    try:
+        with open(path, "rb") as f:
+            f.seek(size - read_len)
+            chunk = f.read(read_len)
+    except OSError:
+        logger.warning("admin_stacks.jsonl_tail: cannot open %s", path)
+        return
 
     text = chunk.decode("utf-8", errors="replace")
     lines = text.splitlines()

--- a/src/findajob/admin/stack_discovery.py
+++ b/src/findajob/admin/stack_discovery.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -24,13 +27,33 @@ def discover_stacks(stacks_root: Path) -> list[StackPath]:
     `archivebox`). Skips `findajob-*` directories without a `state/`
     subdir (mid-onboarding or broken installs).
 
-    Returns an empty list when `stacks_root` is missing or empty.
+    Returns an empty list when `stacks_root` is missing, empty, or
+    unreadable.
+
+    Path semantics:
+      - `Path.is_dir()` follows symlinks. A symlinked stack directory
+        (e.g. `findajob-alice` → `/srv/stacks/alice`) is enumerated as
+        its target. Broken symlinks return False from `is_dir()` and
+        are silently skipped.
+      - A `PermissionError` on `iterdir()` (operator container reading
+        a stacks_root with restrictive parent perms, or a foreign-uid
+        host bind-mount) is caught and logged: the dashboard renders
+        with no stacks rather than 500. This matches the upstream-of-
+        gather() position — `StackHealth.error` only catches per-stack
+        failures, so the discovery layer must handle root-level OS
+        errors itself or the whole page goes blank.
     """
     if not stacks_root.is_dir():
         return []
 
+    try:
+        entries = sorted(stacks_root.iterdir())
+    except OSError as e:
+        logger.warning("admin_stacks.discover_stacks: cannot list %s: %s", stacks_root, e)
+        return []
+
     out: list[StackPath] = []
-    for entry in sorted(stacks_root.iterdir()):
+    for entry in entries:
         if not entry.is_dir():
             continue
         if not entry.name.startswith("findajob-"):

--- a/src/findajob/admin/stack_health.py
+++ b/src/findajob/admin/stack_health.py
@@ -94,7 +94,16 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
                     unread_notifications = 0
         except sqlite3.Error as e:
             error = f"sqlite: {e}"
-        except Exception as e:  # defensive — don't let one stack crash the page
+        except Exception as e:
+            # Intentionally broad. The narrower sqlite3.Error arm above
+            # covers DB-engine failures, but this gather() runs under a
+            # TOCTOU race (the stack's container can rotate the DB out
+            # from under us between is_file() and connect()) and against
+            # foreign-uid bind mounts whose surface includes raw OSError,
+            # PermissionError, and unicode failures from corrupted paths.
+            # The "one broken stack must not crash the dashboard" invariant
+            # is load-bearing here — do not narrow this arm without first
+            # filing a per-source coroutine refactor.
             logger.warning("admin_stacks: gather failed for %s: %s", stack.handle, e)
             error = f"{type(e).__name__}: {e}"
 
@@ -113,15 +122,20 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
             if ts is None:
                 continue
             ev = event.get("event")
+            # `ts > cutoff_24h` (strict) matches `_freshness` below, which
+            # uses `age < 24h` (strict) — both treat exactly-24h-ago as
+            # OUT of the window. Was `>=` before #359; the asymmetric
+            # case was never hit in production but the convention drift
+            # was real.
             if ev == "pipeline_complete":
                 if last_triage_complete is None:
                     last_triage_complete = ts
-                if ts >= cutoff_24h:
+                if ts > cutoff_24h:
                     success_24h += 1
             elif ev == "pipeline_terminated":
                 if last_triage_failed is None:
                     last_triage_failed = ts
-                if ts >= cutoff_24h:
+                if ts > cutoff_24h:
                     failure_24h += 1
             elif ev == "aichat_failure":
                 if last_aichat is None:
@@ -153,12 +167,22 @@ def gather(stack: StackPath, *, now: datetime | None = None) -> StackHealth:
 
 
 def _parse_ts(raw: object) -> datetime | None:
+    """Parse an ISO-8601 timestamp; coerce naïve values to UTC.
+
+    `findajob.utils.log_event` always emits tz-aware ISO strings, but a
+    hand-edited or older log file may contain naïve timestamps. Comparing
+    those against `cutoff_24h` (tz-aware) raises TypeError and crashes
+    the dashboard render. Coerce here so the comparison is always valid.
+    """
     if not isinstance(raw, str):
         return None
     try:
-        return datetime.fromisoformat(raw)
+        dt = datetime.fromisoformat(raw)
     except ValueError:
         return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
 
 
 def _freshness(last: datetime | None, now: datetime) -> Freshness:

--- a/tests/test_admin_jsonl_tail.py
+++ b/tests/test_admin_jsonl_tail.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+
+import pytest
 
 from findajob.admin.jsonl_tail import tail_events
 
@@ -56,6 +59,23 @@ def test_malformed_line_is_skipped(tmp_path: Path) -> None:
     )
     events = list(tail_events(p))
     assert [e["event"] for e in events] == ["pipeline_complete", "pipeline_started"]
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses chmod 0o000")
+def test_unreadable_file_returns_empty(tmp_path: Path) -> None:
+    """A chmod-0o000 JSONL (bind-mount perm flip / cross-uid) yields []
+    rather than raising PermissionError into the dashboard handler.
+    """
+    p = tmp_path / "locked.jsonl"
+    _write_events(
+        p,
+        [{"ts": "2026-04-30T00:00:00+00:00", "event": "pipeline_complete"}],
+    )
+    p.chmod(0o000)
+    try:
+        assert list(tail_events(p)) == []
+    finally:
+        p.chmod(0o644)  # let pytest clean up
 
 
 def test_partial_first_line_at_buffer_boundary_is_dropped(tmp_path: Path) -> None:

--- a/tests/test_admin_stack_discovery.py
+++ b/tests/test_admin_stack_discovery.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from findajob.admin.stack_discovery import StackPath, discover_stacks
 
@@ -57,6 +60,21 @@ def test_paths_resolve_to_state_subdirs(tmp_path: Path) -> None:
     assert s.root == tmp_path / "findajob-alice"
     assert s.db_path == tmp_path / "findajob-alice" / "state" / "data" / "pipeline.db"
     assert s.jsonl_path == tmp_path / "findajob-alice" / "state" / "logs" / "pipeline.jsonl"
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses chmod 0o000")
+def test_unreadable_root_returns_empty(tmp_path: Path) -> None:
+    """A stacks_root with restrictive perms (foreign-uid bind mount,
+    chmod-stripped parent) yields [] rather than 500-ing the dashboard.
+    """
+    root = tmp_path / "stacks"
+    root.mkdir()
+    _make_stack(root, "alice")
+    root.chmod(0o000)
+    try:
+        assert discover_stacks(root) == []
+    finally:
+        root.chmod(0o755)  # let pytest clean up
 
 
 def test_stackpath_is_frozen_dataclass(tmp_path: Path) -> None:

--- a/tests/test_admin_stack_health.py
+++ b/tests/test_admin_stack_health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import patch
 
 from findajob.admin.stack_discovery import StackPath
 from findajob.admin.stack_health import StackHealth, gather
@@ -161,3 +162,65 @@ def test_returns_stackhealth_dataclass(tmp_path: Path) -> None:
     sp = _stackpath(tmp_path)
     h = gather(sp, now=NOW)
     assert isinstance(h, StackHealth)
+
+
+def test_naive_timestamp_is_coerced_to_utc(tmp_path: Path) -> None:
+    """A naïve ISO timestamp (older log file or hand-edited entry) must
+    not crash the dashboard with a TypeError on comparison against the
+    tz-aware cutoff. Coerced to UTC and counted normally.
+    """
+    sp = _stackpath(tmp_path)
+    build_pipeline_db(sp.db_path)
+    naive = (NOW.replace(tzinfo=None) - timedelta(hours=10)).isoformat()
+    build_pipeline_jsonl(
+        sp.jsonl_path,
+        [{"ts": naive, "event": "pipeline_complete"}],
+    )
+    h = gather(sp, now=NOW)
+    assert h.last_triage_complete is not None
+    assert h.triage_success_24h == 1
+    assert h.freshness == "fresh"
+
+
+def test_connect_uri_includes_immutable_flag(tmp_path: Path) -> None:
+    """gather() MUST connect with `immutable=1` in the URI so cross-uid
+    bind-mount reads (operator container reading a tester DB owned by a
+    different host uid) don't fail on the WAL/shm sidecars whose perms
+    `mode=ro` alone doesn't relax.
+
+    Asserted via mock because tmp DBs are owned by the test process,
+    so a regression that drops `immutable=1` wouldn't surface in the
+    other tests in this file.
+    """
+    sp = _stackpath(tmp_path)
+    build_pipeline_db(sp.db_path)
+    build_pipeline_jsonl(sp.jsonl_path, [])
+
+    with patch("findajob.admin.stack_health.sqlite3.connect", wraps=__import__("sqlite3").connect) as mock_connect:
+        gather(sp, now=NOW)
+
+    assert mock_connect.called, "gather() did not call sqlite3.connect"
+    uri = mock_connect.call_args.args[0]
+    assert "immutable=1" in uri, f"sqlite3.connect URI lost immutable=1 flag: {uri!r}"
+    assert "mode=ro" in uri, f"sqlite3.connect URI lost mode=ro flag: {uri!r}"
+    assert mock_connect.call_args.kwargs.get("uri") is True
+
+
+def test_24h_window_excludes_exact_24h_boundary(tmp_path: Path) -> None:
+    """24h-window count uses strict `>`, matching `_freshness`'s strict
+    `<` (where exactly 24h ago is "late", not "fresh"). An event at
+    exactly the cutoff is out of the window.
+    """
+    sp = _stackpath(tmp_path)
+    build_pipeline_db(sp.db_path)
+    boundary = (NOW - timedelta(hours=24)).isoformat()
+    just_inside = (NOW - timedelta(hours=23, minutes=59)).isoformat()
+    build_pipeline_jsonl(
+        sp.jsonl_path,
+        [
+            {"ts": boundary, "event": "pipeline_complete"},
+            {"ts": just_inside, "event": "pipeline_complete"},
+        ],
+    )
+    h = gather(sp, now=NOW)
+    assert h.triage_success_24h == 1


### PR DESCRIPTION
## Summary
- Catches `OSError` (not just `FileNotFoundError`) in `jsonl_tail.tail_events` at both `getsize` + `open` so a chmod-stripped or mid-remount log file degrades to `[]` instead of 500-ing the dashboard.
- Catches `OSError` on `iterdir()` in `stack_discovery.discover_stacks` and returns `[]` + a `logger.warning` rather than blanking the page on a restrictive `stacks_root`. Symlink-following + the policy choice (catch+warn vs let-500) are now documented in the docstring.
- Coerces naïve ISO timestamps to UTC in `stack_health._parse_ts` so older or hand-edited log entries don't `TypeError` on the comparison against the tz-aware `cutoff_24h`.
- Resolves the `<` vs `>=` asymmetry in `stack_health.gather`: 24h-window event count now uses strict `>`, matching `_freshness`'s strict `<` (exactly-24h-ago is OUT of both windows).
- Annotates the broad `except Exception` arm with TOCTOU + cross-uid rationale so a future reviewer doesn't try to narrow it.

## Test plan
- [x] `uv run pytest tests/test_admin_*.py -v` — 39 passed (5 new regression tests added)
  - `test_unreadable_file_returns_empty` (chmod 0o000 jsonl)
  - `test_unreadable_root_returns_empty` (chmod 0o000 stacks_root)
  - `test_naive_timestamp_is_coerced_to_utc`
  - `test_connect_uri_includes_immutable_flag` (mock-based — tmp DBs are same-uid, would not catch a regression that drops `immutable=1`)
  - `test_24h_window_excludes_exact_24h_boundary`
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean

Operator-only impact (route is gated by `FINDAJOB_OPERATOR_MODE=1`); no schema, config, or compose changes.

Closes #359