### PR TITLE
fix: #475 nav bell missing ml-auto when credits chip absent

### DIFF
--- a/src/findajob/web/templates/_nav.html
+++ b/src/findajob/web/templates/_nav.html
@@ -36,8 +36,13 @@
     {# #87 — credits-remaining chip; replaces legacy onboarding-cost chip. #}
     {% include "_nav_credits.html" %}
     {# Notifications bell — links to /notifications/, polls /notifications/badge
-       every 60s for the unread count. #440 #}
-    <li class="{% if current_calibration_for_template is not defined %}ml-auto{% endif %}">
+       every 60s for the unread count. #440. ml-auto here pushes the right-cluster
+       (chip when present, bell, Admin) to the nav's right edge whenever the credits
+       chip is absent — _nav_credits.html only emits an <li> for poll_status='ok' or
+       'stale', so we can't rely on it to anchor the layout. Putting ml-auto on both
+       is safe: a second auto-margin in a flex row collapses to 0 once the first one
+       has consumed remaining space (#475). #}
+    <li class="ml-auto">
       <a href="/notifications/"
          class="px-2 py-1 rounded inline-flex items-center {% if operator_mode %}hover:bg-rose-800{% else %}hover:bg-slate-700{% endif %}"
          aria-label="Notifications"

--- a/tests/test_web_nav.py
+++ b/tests/test_web_nav.py
@@ -85,3 +85,10 @@ def test_nav_omits_credits_chip_on_fresh_stack(client: TestClient, tmp_path: Pat
     assert "nav-credits" not in r.text
     # The legacy "$X.XX onboarding" badge is fully retired.
     assert "$0.00 onboarding" not in r.text
+    # #475 regression: the bell <li> must carry ml-auto so the right-cluster
+    # (bell + Admin) is pushed to the nav's right edge even when the chip's
+    # own ml-auto-bearing <li> isn't rendered. The previous fallback tested
+    # `current_calibration_for_template is not defined` against an
+    # unconditionally-registered Jinja global — a tautology that left the bell
+    # with class="" and visibly collapsed the nav into the group links.
+    assert "ml-auto" in r.text


### PR DESCRIPTION
## Summary

- Layout regression in the top nav introduced by #464 (cost chip): `_nav_credits.html` only emits an `<li>` for `poll_status` of `'ok'` or `'stale'`, leaving the bell + Admin link visibly jammed against the group links in `'warming_up'`, `'http_error'`, `'timeout'`, `'missing_key'`, or empty-table states.
- Root cause: `_nav.html:40` tried to fall back to `ml-auto` on the bell when no chip rendered, but the test was `current_calibration_for_template is not defined` against a Jinja global registered unconditionally in `app.py:73` — always-false. `<li class="">` resulted.
- Fix: always carry `ml-auto` on the bell. Two consecutive auto-margin flex items resolve harmlessly; chip's own `ml-auto` is preserved.
- Verified on operator's stack (`findajob-brock`, `:latest`) — currently in `warming_up` and visibly broken.

## Test plan

- [x] `uv run pytest tests/test_web_nav.py tests/test_web_notifications.py -q` — 15 pass.
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] Existing `test_nav_omits_credits_chip_on_fresh_stack` extended with `ml-auto` presence assertion to lock in the no-chip layout invariant.
- [ ] After merge → auto-deploy → `docker compose pull` on findajob-brock and findajob-test → curl rendered nav, confirm bell `<li class="ml-auto">`.

Closes #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)