### PR TITLE
refactor: #480 wrapper-port polish bundle (post-#471)

### DIFF
--- a/scripts/prep_application.py
+++ b/scripts/prep_application.py
@@ -40,15 +40,15 @@ load_env()
 
 
 def run_role(
-    role,
-    prompt,
+    role: str,
+    prompt: str,
     *,
-    cached_prefix=None,
-    pin_provider=None,
-    conn=None,
-    job_id=None,
-    timeout=300,
-):
+    cached_prefix: str | None = None,
+    pin_provider: str | None = None,
+    conn: sqlite3.Connection | None = None,
+    job_id: str | None = None,
+    timeout: int = 300,
+) -> str:
     """Call openrouter.complete() and return assistant text.
 
     When ``conn`` is provided, a cost_log row is written after a successful
@@ -285,7 +285,7 @@ def main():
     # serve a prompt-cache hit on the second+ call within a batch prep session.
     # Cross-role caching within a single prep run is deferred to #478.
     voice_samples = load_voice_samples()
-    log_event("voice_samples_loaded", caller="cover_letter_writer", chars=len(voice_samples))
+    log_event("voice_samples_loaded", caller="prep_shared_prefix", chars=len(voice_samples))
     voice_section = f"VOICE SAMPLES:\n{voice_samples}\n\n" if voice_samples else ""
     shared_candidate_jd = (
         f"CANDIDATE PROFILE:\n{profile_text}\n\n"

--- a/src/findajob/discoverer/runner.py
+++ b/src/findajob/discoverer/runner.py
@@ -219,7 +219,13 @@ def run(
 
     except OpenRouterError as e:
         msg = f"OpenRouter error ({e.kind}): {str(e)[:300]}"
-        log_event("discovery_failed", reason="openrouter_error", kind=e.kind, message=str(e)[:300])
+        log_event(
+            "discovery_failed",
+            reason="openrouter_error",
+            kind=e.kind,
+            status_code=e.status_code,
+            message=str(e)[:300],
+        )
         if ntfy_enabled:
             _send_ntfy("discovery: openrouter error", msg[:200])
         return RunResult(success=False, count=0, error=msg, cost_usd=None)

--- a/src/findajob/llm/openrouter.py
+++ b/src/findajob/llm/openrouter.py
@@ -127,6 +127,15 @@ def complete(
         :class:`CompletionResult` with text, token counts, cost_usd from
         ``response.usage.cost``, and the generation id.
 
+    Retries:
+        Transient failures (``kind`` in ``{rate_limit, upstream, network}``)
+        retry up to 3 attempts with exponential backoff (~0.5s → 8s cap),
+        so a flapping upstream can stretch a single call to ~10–20s wall
+        time before the final ``OpenRouterError`` bubbles. Other ``kind``s
+        raise on the first failure with no retry. Synchronous callers
+        whose UX depends on quick failure (loading spinners, chat turns)
+        should account for this added perceived latency.
+
     Raises:
         OpenRouterError: every non-success path. ``.kind`` classifies.
     """

--- a/src/findajob/onboarding/interview_runner.py
+++ b/src/findajob/onboarding/interview_runner.py
@@ -161,6 +161,7 @@ def run_turn(
             kind="config",
         )
 
+    # complete() retries transient failures — this call may take ~10-20s (see complete() docstring).
     try:
         result = complete(
             role="onboarding_interviewer",


### PR DESCRIPTION
## Summary
- Four small cleanup items deferred from #471 (Phase 2 wrapper port). All localized 1–5 line changes, no behavior change.
- 1) Forward `OpenRouterError.status_code` to `discovery_failed` log_event (kind alone loses 429/5xx/network distinction on the unattended weekly cron).
- 2) Document `complete()`'s retry contract in a docstring `Retries:` section (3× exp backoff, ~10-20s ceiling on `rate_limit/upstream/network`).
- 3) One-line comment in `interview_runner.run_turn()` pointing to the `complete()` docstring — pointer, not duplicate explanation, to avoid drift.
- 4) `prep_application.py:288` voice_samples_loaded `caller=` corrected from `cover_letter_writer` → `prep_shared_prefix` to reflect Phase 2's shared-prefix builder.
- 5) `prep_application.py:42` `run_role()` type annotations backported to match `interview_prep.py:77` for symmetry.

## Test plan
- [x] `uv run ruff check src/ scripts/ tests/` — passes
- [x] `uv run ruff format --check src/ scripts/ tests/` — 248 files already formatted
- [x] `uv run mypy src/findajob/` — 82 files, no issues
- [x] `uv run pytest` — 1857 passed, 1 skipped

## Out of scope
- Wrapper API changes (Phase 1 lock holds).
- Phase 3 (#472) calibration retirement — separate scope, separate release-notes weight.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)