### PR TITLE
fix: #467 calibration uses windowed delta, not lifetime cumulatives

### DIFF
--- a/scripts/poll_openrouter_credits.py
+++ b/scripts/poll_openrouter_credits.py
@@ -31,6 +31,7 @@ OPENROUTER_CREDITS_URL = "https://openrouter.ai/api/v1/credits"
 HTTP_TIMEOUT_S = 30
 MULTIPLIER_MIN = 0.5
 MULTIPLIER_MAX = 3.0
+WINDOW_DAYS = 7
 
 
 class OpenRouterHTTPError(Exception):
@@ -68,6 +69,56 @@ def _fetch_credits(api_key: str) -> dict[str, float]:
 
 def _heuristic_sum(conn: sqlite3.Connection) -> float:
     row = conn.execute("SELECT COALESCE(SUM(cost_usd), 0) FROM cost_log WHERE cost_usd IS NOT NULL").fetchone()
+    return float(row[0])
+
+
+def _window_baseline(conn: sqlite3.Connection, days: int) -> dict[str, float] | None:
+    """Most recent 'ok' cost_calibration row at least `days` days old.
+
+    Returns {'credits_used_usd': X, 'onboarding_total_usd': Y} or None
+    when no eligible row exists (warming-up state).
+    """
+    row = conn.execute(
+        """SELECT credits_used_usd, onboarding_total_usd
+           FROM cost_calibration
+           WHERE poll_status = 'ok'
+             AND polled_at <= datetime('now', '-' || ? || ' days')
+           ORDER BY id DESC LIMIT 1""",
+        (days,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "credits_used_usd": float(row[0] or 0.0),
+        "onboarding_total_usd": float(row[1] or 0.0),
+    }
+
+
+def _heuristic_sum_windowed(conn: sqlite3.Connection, days: int) -> float:
+    """SUM(cost_log.cost_usd) for cost_usd IS NOT NULL rows logged within the window."""
+    row = conn.execute(
+        """SELECT COALESCE(SUM(cost_usd), 0)
+           FROM cost_log
+           WHERE cost_usd IS NOT NULL
+             AND logged_at >= datetime('now', '-' || ? || ' days')""",
+        (days,),
+    ).fetchone()
+    return float(row[0])
+
+
+def _last_good_multiplier(conn: sqlite3.Connection) -> float | None:
+    """Most recent cost_calibration.multiplier where poll_status='ok'.
+
+    Used to inherit the multiplier on sparse-week polls
+    (no new heuristic activity in the window).
+    """
+    row = conn.execute(
+        """SELECT multiplier FROM cost_calibration
+           WHERE poll_status = 'ok' AND multiplier IS NOT NULL
+           ORDER BY id DESC LIMIT 1"""
+    ).fetchone()
+    if row is None or row[0] is None:
+        return None
     return float(row[0])
 
 
@@ -128,16 +179,43 @@ def poll_once(conn: sqlite3.Connection) -> None:
         return
 
     onboarding_total = _onboarding_total(conn)
-    heuristic_sum = _heuristic_sum(conn)
-    pipeline_actual = max(0.0, credits["total_usage"] - onboarding_total)
+    heuristic_sum = _heuristic_sum(conn)  # lifetime, stored for observability
+    pipeline_actual_lifetime = max(0.0, credits["total_usage"] - onboarding_total)
 
-    if heuristic_sum <= 0:
-        multiplier_raw = 1.0
+    # Windowed delta math (#467) — replaces lifetime-cumulative comparison.
+    baseline = _window_baseline(conn, WINDOW_DAYS)
+
+    if baseline is None:
+        # No `WINDOW_DAYS`-old 'ok' row exists yet — warming up.
+        # Store this row as future baseline; surfaces render uncalibrated.
+        _insert_row(
+            conn,
+            poll_status="warming_up",
+            credits_total=credits["total_credits"],
+            credits_used=credits["total_usage"],
+            onboarding_total=onboarding_total,
+            pipeline_actual=pipeline_actual_lifetime,
+            heuristic_sum=heuristic_sum,
+            multiplier=1.0,
+            multiplier_clamped=0,
+        )
+        return
+
+    delta_credits = max(0.0, credits["total_usage"] - baseline["credits_used_usd"])
+    delta_onboarding = max(0.0, onboarding_total - baseline["onboarding_total_usd"])
+    pipeline_actual_window = max(0.0, delta_credits - delta_onboarding)
+    heuristic_window = _heuristic_sum_windowed(conn, WINDOW_DAYS)
+
+    if heuristic_window <= 0:
+        # Sparse week — no prep activity in the window. Inherit last good
+        # multiplier rather than emitting a clamped/garbage value.
+        last_mult = _last_good_multiplier(conn)
+        multiplier = last_mult if last_mult is not None else 1.0
+        multiplier_clamped = 0
     else:
-        multiplier_raw = pipeline_actual / heuristic_sum
-
-    multiplier = max(MULTIPLIER_MIN, min(MULTIPLIER_MAX, multiplier_raw))
-    multiplier_clamped = 1 if multiplier != multiplier_raw else 0
+        multiplier_raw = pipeline_actual_window / heuristic_window
+        multiplier = max(MULTIPLIER_MIN, min(MULTIPLIER_MAX, multiplier_raw))
+        multiplier_clamped = 1 if multiplier != multiplier_raw else 0
 
     _insert_row(
         conn,
@@ -145,8 +223,8 @@ def poll_once(conn: sqlite3.Connection) -> None:
         credits_total=credits["total_credits"],
         credits_used=credits["total_usage"],
         onboarding_total=onboarding_total,
-        pipeline_actual=pipeline_actual,
-        heuristic_sum=heuristic_sum,
+        pipeline_actual=pipeline_actual_lifetime,  # lifetime, for next poll's baseline
+        heuristic_sum=heuristic_sum,  # lifetime, observability
         multiplier=multiplier,
         multiplier_clamped=multiplier_clamped,
     )

--- a/src/findajob/cost_rollups.py
+++ b/src/findajob/cost_rollups.py
@@ -27,7 +27,7 @@ class Calibration:
     credits_remaining_usd: float | None
     multiplier: float
     multiplier_clamped: bool
-    poll_status: str  # 'ok' | 'stale' | 'http_error' | 'timeout' | 'missing_key'
+    poll_status: str  # 'ok' | 'stale' | 'warming_up' | 'http_error' | 'timeout' | 'missing_key'
 
 
 def current_calibration(conn: sqlite3.Connection) -> Calibration | None:

--- a/tests/test_poll_openrouter_credits.py
+++ b/tests/test_poll_openrouter_credits.py
@@ -45,7 +45,36 @@ def _seed_heuristic(conn: sqlite3.Connection, total: float) -> None:
     conn.commit()
 
 
-def test_poll_inserts_calibration_row_with_subtraction(
+def _seed_calibration_baseline(
+    conn: sqlite3.Connection,
+    *,
+    days_ago: int,
+    credits_used_usd: float,
+    onboarding_total_usd: float = 0.0,
+    multiplier: float = 1.0,
+) -> None:
+    conn.execute(
+        """INSERT INTO cost_calibration
+           (polled_at, credits_total_usd, credits_used_usd, credits_remaining_usd,
+            onboarding_total_usd, pipeline_actual_usd, heuristic_sum_usd,
+            multiplier, multiplier_clamped, poll_status)
+           VALUES (datetime('now', '-' || ? || ' days'),
+                   100.0, ?, 100.0 - ?,
+                   ?, ?, 0.0,
+                   ?, 0, 'ok')""",
+        (
+            days_ago,
+            credits_used_usd,
+            credits_used_usd,
+            onboarding_total_usd,
+            credits_used_usd - onboarding_total_usd,
+            multiplier,
+        ),
+    )
+    conn.commit()
+
+
+def test_poll_warming_up_when_no_baseline(
     db: sqlite3.Connection, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from scripts import poll_openrouter_credits
@@ -62,20 +91,22 @@ def test_poll_inserts_calibration_row_with_subtraction(
         poll_openrouter_credits.poll_once(db)
 
     row = db.execute("SELECT * FROM cost_calibration ORDER BY id DESC LIMIT 1").fetchone()
-    assert row["poll_status"] == "ok"
-    assert row["credits_remaining_usd"] == pytest.approx(67.86, rel=1e-3)
-    assert row["onboarding_total_usd"] == pytest.approx(4.50, rel=1e-3)
-    # pipeline_actual = 32.14 - 4.50 = 27.64
-    assert row["pipeline_actual_usd"] == pytest.approx(27.64, rel=1e-3)
-    # multiplier = 27.64 / 21.26 ≈ 1.3
-    assert row["multiplier"] == pytest.approx(1.3, abs=0.05)
+    assert row["poll_status"] == "warming_up"
+    assert row["multiplier"] == pytest.approx(1.0, rel=1e-3)
     assert row["multiplier_clamped"] == 0
+    assert row["credits_remaining_usd"] == pytest.approx(67.86, rel=1e-3)
+    # pipeline_actual = 32.14 - 4.50 = 27.64 (lifetime, stored for next baseline)
+    assert row["pipeline_actual_usd"] == pytest.approx(27.64, rel=1e-3)
 
 
 def test_poll_clamps_extreme_multiplier(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
     from scripts import poll_openrouter_credits
 
-    _seed_heuristic(db, 1.00)  # tiny heuristic → big multiplier
+    # baseline 8 days ago: credits_used = $0
+    _seed_calibration_baseline(db, days_ago=8, credits_used_usd=0.0)
+    # current credits_used = $50 → delta = $50
+    # cost_log $1 in last 7 days → heuristic_window = $1 → raw = 50, clamped to 3.0
+    _seed_heuristic(db, 1.00)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
 
     with patch.object(
@@ -85,7 +116,7 @@ def test_poll_clamps_extreme_multiplier(db: sqlite3.Connection, monkeypatch: pyt
     ):
         poll_openrouter_credits.poll_once(db)
 
-    row = db.execute("SELECT * FROM cost_calibration ORDER BY id DESC LIMIT 1").fetchone()
+    row = db.execute("SELECT * FROM cost_calibration WHERE poll_status='ok' ORDER BY id DESC LIMIT 1").fetchone()
     # Raw multiplier = 50, clamped to 3.0
     assert row["multiplier"] == pytest.approx(3.0, rel=1e-3)
     assert row["multiplier_clamped"] == 1
@@ -119,6 +150,62 @@ def test_poll_no_ops_on_missing_key(db: sqlite3.Connection, monkeypatch: pytest.
     # We DO record the missing-key state so /admin/ surfaces can show "no key configured".
     assert len(rows) == 1
     assert rows[0]["poll_status"] == "missing_key"
+
+
+def test_poll_uses_windowed_delta_when_baseline_exists(db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With a baseline row 8 days old, multiplier reflects 7-day deltas, not lifetime."""
+    from scripts import poll_openrouter_credits
+
+    # 8-day-old baseline: credits_used was $20 then.
+    _seed_calibration_baseline(db, days_ago=8, credits_used_usd=20.0, multiplier=1.0)
+
+    # Current state: credits_used = $30 → 7-day delta ≈ $10.
+    # Heuristic in last 7 days: one $5 cost_log row.
+    db.execute(
+        """INSERT INTO cost_log (job_id, operation, model, cost_usd, success, logged_at)
+           VALUES (NULL, 'briefing', 'm', 5.0, 1, datetime('now', '-1 day'))"""
+    )
+    db.commit()
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    with patch.object(
+        poll_openrouter_credits,
+        "_fetch_credits",
+        return_value={"total_credits": 100.0, "total_usage": 30.0},
+    ):
+        poll_openrouter_credits.poll_once(db)
+
+    row = db.execute("SELECT * FROM cost_calibration WHERE poll_status='ok' ORDER BY id DESC LIMIT 1").fetchone()
+    # delta_credits = 30 - 20 = 10; heuristic_window = 5 → multiplier = 2.0
+    assert row["multiplier"] == pytest.approx(2.0, abs=0.05)
+    assert row["multiplier_clamped"] == 0
+
+
+def test_poll_inherits_last_good_multiplier_when_window_sparse(
+    db: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When heuristic_window is 0 (no recent prep), multiplier inherits last good 'ok' value."""
+    from scripts import poll_openrouter_credits
+
+    # 8-day baseline + a recent 'ok' row with multiplier=1.5
+    _seed_calibration_baseline(db, days_ago=8, credits_used_usd=10.0)
+    _seed_calibration_baseline(db, days_ago=2, credits_used_usd=20.0, multiplier=1.5)
+    # No cost_log rows → heuristic_window = 0
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    with patch.object(
+        poll_openrouter_credits,
+        "_fetch_credits",
+        return_value={"total_credits": 100.0, "total_usage": 25.0},
+    ):
+        poll_openrouter_credits.poll_once(db)
+
+    row = db.execute(
+        """SELECT * FROM cost_calibration
+           WHERE poll_status = 'ok' ORDER BY id DESC LIMIT 1"""
+    ).fetchone()
+    assert row["multiplier"] == pytest.approx(1.5, abs=1e-6)
+    assert row["multiplier_clamped"] == 0
 
 
 def test_main_resolves_db_path_against_BASE_str(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Fixes #467. Replaces the lifetime-cumulative comparison in `scripts/poll_openrouter_credits.py:poll_once` with rolling 7-day windowed-delta math.

The first calibration row on the operator's stack post-deploy clamped at 3.0× immediately because OpenRouter's \`/api/v1/credits\` returns lifetime \`total_usage\` (~$88) but \`cost_log\` only has a few days of post-#48 history (~$14). The fix compares deltas over the same 7-day window:

- **Baseline:** most recent \`ok\` calibration row at least 7 days old.
- **Numerator:** \`(current_credits_used - baseline_credits_used) - (current_onboarding - baseline_onboarding)\`.
- **Denominator:** \`SUM(cost_log.cost_usd)\` from the last 7 days.

## States added
- \`poll_status='warming_up'\` for first-poll on a stack (no 7-day-prior baseline). UI surfaces fall through to no-chip, same as \`missing_key\`. Multiplier=1.0 (uncalibrated).
- Sparse-week handling: when \`heuristic_window <= 0\` (no prep activity in the window), inherit the last good multiplier instead of emitting a clamped/garbage value.

## Migration
None. Schema unchanged. Existing rows from the lifetime-math era can stay; the new logic just looks back 7 days. After this fix lands, each stack's first poll resets to \`warming_up\` until 7 days of history accumulate.

## Test plan
- [x] \`tests/test_poll_openrouter_credits.py\` — 7/7 pass: warming_up, windowed-delta correctness, sparse-week inheritance, clamp boundary, http_error, missing_key, BASE-Path regression.
- [x] \`tests/test_cost_rollups.py\` — 12/12 pass (no consumer changes).
- [ ] Post-merge: pull \`:latest\`, observe \`poll_status='warming_up'\` for ~7 days, then \`ok\` with sane multiplier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)