### PR TITLE
refactor: #481 wire conn through onboarding voice_processor for cost_log writes

### DIFF
--- a/src/findajob/onboarding/injector.py
+++ b/src/findajob/onboarding/injector.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import sqlite3
 import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -272,6 +273,7 @@ def inject(
     rapidapi_key: str = "",
     redact_voice_samples: bool = True,
     skip_smoke_check: bool = False,
+    conn: sqlite3.Connection | None = None,
 ) -> InjectResult:
     """Backup, stage, commit, smoke-check, then run the discovery hook.
 
@@ -302,6 +304,10 @@ def inject(
 
     ``skip_smoke_check=True`` skips the OpenRouter verification step. Tests
     use this to avoid network calls; production callers must NOT set this.
+
+    ``conn`` is forwarded to ``process_voice_samples`` so a cost_log row is
+    written when voice samples are LLM-redacted (#481). None disables
+    cost-logging.
 
     On any staging or commit error, all tempfiles and the backup dir
     created this run are removed, and the exception propagates.
@@ -362,7 +368,7 @@ def inject(
                 continue
             body = found[opt_name]
             if opt_name == "voice-samples.md":
-                processed, _redaction_ok = process_voice_samples(body, redact=redact_voice_samples)
+                processed, _redaction_ok = process_voice_samples(body, redact=redact_voice_samples, conn=conn)
                 if not processed:
                     continue  # voice-samples processing returned empty → skip write
                 body = processed

--- a/src/findajob/onboarding/voice_processor.py
+++ b/src/findajob/onboarding/voice_processor.py
@@ -151,15 +151,24 @@ def redact_voice_samples(
     return redacted, True
 
 
-def process_voice_samples(raw: str, redact: bool = True, timeout: int = 120) -> tuple[str, bool]:
+def process_voice_samples(
+    raw: str,
+    redact: bool = True,
+    timeout: int = 120,
+    *,
+    conn: sqlite3.Connection | None = None,
+) -> tuple[str, bool]:
     """Clean structural markdown, then optionally LLM-redact PII.
 
     Returns ``(final_text, redaction_succeeded)``. When ``redact=False`` or the
     cleaned text is empty, ``redaction_succeeded`` is ``True`` (nothing to do).
     When the LLM call fails, returns the cleaned text with ``False`` so the
     caller can flag the degradation.
