### PR TITLE
fix: #87 poll_openrouter_credits crashed every cron tick (BASE is str, not Path)

### DIFF
--- a/scripts/poll_openrouter_credits.py
+++ b/scripts/poll_openrouter_credits.py
@@ -157,7 +157,7 @@ def main() -> int:
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
-    db_path = BASE / "data" / "pipeline.db"
+    db_path = Path(BASE) / "data" / "pipeline.db"
     conn = sqlite3.connect(str(db_path))
     try:
         poll_once(conn)

--- a/tests/test_poll_openrouter_credits.py
+++ b/tests/test_poll_openrouter_credits.py
@@ -119,3 +119,34 @@ def test_poll_no_ops_on_missing_key(db: sqlite3.Connection, monkeypatch: pytest.
     # We DO record the missing-key state so /admin/ surfaces can show "no key configured".
     assert len(rows) == 1
     assert rows[0]["poll_status"] == "missing_key"
+
+
+def test_main_resolves_db_path_against_BASE_str(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for #87: findajob.paths.BASE is a str (not a Path), so
+    main() must wrap in Path() before path-joining. The original main()
+    used `BASE / "data" / ...` which raised TypeError every cron tick in
+    production, leaving cost_calibration empty post-merge."""
+    db_path = tmp_path / "data" / "pipeline.db"
+    db_path.parent.mkdir()
+    subprocess.run(
+        [sys.executable, "scripts/init_db.py", str(db_path)],
+        check=True,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+
+    from scripts import poll_openrouter_credits
+
+    monkeypatch.setattr(poll_openrouter_credits, "BASE", str(tmp_path))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    rc = poll_openrouter_credits.main()
+    assert rc == 0
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute("SELECT poll_status FROM cost_calibration").fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0]["poll_status"] == "missing_key"

--- a/tests/test_poll_openrouter_credits.py
+++ b/tests/test_poll_openrouter_credits.py
@@ -121,9 +121,7 @@ def test_poll_no_ops_on_missing_key(db: sqlite3.Connection, monkeypatch: pytest.
     assert rows[0]["poll_status"] == "missing_key"
 
 
-def test_main_resolves_db_path_against_BASE_str(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_resolves_db_path_against_BASE_str(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression for #87: findajob.paths.BASE is a str (not a Path), so
     main() must wrap in Path() before path-joining. The original main()
     used `BASE / "data" / ...` which raised TypeError every cron tick in


### PR DESCRIPTION
## Summary
Hotfix for #87 (PR #464). `findajob.paths.BASE` is a `str`, but `scripts/poll_openrouter_credits.py:main()` did `BASE / "data" / "pipeline.db"` — Python's `/` operator on two strings raises `TypeError`. Result: every 5-min cron tick crashed before reaching the OpenRouter HTTP call, and `cost_calibration` stayed empty post-deploy.

The unit tests covered `poll_once(conn)` directly with a fake connection, so the bug at the `main()` boundary slipped through.

## Fix
- One-line: `db_path = Path(BASE) / "data" / "pipeline.db"`
- Added regression test `test_main_resolves_db_path_against_BASE_str` that monkeypatches `BASE` to a tmp dir and exercises `main()` end-to-end.

## Test plan
- [x] `tests/test_poll_openrouter_credits.py` — 5/5 pass (4 existing + new regression)
- [ ] Post-merge: pull `:latest` on operator's stack, wait 5 min, verify a `cost_calibration` row lands with `poll_status='ok'` and `multiplier ≈ 1.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)