### PR TITLE
test(admin): #360 tighten findajob.admin test hygiene + remove dead tuple

### DIFF
--- a/src/findajob/admin/stack_health.py
+++ b/src/findajob/admin/stack_health.py
@@ -15,8 +15,6 @@ logger = logging.getLogger(__name__)
 
 Freshness = Literal["fresh", "late", "stale", "unknown"]
 
-_FAILURE_EVENTS = ("aichat_failure", "discovery_failed", "prep_failed", "prep_failed_reset")
-
 
 @dataclass(frozen=True)
 class StackHealth:

--- a/tests/test_admin_jsonl_tail.py
+++ b/tests/test_admin_jsonl_tail.py
@@ -79,7 +79,9 @@ def test_unreadable_file_returns_empty(tmp_path: Path) -> None:
 
 
 def test_partial_first_line_at_buffer_boundary_is_dropped(tmp_path: Path) -> None:
-    """When the tail-window cuts mid-line, the partial first line is discarded."""
+    """When the tail-window cuts mid-line, the partial first line is discarded
+    AND the surviving complete event is yielded intact.
+    """
     p = tmp_path / "boundary.jsonl"
     # Two events; force max_bytes to land mid-first-line.
     events = [
@@ -91,6 +93,10 @@ def test_partial_first_line_at_buffer_boundary_is_dropped(tmp_path: Path) -> Non
     full = p.read_text()
     cut_at = len(full) - 100  # well into line 2
     out = list(tail_events(p, max_bytes=full[cut_at:].__len__() + 5))
-    # Whatever survives, every yielded entry must be valid JSON (no half-line).
-    for e in out:
-        assert isinstance(e, dict)
+    # Surviving event must be the complete second event, not [] and not the
+    # partial-first-line garbage. Asserting on the event field — not just
+    # `isinstance(e, dict)` — would catch a regression that yields [] or
+    # malformed-but-still-dict output.
+    assert len(out) == 1
+    assert out[0]["event"] == "pipeline_complete"
+    assert out[0]["ts"] == "2026-04-30T00:05:00+00:00"

--- a/tests/test_admin_stack_discovery.py
+++ b/tests/test_admin_stack_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import os
 from pathlib import Path
 
@@ -81,7 +82,9 @@ def test_stackpath_is_frozen_dataclass(tmp_path: Path) -> None:
     _make_stack(tmp_path, "alice")
     s = discover_stacks(tmp_path)[0]
     assert isinstance(s, StackPath)
-    # Frozen dataclasses raise on mutation.
-    import dataclasses
-
     assert dataclasses.is_dataclass(s)
+    # Frozen dataclasses raise FrozenInstanceError on field assignment.
+    # Without this assertion, dropping `frozen=True` on the @dataclass
+    # decorator would silently regress the immutability contract.
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        s.handle = "mutated"  # type: ignore[misc]

--- a/tests/test_admin_stack_health.py
+++ b/tests/test_admin_stack_health.py
@@ -224,3 +224,30 @@ def test_24h_window_excludes_exact_24h_boundary(tmp_path: Path) -> None:
     )
     h = gather(sp, now=NOW)
     assert h.triage_success_24h == 1
+
+
+def test_only_pipeline_terminated_leaves_freshness_unknown(tmp_path: Path) -> None:
+    """A stack that has started runs but never completed one (cron firing
+    but every triage crashing) must surface freshness="unknown" — not
+    "fresh" off the start event, not "stale" off some default. The
+    completion timestamp drives freshness; failures alone do not.
+    """
+    sp = _stackpath(tmp_path)
+    build_pipeline_db(sp.db_path)
+    recent = (NOW - timedelta(hours=2)).isoformat()
+    older = (NOW - timedelta(hours=14)).isoformat()
+    build_pipeline_jsonl(
+        sp.jsonl_path,
+        [
+            {"ts": older, "event": "pipeline_started"},
+            {"ts": older, "event": "pipeline_terminated"},
+            {"ts": recent, "event": "pipeline_started"},
+            {"ts": recent, "event": "pipeline_terminated"},
+        ],
+    )
+    h = gather(sp, now=NOW)
+    assert h.last_triage_complete is None
+    assert h.last_triage_failed is not None
+    assert h.freshness == "unknown"
+    assert h.triage_success_24h == 0
+    assert h.triage_failure_24h == 2