+
+    ``conn`` is forwarded to :func:`redact_voice_samples` so a cost_log row is
+    written for the LLM call when supplied. None disables cost-logging.
     """
     cleaned = clean_voice_samples(raw)
     if not cleaned or not redact:
         return cleaned, True
-    return redact_voice_samples(cleaned, timeout=timeout)
+    return redact_voice_samples(cleaned, timeout=timeout, conn=conn)

--- a/src/findajob/web/routes/onboarding_interview.py
+++ b/src/findajob/web/routes/onboarding_interview.py
@@ -496,6 +496,7 @@ def finalize_interview(
                 sess.captured_blocks,
                 openrouter_api_key=creds.openrouter_api_key.strip(),
                 rapidapi_key=(creds.rapidapi_key or "").strip(),
+                conn=conn,
             )
         except OnboardingSmokeCheckFailed as e:
             return _render_chat(

--- a/tests/test_onboarding_injector.py
+++ b/tests/test_onboarding_injector.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import os
+import sqlite3
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -276,7 +279,7 @@ def test_inject_runs_process_voice_samples_with_redact_flag(tmp_path: Path) -> N
             redact_voice_samples=False,
             skip_smoke_check=True,
         )
-        mock_process.assert_called_once_with(voice_body, redact=False)
+        mock_process.assert_called_once_with(voice_body, redact=False, conn=None)
 
 
 def test_inject_skips_voice_write_when_processing_returns_empty(tmp_path: Path) -> None:
@@ -319,6 +322,98 @@ def test_inject_backs_up_existing_voice_samples_file(tmp_path: Path) -> None:
     backed_up = backups[0] / "candidate_context" / "voice_samples" / "voice-samples.md"
     assert backed_up.exists()
     assert backed_up.read_text(encoding="utf-8") == "OLD voice content."
+
+
+_COST_LOG_SCHEMA = """
+CREATE TABLE cost_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT,
+    operation TEXT NOT NULL,
+    model TEXT NOT NULL,
+    latency_ms INTEGER,
+    success INTEGER DEFAULT 1,
+    error_message TEXT,
+    logged_at TEXT DEFAULT (datetime('now')),
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cost_usd REAL
+);
+"""
+
+
+def _stub_openrouter_response(cost: float = 0.005, prompt_tokens: int = 400, completion_tokens: int = 120):
+    body = json.dumps(
+        {
+            "id": "gen-vp-test",
+            "choices": [{"message": {"content": "Generalized prose output."}}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "cost": cost,
+                "prompt_tokens_details": {"cached_tokens": 0},
+            },
+        }
+    ).encode("utf-8")
+
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def read(self):
+            return body
+
+    return _Resp()
+
+
+def test_inject_with_conn_writes_voice_processor_cost_log(tmp_path: Path) -> None:
+    """End-to-end: inject() with conn + voice-samples.md writes exactly one
+    cost_log row with operation='voice_processor' and API-authoritative cost.
+
+    Closes the #471 wiring gap (#481): the production call site now plumbs
+    a sqlite connection through inject → process_voice_samples → redact_voice_samples
+    so voice-processor LLM cost lands in cost_log alongside every other call site.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_COST_LOG_SCHEMA)
+
+    voice_body = "I lived for quite a while in this house. Things got bad before they got better."
+
+    with (
+        patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-v1-test"}),
+        patch(
+            "findajob.llm.openrouter.urllib.request.urlopen",
+            return_value=_stub_openrouter_response(cost=0.005, prompt_tokens=400, completion_tokens=120),
+        ),
+    ):
+        inject(tmp_path, _full_files_with_voice(voice_body), conn=conn, skip_smoke_check=True)
+
+    # Exactly one row: the discoverer runs in a subprocess at the tail of inject(),
+    # so its complete() call doesn't share this process's urlopen patch and doesn't
+    # contribute to the parent conn's cost_log. If the discoverer is ever made
+    # in-process this count rises to two — the regression is real, not a test bug.
+    rows = conn.execute("SELECT operation, cost_usd, input_tokens, output_tokens, success FROM cost_log").fetchall()
+    assert len(rows) == 1, f"Expected exactly one cost_log row, got {len(rows)}"
+    row = rows[0]
+    assert row["operation"] == "voice_processor"
+    assert row["cost_usd"] == 0.005
+    assert row["input_tokens"] == 400
+    assert row["output_tokens"] == 120
+    assert row["success"] == 1
+
+
+def test_inject_without_conn_skips_cost_log(tmp_path: Path) -> None:
+    """Backwards-compat: inject() called without conn still processes voice
+    samples, just doesn't log cost — matches pre-#481 behavior.
+    """
+    voice_body = "Some prose."
+    with patch("findajob.onboarding.injector.process_voice_samples") as mock_process:
+        mock_process.return_value = (voice_body, True)
+        inject(tmp_path, _full_files_with_voice(voice_body), skip_smoke_check=True)
+        mock_process.assert_called_once_with(voice_body, redact=True, conn=None)
 
 
 def test_inject_discovery_hook_soft_fails_when_aichat_missing(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_web_onboarding_interview_routes.py
+++ b/tests/test_web_onboarding_interview_routes.py
@@ -534,6 +534,8 @@ def test_finalize_calls_inject_and_marks_complete(
         *,
         openrouter_api_key,
         rapidapi_key="",
+        conn=None,
+        **_kwargs,
     ):
         inject_calls.append(
             {
@@ -541,6 +543,7 @@ def test_finalize_calls_inject_and_marks_complete(
                 "parsed_files": dict(parsed_files),
                 "openrouter_api_key": openrouter_api_key,
                 "rapidapi_key": rapidapi_key,
+                "conn": conn,
             }
         )
         return InjectResult(
@@ -562,6 +565,9 @@ def test_finalize_calls_inject_and_marks_complete(
     assert len(inject_calls) == 1
     assert inject_calls[0]["openrouter_api_key"] == _USER_KEY
     assert set(inject_calls[0]["parsed_files"].keys()) >= set(all_captured.keys())
+    # #481: route handler threads the request-scoped sqlite connection through
+    # so voice_processor's cost_log write fires against the real DB.
+    assert inject_calls[0]["conn"] is not None
 
     # Session marked complete
     _hist, _cap, completed_at, _err = _read_session(base_root, sid)


### PR DESCRIPTION
## Summary
- Closes the wiring gap left by #471 Phase 2: `redact_voice_samples()` already accepts `conn=None`, but the production call site in `injector.py` didn't pass one, so voice-processor LLM calls (~$0.01–0.05 per onboarding) wrote no `cost_log` row.
- Plumb a sqlite connection through `routes/onboarding_interview.py` → `inject()` → `process_voice_samples()` → `redact_voice_samples()`. Same architectural shape as #463's onboarding-interview cost_log close in PR #479.
- Two tests cover the wiring: an end-to-end one asserting exactly one `cost_log` row with API-authoritative cost when inject() is invoked with conn, and a route-boundary one asserting the finalize handler hands a non-None connection to `inject()`.

## Acceptance criteria
1. ✅ Route handler reuses request-scoped sqlite connection and threads it through `process_voice_samples()` → `redact_voice_samples(conn=conn, ...)`.
2. ✅ After redaction, a `cost_log` row exists for `voice_processor` with API-authoritative `cost_usd` (matches `result.cost_usd` from the wrapper).
3. ✅ Failure path: cost_log write failures are best-effort swallowed via `log_event("cost_log_failed", ...)` (pre-existing behavior in `redact_voice_samples`).
4. ✅ Test added: `test_inject_with_conn_writes_voice_processor_cost_log` asserts exactly one cost_log row, operation=`voice_processor`, non-NULL `cost_usd`.

## Test plan
- [x] `uv run ruff check src/ scripts/ tests/` — passes
- [x] `uv run ruff format --check src/ scripts/ tests/` — 248 files formatted
- [x] `uv run mypy src/findajob/` — 82 files, no issues
- [x] `uv run pytest` — 1859 passed, 1 skipped (+2 from new tests)

## Out of scope
- Changes to `voice_processor` role file or `redact_voice_samples()` body.
- Wrapper API changes (Phase 1 lock holds).

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)