### PR TITLE
docs: move [Unreleased] → [0.20.1] in CHANGELOG (#69 process)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+_(no entries yet)_
+
+## [0.20.1] — 2026-05-07
+
+Patch release on top of v0.20.0 with two web-layer hotfixes: dashboard 5xx under concurrent load (#486) — a SQLite cross-thread bug surfaced post-OpenRouter-migration deploy by HTMX polling on the operator's stack — and a new post-deploy auth-gate verifier + hard rule (#487), triggered by an internet-exposed-without-auth incident on a sibling stack the same day. Also the previously-staged #485 (speculative ingest UX bundle) and #462 (`company_discoverer` cost-threshold ntfy verification) ride along. No migration required; rolls automatically to all stacks pinned to moving aliases.
+
 ### Fixed
 - **#486 SQLite cross-thread error on dashboard under concurrent load.** Pre-fix, `/board/dashboard` returned HTTP 500 ~85% of the time on the operator's stack running v0.20.0 under any concurrent request load (HTMX polling, multiple browser tabs). Reproduced from inside the container with valid auth: sequential 10/10 → 200; concurrent 17/20 → 500, 3/20 → 200. Root cause: `sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in that same thread.` at `src/findajob/web/app.py:110`. Mechanism: `findajob.web.auth.BasicAuthMiddleware` is a `BaseHTTPMiddleware` subclass; Starlette wraps the inner app in a separate anyio task, which can dispatch `Depends(get_db)` resolution and the route handler to different threadpool workers. The connection was created in thread A and used in thread B, tripping SQLite's default thread-check. Sequential bursts hid the bug because anyio reused a single worker. Fix: pass `check_same_thread=False` to the per-request `sqlite3.connect()` (per-request connection in serialized SQLite mode is safe to disable the thread guard). Regression test reconstructs the cross-thread scenario directly without TestClient (which bridges every call through a single anyio portal pinned to one threadpool worker — masking the bug). Pre-fix the test fails with the production error string; post-fix it passes.
 - **#485 Speculative ingest UX bundle.** Three small but compounding bugs made the speculative-ingest path feel broken on `:v0.20`:
@@ -845,7 +851,9 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.20.1...HEAD
+[0.20.1]: https://github.com/brockamer/findajob/releases/tag/v0.20.1
+[0.20.0]: https://github.com/brockamer/findajob/releases/tag/v0.20.0
 [0.19.0]: https://github.com/brockamer/findajob/releases/tag/v0.19.0
 [0.18.0]: https://github.com/brockamer/findajob/releases/tag/v0.18.0
 [0.17.0]: https://github.com/brockamer/findajob/releases/tag/v0.17.0


### PR DESCRIPTION
## Summary

CHANGELOG move from `[Unreleased]` → `[0.20.1] — 2026-05-07` per the release-process.md workflow. Patch hotfix bundling:

- **#486** dashboard 5xx under concurrent load (SQLite cross-thread bug; one-line `check_same_thread=False` fix)
- **#487** post-deploy auth-gate verifier `findajob.web.verify_auth` + hard rule + auto-shutdown discipline
- **#485** speculative ingest UX bundle (already on main, surfaced in this release block)
- **#462** `company_discoverer` cost-threshold ntfy verification (already on main, surfaced in this release block)

Also backfills the missing `[0.20.0]` cross-reference link at the bottom of the file — that link was omitted when v0.20.0 was tagged earlier today.

Pre-tag smoke check on the operator's docker host: ✅ 17 jobs scored, 17 cost_log rows, pipeline_complete fired, materials viewer + /healthz + /docs all 200 OK.

No `migration-required` triggers — every stack (operator + tester cohort) rolls automatically on `docker compose pull`.

## Test plan

- [x] Pre-tag smoke green
- [x] CHANGELOG cross-ref links validated (Unreleased → compare from v0.20.1; new [0.20.1] + backfilled [0.20.0] entries present)
- [x] CI green on PR
- [ ] After merge: wait for `:latest` to rebuild off the CHANGELOG commit, then push `v0.20.1` tag
- [ ] Post-tag verification per docs/release-process.md
- [ ] Cohort deploy + per-stack `python -m findajob.web.verify_auth`
- [ ] Bring `findajob-test` back up + verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)
