### PR TITLE
fix: #473 archive Promote button for user-rejected jobs

### DIFF
--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -27,6 +27,7 @@ from findajob.actions import (
     handle_waitlist,
     notify_waitlist_resurface,
     promote_to_scored,
+    un_reject_job,
 )
 from findajob.paths import BASE
 from findajob.utils import is_synthetic_job, log_event, write_audit
@@ -436,6 +437,36 @@ def promote(
     if job["stage"] not in _PROMOTABLE_STAGES:
         raise HTTPException(status_code=409, detail="Job is not promotable from its current stage")
     promote_to_scored(db, job, reason="Promoted from web UI")
+    return HTMLResponse("")
+
+
+def _fetch_un_reject_job(db: sqlite3.Connection, fingerprint: str) -> sqlite3.Row | None:
+    """un_reject_job reads prep_folder_path and reject_reason off the row."""
+    return db.execute(
+        "SELECT id, fingerprint, title, company, url, stage, prep_folder_path, reject_reason "
+        "FROM jobs WHERE fingerprint=?",
+        (fingerprint,),
+    ).fetchone()
+
+
+@router.post("/board/jobs/{fingerprint}/un-reject", response_class=HTMLResponse)
+def un_reject(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Reverse a user rejection of a job — clears the feedback_log row,
+    restores stage='scored', moves the prep folder out of _rejected/, sets
+    relevance_score=8. Only valid for stage='rejected' (user rejection);
+    rows at stage='not_selected' (company rejection) cannot be revived
+    this way and return 409.
+    """
+    job = _fetch_un_reject_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] != "rejected":
+        raise HTTPException(status_code=409, detail="Only user-rejected jobs can be un-rejected")
+    un_reject_job(db, job, overwrite_fields={})
     return HTMLResponse("")
 
 

--- a/src/findajob/web/templates/board/_archive_promote_cell.html
+++ b/src/findajob/web/templates/board/_archive_promote_cell.html
@@ -1,8 +1,16 @@
 {#
-  Archive-tab-only: Promote action cell. Renders a button for rows at
-  stage='scored' — clicking bumps relevance_score to 7 so the row
-  surfaces on the Dashboard for a Flag for Prep decision. Empty cell
-  for rows already past that stage.
+  Archive-tab-only: Promote action cell. Renders a button for two stages:
+
+  - stage='scored': POSTs to /promote — bumps relevance_score to 7 so the row
+    surfaces on the Dashboard for a Flag for Prep decision.
+  - stage='rejected' (user-rejected): POSTs to /un-reject — restores stage to
+    scored, sets score=8, deletes the feedback_log row, moves the prep folder
+    out of _rejected/. Different route because un_reject_job has side effects
+    (feedback_log delete) that promote_to_scored does not.
+
+  stage='not_selected' (company-rejected) intentionally has no button — it's
+  a closed application, not a state to revive.
+
   Inputs: row — sqlite3.Row with fingerprint + stage.
 #}
 <td class="px-3 py-1 align-top text-sm whitespace-nowrap">
@@ -12,5 +20,12 @@
             hx-post="/board/jobs/{{ row.fingerprint }}/promote"
             hx-target="closest tr"
             hx-swap="outerHTML">Promote</button>
+  {% elif row.stage == 'rejected' %}
+    <button type="button"
+            class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+            hx-post="/board/jobs/{{ row.fingerprint }}/un-reject"
+            hx-target="closest tr"
+            hx-swap="outerHTML"
+            title="Restore: clears feedback_log entry, score=8, stage=scored">Promote</button>
   {% endif %}
 </td>

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -280,6 +280,7 @@ def test_router_registered_on_app(client: TestClient):
         "waitlist",
         "reactivate",
         "promote",
+        "un-reject",
         "reject",
         "not-selected",
         "regenerate",
@@ -837,6 +838,105 @@ class TestPromote:
 
     def test_404_on_unknown_fingerprint(self, client: TestClient):
         response = client.post("/board/jobs/fp_nonexistent/promote")
+        assert response.status_code == 404
+
+
+# ── /un-reject handler ────────────────────────────────────────────────────
+
+
+def _seed_user_rejected_job(
+    client: TestClient,
+    fingerprint: str,
+    *,
+    with_folder: bool = False,
+    with_feedback: bool = True,
+) -> Path | None:
+    """Seed a stage='rejected' row with the side effects a real user rejection
+    would leave behind: a feedback_log row and (optionally) a folder under
+    companies/_rejected/."""
+    conn = sqlite3.connect(client._db_path)
+    _insert_job(conn, fingerprint=fingerprint, stage="rejected", score=4)
+    job_id = conn.execute("SELECT id FROM jobs WHERE fingerprint=?", (fingerprint,)).fetchone()[0]
+    folder_path: Path | None = None
+    if with_folder:
+        folder_path = client._tmp_path / "companies" / "_rejected" / f"Acme_Ops_{fingerprint}"
+        folder_path.mkdir(parents=True)
+        (folder_path / "resume.pdf").touch()
+        conn.execute(
+            "UPDATE jobs SET prep_folder_path=?, reject_reason='Wrong domain' WHERE id=?",
+            (str(folder_path), job_id),
+        )
+    else:
+        conn.execute("UPDATE jobs SET reject_reason='Wrong domain' WHERE id=?", (job_id,))
+    if with_feedback:
+        conn.execute(
+            "INSERT INTO feedback_log (job_id, title, company, relevance_score, reject_reason, jd_excerpt) "
+            "VALUES (?, 'Senior Ops', 'Acme Corp', 4, 'Wrong domain', '')",
+            (job_id,),
+        )
+    conn.commit()
+    conn.close()
+    return folder_path
+
+
+class TestUnReject:
+    def test_happy_path_without_folder(self, client: TestClient):
+        _seed_user_rejected_job(client, "fp_user_rej")
+
+        response = client.post("/board/jobs/fp_user_rej/un-reject")
+
+        assert response.status_code == 200
+        assert response.text == ""
+
+        conn = sqlite3.connect(client._db_path)
+        row = conn.execute(
+            "SELECT stage, relevance_score, reject_reason FROM jobs WHERE fingerprint='fp_user_rej'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "scored"
+        assert row[1] == 8
+        assert row[2] == ""
+
+        # feedback_log row removed so the scorer's feedback loop stays clean
+        assert _fetch_feedback(client, "fp_user_rej") == []
+
+        audit = _fetch_audit(client, "fp_user_rej")
+        assert any(a == ("stage", "rejected", "scored") for a in audit)
+
+    def test_happy_path_restores_folder(self, client: TestClient):
+        """Folder under companies/_rejected/ is moved back to companies/."""
+        rejected_folder = _seed_user_rejected_job(client, "fp_user_rej_f", with_folder=True)
+        assert rejected_folder is not None
+
+        client.post("/board/jobs/fp_user_rej_f/un-reject")
+
+        conn = sqlite3.connect(client._db_path)
+        new_path = conn.execute("SELECT prep_folder_path FROM jobs WHERE fingerprint='fp_user_rej_f'").fetchone()[0]
+        conn.close()
+        assert "_rejected" not in new_path
+        assert Path(new_path).is_dir()
+        assert not rejected_folder.exists()
+
+    def test_409_on_company_not_selected(self, client: TestClient):
+        """stage='not_selected' (company rejection) cannot be un-rejected — only user rejection."""
+        conn = sqlite3.connect(client._db_path)
+        _insert_job(conn, fingerprint="fp_not_sel", stage="not_selected")
+        conn.close()
+
+        response = client.post("/board/jobs/fp_not_sel/un-reject")
+
+        assert response.status_code == 409
+        assert _fetch_stage(client, "fp_not_sel") == "not_selected"
+
+    def test_409_on_scored_stage(self, client: TestClient):
+        """A scored row uses /promote, not /un-reject — gate on stage='rejected' only."""
+        response = client.post("/board/jobs/fp_scored/un-reject")
+
+        assert response.status_code == 409
+        assert _fetch_stage(client, "fp_scored") == "scored"
+
+    def test_404_on_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/un-reject")
         assert response.status_code == 404
 
 


### PR DESCRIPTION
## Summary
- Adds `POST /board/jobs/{fp}/un-reject` and renders a Promote button on Archive rows where `stage='rejected'` (user-rejected before applying).
- Wires the existing `un_reject_job` action into the UI — it already does the right thing on the manual-ingest path (clears `feedback_log`, moves folder out of `_rejected/`, sets `relevance_score=8`); it just had no one-click button.
- `stage='not_selected'` (company rejection) intentionally has no button — that's a closed application, not a state to revive.

Closes #473

## Why a separate route from `/promote`
`un_reject_job` deletes the originating `feedback_log` row so the scorer's training signal stays honest. `promote_to_scored` does not. Routing both through `/promote` would either silently clear feedback rows for the existing scored→7 path or leave a stale rejection in feedback_log when un-rejecting.

## Test plan
- [x] `tests/test_board_actions.py::TestUnReject` — 5 cases: happy path with/without folder, 409 on `not_selected`, 409 on `scored`, 404 on unknown fingerprint.
- [x] Smoke test of router registration updated to include `un-reject`.
- [x] `uv run pytest tests/test_board_actions.py tests/test_actions.py tests/test_web_board_archive.py tests/test_web_board_rejected.py` — 117 pass.
- [x] `uv run ruff check`, `ruff format --check`, `mypy src/findajob/web/routes/board_actions.py` — clean.
- [ ] Manual verification on findajob-brock: open the archive URL for the Senior TPM AI Infra row, confirm Promote button appears, click, confirm row leaves archive and lands on dashboard with score=8 and stage=scored, confirm `feedback_log` row is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)