--- a/tests/test_admin_stacks_route.py
+++ b/tests/test_admin_stacks_route.py
@@ -180,18 +180,37 @@ def test_basic_auth_inherited_when_set(tmp_path: Path, monkeypatch: pytest.Monke
 
 
 def test_render_under_2s(operator_app, tmp_path: Path) -> None:
-    """Performance budget per spec §4.6 — <2s for 6 stacks."""
+    """Performance budget per spec §4.6 — <2s for 6 stacks even with multi-MB
+    pipeline.jsonl files. The bounded-tail design (tail_events max_bytes=1MB)
+    is what makes this hold; seeding ~6MB JSONL per stack proves it instead
+    of running the test against trivial fixtures (the previous 500-event ~30KB
+    files exercised the happy path without proving the bound matters).
+
+    Operator's stack pipeline.jsonl was ~10MB on 2026-04-30; long-running
+    tester stacks will land in the same range.
+    """
+    import json
     import time
 
     stacks = tmp_path / "stacks"
     stacks.mkdir()
+    # ~61 bytes/line × 90_000 ≈ 5.5 MB per stack. String-multiply instead of
+    # json.dumps-per-event to keep setup cost out of the perf measurement.
+    filler_line = json.dumps({"ts": "2026-04-30T11:00:00+00:00", "event": "watchdog_run"}) + "\n"
+    filler_block = filler_line * 90_000
+    completion_line = json.dumps({"ts": "2026-04-30T11:30:00+00:00", "event": "pipeline_complete"}) + "\n"
+
     for h in ("alice", "dave", "ed", "judy", "papa", "tango"):
         sp_root = stacks / f"findajob-{h}" / "state"
         rows = [{"id": f"{h}-{i}", "stage": "scored"} for i in range(50)]
         build_pipeline_db(sp_root / "data" / "pipeline.db", rows=rows)
-        events = [{"ts": "2026-04-30T11:00:00+00:00", "event": "watchdog_run"} for _ in range(500)]
-        events.append({"ts": "2026-04-30T11:30:00+00:00", "event": "pipeline_complete"})
-        build_pipeline_jsonl(sp_root / "logs" / "pipeline.jsonl", events)
+        jsonl_path = sp_root / "logs" / "pipeline.jsonl"
+        jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+        # Completion event LAST so newest-first tail starts there and freshness
+        # is computed without reading the whole file.
+        jsonl_path.write_text(filler_block + completion_line)
+        # Sanity: prove fixture actually produced multi-MB files.
+        assert jsonl_path.stat().st_size > 5_000_000, f"fixture for {h} only {jsonl_path.stat().st_size} bytes"
 
     client = TestClient(operator_app)
     t0 = time.perf_counter()


### PR DESCRIPTION
## Summary
- **Frozen-dataclass test now actually proves frozen-ness.** `test_stackpath_is_frozen_dataclass` adds `pytest.raises(dataclasses.FrozenInstanceError)` on a field assignment, so dropping `frozen=True` from the decorator would fail the test. Previously it only checked `isinstance` + `is_dataclass` — both true regardless of frozen-ness.
- **Boundary test no longer passes when the function yields `[]`.** `test_partial_first_line_at_buffer_boundary_is_dropped` now asserts `out[0]["event"] == "pipeline_complete"` and `len(out) == 1` instead of just `isinstance(e, dict)`. Strictly stronger assertion.
- **New test for the "started but never completed" scenario.** `test_only_pipeline_terminated_leaves_freshness_unknown` seeds JSONL with only `pipeline_terminated` events and asserts `last_triage_complete is None` + `freshness == "unknown"`. No existing test exercised this path.
- **Perf-budget realism.** `test_render_under_2s` now writes ~5.5MB JSONL per stack (90K filler events × 6 stacks), proving the bounded-tail design (`tail_events` `max_bytes=1MB`) holds the 2s budget on production-sized files. Operator's `pipeline.jsonl` was ~10MB on 2026-04-30; the old test's ~30KB fixtures only exercised the happy path. String-multiplied to keep setup cost out of the perf measurement.
- **Dead code removed.** `_FAILURE_EVENTS` tuple in `findajob.admin.stack_health` was defined but unreferenced (the `elif` chain inlines the strings); deleted.
- **AC `flagged_at` no-op.** The `flagged_at` column AC item targeted `tests/conftest_admin.py`'s `_JOBS_SCHEMA`, but the schema only declares `id`, `stage`, `stage_updated`. Likely cleaned up in an earlier PR.

## Test plan
- [x] `uv run pytest tests/test_admin_*.py` — 35 passed (1 modified, 1 new)
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] Sanity assertion in perf test verifies fixture actually produces multi-MB files (`> 5_000_000` bytes); failure mode is loud, not silent.

## Stacking note
Cut from `origin/main`, not from `feat/359-admin-error-paths`. Touches the same files but on different lines — clean rebase if #453 lands first.

Closes #360