### PR TITLE
feat(web): #490 reject_reasons editor — /settings/ namespace + cache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,16 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
-_(no entries yet)_
+### Added
+- **#490 `/settings/reject-reasons/` editor for `config/reject_reasons.yaml`.** First occupant of the new `/settings/` URL namespace — domain-aware config editor with rich UX (editable rows, per-row `title-signal` checkbox, add/remove via Alpine, HTMX partial-swap save). Lets users tune their rejection taxonomy at any time without re-running the onboarding interview. Server-side validation rejects empty saves, comma-in-reason (URL-filter contract), duplicates, and `title_signal_reasons` not in `reasons`; on validation failure the file is unchanged and an inline error renders. Distinguished from `/config/` (raw text editor for allowlisted files) — `/settings/` is the home for per-page rich editors. Future similar editors (e.g., for `prefilter_rules.yaml`) live here.
+
+### Changed
+- **#490 `findajob.config_loader.load_reject_reasons` no longer caches its result.** File edits are picked up on the next call (small YAML, parse-per-call cost is microseconds). Required so `/settings/reject-reasons/` saves take effect on the next request without a container restart. The module-level `_reject_reasons_cache` is gone; `_reset_cache()` no longer touches it; `test_caches_result` is replaced by `test_no_cache_picks_up_file_changes`. No external behavior change — the dropdown and filter chips already re-resolve per render.
+- **#490 `findajob.web.filters.spec.ColumnSpec.enum_values` now accepts `tuple[str, ...] | Callable[[], tuple[str, ...]] | None`.** New `resolved_enum_values` property invokes the callable per access. Eager comma-validation in `__post_init__` is skipped for the callable form (deferred to resolution time). `web/filters/registry.py` switches the reject-reason chip column from a module-level capture to a callable so chip values refresh per request alongside the board's reject-reason dropdown. Two consumer call sites switched to `resolved_enum_values`: `web/filters/url.py:65` and `web/templates/_table_header.html:119`.
+
+### Migration required
+
+None. No schema, config, crontab, mount, or compose changes. `config/reject_reasons.yaml` was already gitignored and per-stack; existing stacks pick up the editor on `docker compose pull` + `docker compose up -d` without any operator action.
 
 ## [0.20.1] — 2026-05-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,12 +170,14 @@ Lives at `src/findajob/web/`. One file per URL group in `routes/` (e.g. `routes/
 
 Foundational decisions (design rationale lives in operator-private specs):
 - Server-rendered HTML + HTMX (no SPA)
-- Grouped URL IA — top-nav = `/`, `/board/`, `/materials/`, `/ingest/`, `/stats/`, `/tools/`, `/config/`, `/docs/`
+- Grouped URL IA — top-nav = `/`, `/board/`, `/materials/`, `/ingest/`, `/stats/`, `/tools/`, `/config/`, `/settings/`, `/docs/`
 - Tailwind via CDN + `static/app.css` design tokens
 - URL query params for UI state (not cookies/localStorage)
 - Alpine.js added only when ephemeral client state is needed
 
 **`/config/`** — in-browser editor for editable pipeline config; allowlist in `findajob.web.config_files`. No per-user authorization inside findajob — perimeter is the boundary. Default perimeter is Wireguard; internet-exposed instances additionally require HTTP Basic Auth via `FINDAJOB_AUTH_USER` / `FINDAJOB_AUTH_PASS` (see `findajob.web.auth` and `docs/setup/internet-exposure.md`).
+
+**`/settings/`** — domain-aware config editors with rich UX. First occupant: `/settings/reject-reasons/` (#490) — editable rows + per-row `title-signal` checkbox for `config/reject_reasons.yaml`. Distinguished from `/config/` (raw text editor for any allowlisted file): `/settings/` has per-page UX tailored to the config it edits (validation, structured rows, HTMX partial-swap save flow). Saves take effect on the next request without container restart — `findajob.config_loader.load_reject_reasons` is no-cache and `ColumnSpec.enum_values` accepts a callable so dropdown + filter chip values both refresh per request. Future similar editors (e.g., `prefilter_rules.yaml`, `in_domain_patterns.yaml`) live here.
 
 **`/onboarding/`** — first-run NUX. Two-step structure:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -136,6 +136,10 @@ The reject dropdown has eleven preset reasons so they can be counted and charted
 
 If the reason you want isn't here, use *Other* and put the detail in the notes column.
 
+The list is editable. Open **Settings → Reject reasons** in the top nav (`/settings/reject-reasons/`) to add, remove, or rename entries. Changes apply on the next page load — no container restart needed. Tick **title-signal** for reasons that mean the scorer misread the job title (e.g., "Skills Mismatch", "Wrong Domain") — those reasons feed the prefilter-tuning analysis and tell the scorer's feedback loop that the underlying job title was a false positive.
+
+A reason you remove from the taxonomy doesn't break older rejections that used it — `/board/rejected/` and the stats views render historical entries even if the reason no longer appears in the current dropdown.
+
 ---
 
 ## What happens when you Flag for Prep

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -59,7 +59,9 @@ _companies_cache: frozenset[str] | None = None
 _indeed_title_allow_cache: re.Pattern[str] | None = None
 _indeed_title_allow_loaded: bool = False  # distinguishes "cached None" from "not yet loaded"
 _excluded_employers_cache: tuple[frozenset[str], re.Pattern[str] | None] | None = None
-_reject_reasons_cache: tuple[tuple[str, ...], frozenset[str]] | None = None
+# Note: reject_reasons is intentionally NOT cached so /settings/reject-reasons/
+# saves take effect on the next request without a process restart (#490).
+# Cost is negligible — small YAML, parse-per-call is microseconds.
 
 # Warnings emitted (dedup per process)
 _warned: set[str] = set()
@@ -330,15 +332,14 @@ def load_reject_reasons() -> tuple[tuple[str, ...], frozenset[str]]:
     Missing file or empty `reasons:` → returns the field-agnostic defaults
     (`_DEFAULT_REJECT_REASONS` / `_DEFAULT_TITLE_SIGNAL_REASONS`). Malformed
     entries raise `ConfigError`.
-    """
-    global _reject_reasons_cache
-    if _reject_reasons_cache is not None:
-        return _reject_reasons_cache
 
+    Returns fresh values on every call — small file, parse-per-call cost is
+    negligible (~µs), and lets `/settings/reject-reasons/` saves take effect
+    on the next request without a process restart (#490).
+    """
     data = _safe_load_yaml(_REJECT_REASONS_PATH, "reject_reasons.yaml")
     if data is None:
-        _reject_reasons_cache = (_DEFAULT_REJECT_REASONS, _DEFAULT_TITLE_SIGNAL_REASONS)
-        return _reject_reasons_cache
+        return (_DEFAULT_REJECT_REASONS, _DEFAULT_TITLE_SIGNAL_REASONS)
 
     raw_reasons = data.get("reasons", [])
     if not isinstance(raw_reasons, list):
@@ -347,8 +348,7 @@ def load_reject_reasons() -> tuple[tuple[str, ...], frozenset[str]]:
         if not isinstance(r, str):
             raise ConfigError(f"reject_reasons.yaml: reasons entry is not a string: {r!r}")
     if not raw_reasons:
-        _reject_reasons_cache = (_DEFAULT_REJECT_REASONS, _DEFAULT_TITLE_SIGNAL_REASONS)
-        return _reject_reasons_cache
+        return (_DEFAULT_REJECT_REASONS, _DEFAULT_TITLE_SIGNAL_REASONS)
 
     raw_title = data.get("title_signal_reasons", []) or []
     if not isinstance(raw_title, list):
@@ -357,22 +357,84 @@ def load_reject_reasons() -> tuple[tuple[str, ...], frozenset[str]]:
         if not isinstance(t, str):
             raise ConfigError(f"reject_reasons.yaml: title_signal_reasons entry is not a string: {t!r}")
 
-    _reject_reasons_cache = (tuple(raw_reasons), frozenset(raw_title))
-    return _reject_reasons_cache
+    return (tuple(raw_reasons), frozenset(raw_title))
+
+
+def save_reject_reasons(
+    reasons: tuple[str, ...],
+    title_signal_reasons: frozenset[str],
+) -> None:
+    """Atomically write `config/reject_reasons.yaml` (#490).
+
+    Validates input before writing. On validation failure, raises ConfigError
+    and does not touch the file. On write failure, the original file is left
+    intact (atomic os.replace).
+
+    Validation:
+      - `reasons` must be non-empty (after stripping whitespace)
+      - Each reason: non-empty after strip, no comma (URL filter contract)
+      - No duplicate reasons (post-strip)
+      - `title_signal_reasons` ⊆ set(reasons) (post-strip)
+    """
+    import os
+    import tempfile
+
+    cleaned_reasons = tuple(r.strip() for r in reasons if r.strip())
+    if not cleaned_reasons:
+        raise ConfigError("reject_reasons: 'reasons' must be non-empty")
+    for r in cleaned_reasons:
+        if "," in r:
+            raise ConfigError(
+                f"reject_reasons: reason {r!r} contains comma; "
+                f"the URL filter contract uses comma as separator"
+            )
+    if len(set(cleaned_reasons)) != len(cleaned_reasons):
+        raise ConfigError("reject_reasons: duplicate entries in 'reasons'")
+
+    cleaned_title = frozenset(t.strip() for t in title_signal_reasons if t.strip())
+    extra = cleaned_title - set(cleaned_reasons)
+    if extra:
+        raise ConfigError(
+            f"reject_reasons: title_signal entries not in reasons: {sorted(extra)}"
+        )
+
+    lines = ["reasons:"]
+    for r in cleaned_reasons:
+        lines.append(f"  - {r}")
+    if cleaned_title:
+        lines.append("title_signal_reasons:")
+        for r in cleaned_reasons:
+            if r in cleaned_title:
+                lines.append(f"  - {r}")
+    body = "\n".join(lines) + "\n"
+
+    _REJECT_REASONS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=_REJECT_REASONS_PATH.name + ".",
+        suffix=".tmp",
+        dir=str(_REJECT_REASONS_PATH.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(body)
+        os.replace(tmp_name, _REJECT_REASONS_PATH)
+    except Exception:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+        raise
 
 
 def _reset_cache() -> None:
     """Test-only. Clears module-level caches and warning dedup."""
     global _hard_reject_cache, _in_domain_cache, _companies_cache
     global _indeed_title_allow_cache, _indeed_title_allow_loaded
-    global _excluded_employers_cache, _reject_reasons_cache
+    global _excluded_employers_cache
     _hard_reject_cache = None
     _in_domain_cache = None
     _companies_cache = None
     _indeed_title_allow_cache = None
     _indeed_title_allow_loaded = False
     _excluded_employers_cache = None
-    _reject_reasons_cache = None
     _warned.clear()
 
 

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -385,8 +385,7 @@ def save_reject_reasons(
     for r in cleaned_reasons:
         if "," in r:
             raise ConfigError(
-                f"reject_reasons: reason {r!r} contains comma; "
-                f"the URL filter contract uses comma as separator"
+                f"reject_reasons: reason {r!r} contains comma; the URL filter contract uses comma as separator"
             )
     if len(set(cleaned_reasons)) != len(cleaned_reasons):
         raise ConfigError("reject_reasons: duplicate entries in 'reasons'")
@@ -394,9 +393,7 @@ def save_reject_reasons(
     cleaned_title = frozenset(t.strip() for t in title_signal_reasons if t.strip())
     extra = cleaned_title - set(cleaned_reasons)
     if extra:
-        raise ConfigError(
-            f"reject_reasons: title_signal entries not in reasons: {sorted(extra)}"
-        )
+        raise ConfigError(f"reject_reasons: title_signal entries not in reasons: {sorted(extra)}")
 
     lines = ["reasons:"]
     for r in cleaned_reasons:

--- a/src/findajob/web/filters/registry.py
+++ b/src/findajob/web/filters/registry.py
@@ -39,9 +39,15 @@ _STAGE_VALUES = (
     "withdrew",
 )
 _REMOTE_VALUES = ("Remote", "Hybrid", "On-site", "Unknown")
-# Filter chip values come from the same source as the dropdown — fixes the
-# silent-filtering drift bug surfaced by the #301 audit (§2.1).
-_REJECT_REASON_VALUES, _ = load_reject_reasons()
+
+
+# Reject-reason chip values resolve per-request (lazy callable) so
+# /settings/reject-reasons/ saves are reflected on the next page load
+# without a container restart (#490). Same source as the board's
+# reject-reason dropdown — fixes the silent-filtering drift bug from
+# #301 §2.1.
+def _reject_reason_values() -> tuple[str, ...]:
+    return load_reject_reasons()[0]
 
 # ─── Dashboard ────────────────────────────────────────────────────────────────
 DASHBOARD_COLUMNS: tuple[ColumnSpec, ...] = (
@@ -227,7 +233,7 @@ REJECTED_COLUMNS: tuple[ColumnSpec, ...] = (
         name="reject_reason",
         label="Reason",
         kind=Kind.ENUM,
-        enum_values=_REJECT_REASON_VALUES,
+        enum_values=_reject_reason_values,
         db_expr="j.reject_reason",
     ),
     ColumnSpec(

--- a/src/findajob/web/filters/registry.py
+++ b/src/findajob/web/filters/registry.py
@@ -49,6 +49,7 @@ _REMOTE_VALUES = ("Remote", "Hybrid", "On-site", "Unknown")
 def _reject_reason_values() -> tuple[str, ...]:
     return load_reject_reasons()[0]
 
+
 # ─── Dashboard ────────────────────────────────────────────────────────────────
 DASHBOARD_COLUMNS: tuple[ColumnSpec, ...] = (
     ColumnSpec(name="relevance_score", label="Rel", kind=Kind.SCORE),

--- a/src/findajob/web/filters/spec.py
+++ b/src/findajob/web/filters/spec.py
@@ -47,9 +47,7 @@ class ColumnSpec:
             # resolved_enum_values).
             if not callable(self.enum_values):
                 if not self.enum_values:
-                    raise ValueError(
-                        f"ColumnSpec {self.name!r}: kind=ENUM requires non-empty enum_values"
-                    )
+                    raise ValueError(f"ColumnSpec {self.name!r}: kind=ENUM requires non-empty enum_values")
                 for v in self.enum_values:
                     if "," in v:
                         raise ValueError(

--- a/src/findajob/web/filters/spec.py
+++ b/src/findajob/web/filters/spec.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -21,6 +21,12 @@ class Kind(StrEnum):
     COMPUTED = "computed"
 
 
+# Callable form lets a column's enum values resolve per-request — used for
+# dynamic config like #490's reject_reasons.yaml editor where the values
+# can change between requests without a process restart.
+EnumValuesProvider = tuple[str, ...] | Callable[[], tuple[str, ...]]
+
+
 @dataclass(frozen=True)
 class ColumnSpec:
     name: str
@@ -29,19 +35,42 @@ class ColumnSpec:
     sortable: bool = True
     filterable: bool = True
     default_visible: bool = True
-    enum_values: tuple[str, ...] | None = None
+    enum_values: EnumValuesProvider | None = None
     db_expr: str | None = None
 
     def __post_init__(self) -> None:
         if self.kind is Kind.ENUM:
-            if not self.enum_values:
+            if self.enum_values is None:
                 raise ValueError(f"ColumnSpec {self.name!r}: kind=ENUM requires enum_values")
-            for v in self.enum_values:
-                if "," in v:
+            # Eager validation only for the tuple form. Callable form defers
+            # validation to resolution time (called per request via
+            # resolved_enum_values).
+            if not callable(self.enum_values):
+                if not self.enum_values:
                     raise ValueError(
-                        f"ColumnSpec {self.name!r}: enum_values must not contain comma "
-                        f"(got {v!r}); the URL contract uses comma as the separator."
+                        f"ColumnSpec {self.name!r}: kind=ENUM requires non-empty enum_values"
                     )
+                for v in self.enum_values:
+                    if "," in v:
+                        raise ValueError(
+                            f"ColumnSpec {self.name!r}: enum_values must not contain comma "
+                            f"(got {v!r}); the URL contract uses comma as the separator."
+                        )
+
+    @property
+    def resolved_enum_values(self) -> tuple[str, ...]:
+        """Return enum_values, calling the provider if it is a callable.
+
+        Use this in url.py and template chip rendering instead of accessing
+        `.enum_values` directly. Re-evaluates per access for the callable
+        form so dynamic config (e.g., #490's reject_reasons.yaml edits) is
+        reflected without a process restart.
+        """
+        if self.enum_values is None:
+            return ()
+        if callable(self.enum_values):
+            return self.enum_values()
+        return self.enum_values
 
     @property
     def sql_ref(self) -> str:

--- a/src/findajob/web/filters/url.py
+++ b/src/findajob/web/filters/url.py
@@ -62,7 +62,7 @@ def parse_filter_params(specs: Sequence[ColumnSpec], params: Mapping[str, str]) 
             raw = params.get(name)
             if raw is None or raw == "":
                 continue
-            allowed = set(spec.enum_values or ())
+            allowed = set(spec.resolved_enum_values)
             picks = tuple(p for p in (s.strip() for s in raw.split(",")) if p and p in allowed)
             if picks:
                 enum[name] = picks

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -18,6 +18,7 @@ from findajob.web.routes import (
     onboarding,
     onboarding_feed_config,
     onboarding_gmail_config,
+    settings_reject_reasons,
     speculative,
     stats,
     tools,
@@ -39,6 +40,7 @@ router.include_router(landing.router, dependencies=_guard)
 router.include_router(board.router, dependencies=_guard)
 router.include_router(board_actions.router, dependencies=_guard)
 router.include_router(ingest.router)
+router.include_router(settings_reject_reasons.router, dependencies=_guard)
 router.include_router(speculative.router, dependencies=_guard)
 router.include_router(stats.router, dependencies=_guard)
 router.include_router(config.router)

--- a/src/findajob/web/routes/settings_reject_reasons.py
+++ b/src/findajob/web/routes/settings_reject_reasons.py
@@ -1,0 +1,73 @@
+"""#490: /settings/reject-reasons/ — rich editor for config/reject_reasons.yaml.
+
+The first occupant of the /settings/ namespace. /settings/ is the home for
+domain-aware config editors (vs. /config/'s raw text editor); future similar
+editors (e.g., for prefilter_rules.yaml) live next to this one.
+
+GET renders the current reasons + title_signal flags as editable rows.
+POST validates and writes via findajob.config_loader.save_reject_reasons,
+returning an HTMX partial with success/error feedback.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from findajob.config_loader import ConfigError, load_reject_reasons, save_reject_reasons
+
+router = APIRouter(prefix="/settings/reject-reasons", tags=["settings"])
+
+
+@router.get("/", response_class=HTMLResponse)
+def get_reject_reasons_editor(request: Request) -> HTMLResponse:
+    """Render the reject-reasons editor with current values."""
+    reasons, title_signal = load_reject_reasons()
+    rows = [{"text": r, "title_signal": r in title_signal} for r in reasons]
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="settings/reject_reasons.html",
+        context={"rows": rows},
+    )
+
+
+@router.post("/", response_class=HTMLResponse)
+async def post_reject_reasons_editor(request: Request) -> HTMLResponse:
+    """Validate and save submitted reasons + title_signal flags."""
+    form = await request.form()
+
+    try:
+        row_count = int(form.get("row_count", "0"))
+    except (TypeError, ValueError):
+        return _render_save_result(request, "error", "Malformed form payload")
+
+    reasons: list[str] = []
+    title_signal: set[str] = set()
+    for i in range(row_count):
+        raw = form.get(f"reason_{i}", "")
+        if not isinstance(raw, str):
+            continue
+        text = raw.strip()
+        if not text:
+            continue  # skip empty rows
+        reasons.append(text)
+        if form.get(f"title_signal_{i}"):
+            title_signal.add(text)
+
+    try:
+        save_reject_reasons(tuple(reasons), frozenset(title_signal))
+    except ConfigError as e:
+        return _render_save_result(request, "error", str(e))
+
+    return _render_save_result(request, "success", "")
+
+
+def _render_save_result(request: Request, outcome: str, message: str) -> HTMLResponse:
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="settings/_reject_reasons_save_result.html",
+        context={"outcome": outcome, "message": message},
+    )

--- a/src/findajob/web/routes/settings_reject_reasons.py
+++ b/src/findajob/web/routes/settings_reject_reasons.py
@@ -38,9 +38,12 @@ async def post_reject_reasons_editor(request: Request) -> HTMLResponse:
     """Validate and save submitted reasons + title_signal flags."""
     form = await request.form()
 
+    raw_count = form.get("row_count", "0")
+    if not isinstance(raw_count, str):
+        return _render_save_result(request, "error", "Malformed form payload")
     try:
-        row_count = int(form.get("row_count", "0"))
-    except (TypeError, ValueError):
+        row_count = int(raw_count)
+    except ValueError:
         return _render_save_result(request, "error", "Malformed form payload")
 
     reasons: list[str] = []

--- a/src/findajob/web/templates/_nav.html
+++ b/src/findajob/web/templates/_nav.html
@@ -17,6 +17,7 @@
   ("/stats/funnel", "Stats", "/stats/"),
   ("/tools/", "Tools", "/tools/"),
   ("/config/", "Config", "/config/"),
+  ("/settings/reject-reasons/", "Settings", "/settings/"),
   ("/docs/", "Docs", "/docs/"),
 ] %}
 <nav class="{% if operator_mode %}bg-rose-700{% else %}bg-slate-800{% endif %} text-slate-100 px-4 py-2 shadow-sm">

--- a/src/findajob/web/templates/_table_header.html
+++ b/src/findajob/web/templates/_table_header.html
@@ -116,7 +116,7 @@
                  @click.outside="open = false"
                  class="absolute z-10 mt-1 bg-white border border-slate-300 rounded shadow-lg p-2 min-w-[10rem] text-xs">
               <div class="font-semibold uppercase text-slate-500 mb-1">{{ s.label }}</div>
-              {% for v in s.enum_values %}
+              {% for v in s.resolved_enum_values %}
                 <label class="block">
                   <input type="checkbox"
                          value="{{ v }}"

--- a/src/findajob/web/templates/settings/_reject_reasons_save_result.html
+++ b/src/findajob/web/templates/settings/_reject_reasons_save_result.html
@@ -1,0 +1,9 @@
+{% if outcome == "success" %}
+  <div class="px-3 py-2 rounded bg-emerald-50 border border-emerald-200 text-emerald-900">
+    Saved. Reload the board to see the updated dropdown.
+  </div>
+{% else %}
+  <div class="px-3 py-2 rounded bg-rose-50 border border-rose-200 text-rose-900">
+    <strong>Could not save:</strong> {{ message }}
+  </div>
+{% endif %}

--- a/src/findajob/web/templates/settings/reject_reasons.html
+++ b/src/findajob/web/templates/settings/reject_reasons.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Reject reasons — Settings{% endblock %}
+{% block content %}
+<h1>Reject reasons</h1>
+{% for row in rows %}
+<div data-reason="{{ row.text }}" data-title-signal="{{ row.title_signal }}">
+  {{ row.text }}{% if row.title_signal %} (title-signal){% endif %}
+</div>
+{% endfor %}
+{% endblock %}

--- a/src/findajob/web/templates/settings/reject_reasons.html
+++ b/src/findajob/web/templates/settings/reject_reasons.html
@@ -1,10 +1,89 @@
 {% extends "base.html" %}
 {% block title %}Reject reasons — Settings{% endblock %}
 {% block content %}
-<h1>Reject reasons</h1>
-{% for row in rows %}
-<div data-reason="{{ row.text }}" data-title-signal="{{ row.title_signal }}">
-  {{ row.text }}{% if row.title_signal %} (title-signal){% endif %}
+<div class="max-w-2xl">
+  <h1 class="text-2xl font-semibold mb-1">Reject reasons</h1>
+  <p class="text-sm text-slate-600 mb-6">
+    Edit the reject-reason taxonomy used on the board's reject button.
+    Changes apply on the next page load — no restart required.
+    Check <strong>title-signal</strong> for reasons that mean the scorer misread
+    the title (used by feedback analysis to find prefilter candidates).
+  </p>
+
+  <div
+    x-data="{
+      rows: {{ rows | tojson }}.map(function(r) {
+        return { text: r.text, title_signal: r.title_signal };
+      }),
+      addRow: function() {
+        this.rows.push({ text: '', title_signal: false });
+      },
+      removeRow: function(i) {
+        this.rows.splice(i, 1);
+      }
+    }"
+  >
+    <form
+      hx-post="/settings/reject-reasons/"
+      hx-target="#save-result"
+      hx-swap="innerHTML"
+      class="space-y-2"
+    >
+      {# Hidden field so server knows how many rows to read #}
+      <input type="hidden" name="row_count" :value="rows.length" />
+
+      {# Editable rows #}
+      <template x-for="(row, i) in rows" :key="i">
+        <div class="flex items-center gap-3">
+          <input
+            type="text"
+            :name="'reason_' + i"
+            x-model="row.text"
+            placeholder="Reason label"
+            class="flex-1 rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm"
+          />
+          <label class="flex items-center gap-1.5 text-sm text-slate-700 whitespace-nowrap">
+            <input
+              type="checkbox"
+              :name="'title_signal_' + i"
+              x-model="row.title_signal"
+              value="on"
+              class="rounded border-slate-400 text-slate-700 focus:ring-slate-500"
+            />
+            title-signal
+          </label>
+          <button
+            type="button"
+            @click="removeRow(i)"
+            class="text-slate-400 hover:text-rose-600 text-sm font-medium px-2 py-1 rounded hover:bg-rose-50"
+            title="Remove this reason"
+          >
+            &times;
+          </button>
+        </div>
+      </template>
+
+      <div class="flex items-center gap-3 pt-2">
+        <button
+          type="button"
+          @click="addRow()"
+          class="text-sm text-slate-600 hover:text-slate-900 border border-slate-300 rounded px-3 py-1.5 hover:bg-slate-100"
+        >
+          + Add reason
+        </button>
+
+        <button
+          type="submit"
+          class="bg-slate-800 text-white text-sm font-medium rounded px-4 py-1.5 hover:bg-slate-700"
+        >
+          Save
+        </button>
+
+        <span class="text-xs text-slate-500 htmx-indicator">Saving…</span>
+      </div>
+    </form>
+
+    <div id="save-result" class="mt-4"></div>
+  </div>
 </div>
-{% endfor %}
 {% endblock %}

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -450,11 +450,83 @@ class TestLoadRejectReasons:
         with pytest.raises(ConfigError, match="reasons entry is not a string"):
             config_loader.load_reject_reasons()
 
-    def test_caches_result(self, monkeypatch, tmp_path):
+    def test_no_cache_picks_up_file_changes(self, monkeypatch, tmp_path):
+        """#490: cache removed so /settings/reject-reasons/ saves take
+        effect on the next request without a process restart."""
         f = tmp_path / "reject_reasons.yaml"
-        f.write_text('reasons:\n  - "x"\n')
+        f.write_text("reasons:\n  - One\n  - Two\n")
         monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
-        config_loader._reset_cache()
-        r1 = config_loader.load_reject_reasons()
-        r2 = config_loader.load_reject_reasons()
-        assert r1 is r2  # cache hit
+
+        reasons1, _ = config_loader.load_reject_reasons()
+        assert reasons1 == ("One", "Two")
+
+        f.write_text("reasons:\n  - Three\n  - Four\n")
+        reasons2, _ = config_loader.load_reject_reasons()
+        assert reasons2 == ("Three", "Four")  # No _reset_cache() call needed
+
+
+class TestSaveRejectReasons:
+    """#490: writer for `config/reject_reasons.yaml`."""
+
+    def test_atomic_roundtrip(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+
+        config_loader.save_reject_reasons(("Alpha", "Beta", "Gamma"), frozenset({"Alpha"}))
+        reasons, title_signal = config_loader.load_reject_reasons()
+        assert reasons == ("Alpha", "Beta", "Gamma")
+        assert title_signal == frozenset({"Alpha"})
+
+    def test_rejects_empty_reasons(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        with pytest.raises(ConfigError, match="non-empty"):
+            config_loader.save_reject_reasons((), frozenset())
+
+    def test_rejects_empty_after_strip(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        with pytest.raises(ConfigError, match="non-empty|empty"):
+            config_loader.save_reject_reasons(("",), frozenset())
+
+    def test_rejects_comma_in_reason(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        with pytest.raises(ConfigError, match="comma"):
+            config_loader.save_reject_reasons(("Skills, mismatch",), frozenset())
+
+    def test_rejects_title_signal_not_in_reasons(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        with pytest.raises(ConfigError, match="title_signal"):
+            config_loader.save_reject_reasons(("Alpha",), frozenset({"NotInReasons"}))
+
+    def test_rejects_duplicate_reasons(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        with pytest.raises(ConfigError, match="duplicate"):
+            config_loader.save_reject_reasons(("Alpha", "Alpha"), frozenset())
+
+    def test_atomic_no_partial_write_on_failure(self, monkeypatch, tmp_path):
+        """If os.replace fails mid-write, the original file is left intact."""
+        f = tmp_path / "reject_reasons.yaml"
+        f.write_text("reasons:\n  - Original\n")
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+
+        def boom(*a, **kw):
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr("os.replace", boom)
+
+        with pytest.raises(OSError):
+            config_loader.save_reject_reasons(("New",), frozenset())
+
+        assert "Original" in f.read_text()
+
+    def test_strips_whitespace(self, monkeypatch, tmp_path):
+        f = tmp_path / "reject_reasons.yaml"
+        monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", f)
+        config_loader.save_reject_reasons(("  Padded  ",), frozenset({"  Padded  "}))
+        reasons, title_signal = config_loader.load_reject_reasons()
+        assert reasons == ("Padded",)
+        assert title_signal == frozenset({"Padded"})

--- a/tests/test_filter_spec.py
+++ b/tests/test_filter_spec.py
@@ -128,7 +128,9 @@ def test_resolved_enum_values_returns_tuple_form_unchanged() -> None:
 def test_resolved_enum_values_invokes_callable() -> None:
     state = {"vals": ("alpha", "beta")}
     s = ColumnSpec(
-        name="x", label="X", kind=Kind.ENUM,
+        name="x",
+        label="X",
+        kind=Kind.ENUM,
         enum_values=lambda: state["vals"],
     )
     assert s.resolved_enum_values == ("alpha", "beta")
@@ -141,7 +143,9 @@ def test_callable_enum_values_skips_eager_comma_validation() -> None:
     # Constructing the spec must not raise even though the callable
     # would eventually be inspected for commas.
     s = ColumnSpec(
-        name="x", label="X", kind=Kind.ENUM,
+        name="x",
+        label="X",
+        kind=Kind.ENUM,
         enum_values=lambda: ("legal_value",),
     )
     assert s.resolved_enum_values == ("legal_value",)
@@ -150,7 +154,9 @@ def test_callable_enum_values_skips_eager_comma_validation() -> None:
 def test_tuple_enum_values_still_eagerly_validated_for_commas() -> None:
     with pytest.raises(ValueError, match="comma"):
         ColumnSpec(
-            name="x", label="X", kind=Kind.ENUM,
+            name="x",
+            label="X",
+            kind=Kind.ENUM,
             enum_values=("with,comma",),
         )
 

--- a/tests/test_filter_spec.py
+++ b/tests/test_filter_spec.py
@@ -115,3 +115,46 @@ def test_waitlist_includes_likelihood_visible() -> None:
 
     visible = {s.name for s in registry.WAITLIST_COLUMNS if s.default_visible}
     assert "interview_likelihood" in visible
+
+
+# ─── #490: lazy enum_values via callable ─────────────────────────────────────
+
+
+def test_resolved_enum_values_returns_tuple_form_unchanged() -> None:
+    s = ColumnSpec(name="x", label="X", kind=Kind.ENUM, enum_values=("a", "b"))
+    assert s.resolved_enum_values == ("a", "b")
+
+
+def test_resolved_enum_values_invokes_callable() -> None:
+    state = {"vals": ("alpha", "beta")}
+    s = ColumnSpec(
+        name="x", label="X", kind=Kind.ENUM,
+        enum_values=lambda: state["vals"],
+    )
+    assert s.resolved_enum_values == ("alpha", "beta")
+    state["vals"] = ("gamma",)
+    assert s.resolved_enum_values == ("gamma",)  # Re-resolves each access
+
+
+def test_callable_enum_values_skips_eager_comma_validation() -> None:
+    # Callable form defers validation until resolution.
+    # Constructing the spec must not raise even though the callable
+    # would eventually be inspected for commas.
+    s = ColumnSpec(
+        name="x", label="X", kind=Kind.ENUM,
+        enum_values=lambda: ("legal_value",),
+    )
+    assert s.resolved_enum_values == ("legal_value",)
+
+
+def test_tuple_enum_values_still_eagerly_validated_for_commas() -> None:
+    with pytest.raises(ValueError, match="comma"):
+        ColumnSpec(
+            name="x", label="X", kind=Kind.ENUM,
+            enum_values=("with,comma",),
+        )
+
+
+def test_resolved_enum_values_returns_empty_tuple_when_none() -> None:
+    s = ColumnSpec(name="x", label="X", kind=Kind.TEXT)  # No enum_values
+    assert s.resolved_enum_values == ()

--- a/tests/test_reject_reasons_cache_and_chips.py
+++ b/tests/test_reject_reasons_cache_and_chips.py
@@ -1,0 +1,116 @@
+"""End-to-end regression: save_reject_reasons() → next request reflects.
+
+Pins the contract: after save_reject_reasons() is called the next HTTP
+request against both the board reject-reason dropdown
+(Jinja global reject_reason_options, /board/dashboard) and the
+/board/rejected/ filter chip values (ColumnSpec.resolved_enum_values)
+returns the updated reasons — with NO restart, cache reset, or
+_reset_cache() call. (#490)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # 1. Point _REJECT_REASONS_PATH at a tmpdir YAML before create_app().
+    yaml_path = tmp_path / "reject_reasons.yaml"
+    yaml_path.write_text("reasons:\n  - Initial Reason\n")
+    from findajob import config_loader
+
+    monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", yaml_path)
+
+    # 2. Minimal schema sufficient for /board/dashboard and /board/rejected.
+    #    Dashboard requires: id, fingerprint, title, company, stage,
+    #      relevance_score, fit_score, probability_score, interview_likelihood,
+    #      location, remote_status, known_contacts, comp_estimate, ai_notes,
+    #      created_at, stage_updated, url, prep_folder_path
+    #    Rejected additionally requires: reject_reason; both routes LEFT JOIN
+    #      audit_log.
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs ("
+        "id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, company TEXT, "
+        "stage TEXT, reject_reason TEXT, relevance_score INTEGER, "
+        "fit_score REAL, probability_score REAL, interview_likelihood INTEGER, "
+        "location TEXT, remote_status TEXT, known_contacts TEXT, "
+        "comp_estimate TEXT, ai_notes TEXT, created_at TEXT, "
+        "stage_updated TEXT, url TEXT, prep_folder_path TEXT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log ("
+        "id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT"
+        ")"
+    )
+    # A high-scoring dashboard row (score >= 7 passes the default floor).
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, url) "
+        "VALUES ('id-dash','fp-dash','Staff Eng','Meta','scored',9,"
+        "'https://example.com/j1')"
+    )
+    # A rejected row — ensures /board/rejected/ renders filter chips even with data.
+    # Use a reject_reason value that is NOT one of the YAML reasons being tested
+    # so that row-data text doesn't interfere with chip-value assertions.
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, reject_reason, url) "
+        "VALUES ('id-rej','fp-rej','Old Role','Acme','rejected','Geography',"
+        "'https://example.com/j2')"
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, "
+        "changed_at, changed_by) "
+        "VALUES ('id-rej','stage','scored','rejected','2026-01-01 00:00:00','user')"
+    )
+    conn.commit()
+    conn.close()
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+def test_dropdown_reflects_save_without_restart(client: TestClient, tmp_path: Path) -> None:
+    """Save → board reject-reason dropdown reflects on next request."""
+    resp = client.get("/board/dashboard")
+    assert resp.status_code == 200
+    assert "Initial Reason" in resp.text
+
+    from findajob.config_loader import save_reject_reasons
+
+    save_reject_reasons(("Brand New Reason",), frozenset())
+
+    # Same client, no restart, no _reset_cache. Next request must reflect.
+    resp = client.get("/board/dashboard")
+    assert resp.status_code == 200
+    assert "Brand New Reason" in resp.text
+    assert "Initial Reason" not in resp.text
+
+
+def test_filter_chips_reflect_save_without_restart(client: TestClient, tmp_path: Path) -> None:
+    """Save → /board/rejected filter chip values reflect on next request."""
+    resp = client.get("/board/rejected")
+    assert resp.status_code == 200
+    assert "Initial Reason" in resp.text
+
+    from findajob.config_loader import save_reject_reasons
+
+    save_reject_reasons(("Updated Reason",), frozenset())
+
+    resp = client.get("/board/rejected")
+    assert resp.status_code == 200
+    assert "Updated Reason" in resp.text
+    assert "Initial Reason" not in resp.text

--- a/tests/test_reject_reasons_removed_in_history.py
+++ b/tests/test_reject_reasons_removed_in_history.py
@@ -1,0 +1,131 @@
+"""AC #3 from #490: a reason that exists in `feedback_log` historical
+rows but has been removed from `reject_reasons.yaml` MUST NOT break
+/board/dashboard/, /stats/, or /board/rejected/.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob import config_loader
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def client_with_orphan_feedback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # 1. reject_reasons.yaml WITHOUT "Orphaned Reason"
+    yaml_path = tmp_path / "reject_reasons.yaml"
+    yaml_path.write_text("reasons:\n  - Skills Mismatch\n  - Wrong Domain\n")
+    monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", yaml_path)
+
+    # 2. SQLite with the schemas the three views need.
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE jobs (
+            id TEXT PRIMARY KEY,
+            fingerprint TEXT UNIQUE NOT NULL,
+            loose_fingerprint TEXT,
+            url TEXT NOT NULL,
+            title TEXT NOT NULL,
+            company TEXT NOT NULL,
+            location TEXT DEFAULT '',
+            source TEXT NOT NULL,
+            raw_jd_text TEXT,
+            remote_status TEXT DEFAULT 'Unknown',
+            known_contacts TEXT DEFAULT '',
+            ai_notes TEXT,
+            relevance_score INTEGER,
+            fit_score REAL,
+            probability_score REAL,
+            interview_likelihood INTEGER,
+            stage TEXT DEFAULT 'discovered',
+            apply_flag INTEGER DEFAULT 0,
+            reject_reason TEXT DEFAULT '',
+            prep_folder_path TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            stage_updated TEXT,
+            dupe_of TEXT DEFAULT '',
+            synthetic INTEGER NOT NULL DEFAULT 0,
+            score_flag_reason TEXT,
+            comp_estimate TEXT,
+            user_notes TEXT
+        );
+        CREATE TABLE audit_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id TEXT NOT NULL,
+            field_changed TEXT NOT NULL,
+            old_value TEXT,
+            new_value TEXT,
+            changed_at TEXT DEFAULT (datetime('now')),
+            changed_by TEXT DEFAULT 'system'
+        );
+        CREATE TABLE feedback_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            company TEXT NOT NULL,
+            relevance_score INTEGER,
+            reject_reason TEXT NOT NULL,
+            jd_excerpt TEXT DEFAULT '',
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        CREATE TABLE cost_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id TEXT,
+            cost_usd REAL,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        """
+    )
+
+    # 3. Insert one rejected job + a feedback_log row whose reason is
+    #    NOT in the current YAML — this is the orphan condition.
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, reject_reason, "
+        "source, url, created_at) "
+        "VALUES ('fp-orphan', 'fp-orphan', 'Some Job', 'Acme', 'rejected', "
+        "'Orphaned Reason', 'test', 'https://example.com/j1', '2026-04-01 00:00:00')"
+    )
+    conn.execute(
+        "INSERT INTO feedback_log (job_id, title, company, relevance_score, reject_reason, "
+        "created_at) "
+        "VALUES ('fp-orphan', 'Some Job', 'Acme', 5, 'Orphaned Reason', "
+        "'2026-04-01 00:00:00')"
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, "
+        "changed_at, changed_by) "
+        "VALUES ('fp-orphan', 'stage', 'scored', 'rejected', '2026-04-01 00:00:00', 'user')"
+    )
+    conn.commit()
+    conn.close()
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+
+    return TestClient(
+        create_app(companies_root=companies, db_path=db, base_root=tmp_path),
+        follow_redirects=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/board/dashboard/",
+        "/stats/",
+        "/board/rejected/",
+    ],
+)
+def test_orphan_reason_does_not_break_view(client_with_orphan_feedback: TestClient, path: str) -> None:
+    resp = client_with_orphan_feedback.get(path)
+    assert resp.status_code == 200, f"{path} returned {resp.status_code}: {resp.text[:500]}"

--- a/tests/test_settings_reject_reasons.py
+++ b/tests/test_settings_reject_reasons.py
@@ -71,9 +71,7 @@ def test_get_renders_current_reasons(client: TestClient) -> None:
     assert "Geography" in resp.text
 
 
-def test_post_happy_path_writes_yaml_and_returns_partial(
-    client: TestClient, yaml_path: Path
-) -> None:
+def test_post_happy_path_writes_yaml_and_returns_partial(client: TestClient, yaml_path: Path) -> None:
     resp = client.post(
         "/settings/reject-reasons/",
         data={
@@ -120,9 +118,7 @@ def test_post_validation_error_does_not_write(client: TestClient, yaml_path: Pat
     assert yaml_path.read_text() == original  # File unchanged
 
 
-def test_post_empty_after_strip_returns_validation_error(
-    client: TestClient, yaml_path: Path
-) -> None:
+def test_post_empty_after_strip_returns_validation_error(client: TestClient, yaml_path: Path) -> None:
     original = yaml_path.read_text()
     resp = client.post(
         "/settings/reject-reasons/",

--- a/tests/test_settings_reject_reasons.py
+++ b/tests/test_settings_reject_reasons.py
@@ -1,0 +1,133 @@
+"""Tests for GET + POST /settings/reject-reasons/ (#490).
+
+Covers Task 6 (GET renders current values), Task 7 (full UX — structural
+presence checked via the stub/full template), and Task 8 (POST validate+save).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob import config_loader
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+
+
+@pytest.fixture
+def yaml_path(tmp_path: Path) -> Path:
+    p = tmp_path / "reject_reasons.yaml"
+    p.write_text("reasons:\n  - Skills Mismatch\n  - Geography\n")
+    return p
+
+
+@pytest.fixture
+def client(tmp_path: Path, yaml_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # 1. Point _REJECT_REASONS_PATH at the tmpdir YAML before create_app().
+    monkeypatch.setattr(config_loader, "_REJECT_REASONS_PATH", yaml_path)
+
+    # 2. Minimal schema — settings routes don't query jobs/audit_log, but
+    #    create_app wires the full router which may reference them transitively
+    #    (e.g., the nav spend chip). Use the same minimal schema as the
+    #    cache_and_chips fixture to avoid surprises.
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs ("
+        "id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, company TEXT, "
+        "stage TEXT, reject_reason TEXT, relevance_score INTEGER, "
+        "fit_score REAL, probability_score REAL, interview_likelihood INTEGER, "
+        "location TEXT, remote_status TEXT, known_contacts TEXT, "
+        "comp_estimate TEXT, ai_notes TEXT, created_at TEXT, "
+        "stage_updated TEXT, url TEXT, prep_folder_path TEXT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log ("
+        "id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT"
+        ")"
+    )
+    conn.commit()
+    conn.close()
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+
+    # mark_complete must run BEFORE create_app so the onboarding flag is set.
+    mark_complete(tmp_path)
+
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+def test_get_renders_current_reasons(client: TestClient) -> None:
+    """GET /settings/reject-reasons/ shows seeded reasons from the YAML."""
+    resp = client.get("/settings/reject-reasons/")
+    assert resp.status_code == 200
+    assert "Skills Mismatch" in resp.text
+    assert "Geography" in resp.text
+
+
+def test_post_happy_path_writes_yaml_and_returns_partial(
+    client: TestClient, yaml_path: Path
+) -> None:
+    resp = client.post(
+        "/settings/reject-reasons/",
+        data={
+            "row_count": "2",
+            "reason_0": "Skills Mismatch",
+            "title_signal_0": "on",
+            "reason_1": "Wrong Domain",
+        },
+    )
+    assert resp.status_code == 200
+    assert "Saved" in resp.text
+    body = yaml_path.read_text()
+    assert "Skills Mismatch" in body
+    assert "Wrong Domain" in body
+    assert "title_signal_reasons" in body
+
+
+def test_post_strips_empty_rows(client: TestClient, yaml_path: Path) -> None:
+    """Empty rows in the form (user clicked Add but didn't type) are dropped."""
+    resp = client.post(
+        "/settings/reject-reasons/",
+        data={
+            "row_count": "3",
+            "reason_0": "Real Reason",
+            "reason_1": "",
+            "reason_2": "  ",  # whitespace-only
+        },
+    )
+    assert resp.status_code == 200
+    assert "Saved" in resp.text
+    body = yaml_path.read_text()
+    assert "Real Reason" in body
+
+
+def test_post_validation_error_does_not_write(client: TestClient, yaml_path: Path) -> None:
+    original = yaml_path.read_text()
+    resp = client.post(
+        "/settings/reject-reasons/",
+        data={"row_count": "1", "reason_0": "with,comma"},
+    )
+    assert resp.status_code == 200  # HTMX error partial returns 200
+    assert "Could not save" in resp.text
+    assert "comma" in resp.text.lower()
+    assert yaml_path.read_text() == original  # File unchanged
+
+
+def test_post_empty_after_strip_returns_validation_error(
+    client: TestClient, yaml_path: Path
+) -> None:
+    original = yaml_path.read_text()
+    resp = client.post(
+        "/settings/reject-reasons/",
+        data={"row_count": "1", "reason_0": ""},
+    )
+    assert resp.status_code == 200
+    assert "Could not save" in resp.text
+    assert yaml_path.read_text() == original


### PR DESCRIPTION
## Summary

- Adds `/settings/reject-reasons/` rich editor for `config/reject_reasons.yaml` — edit your reject-reason taxonomy at any time without re-running onboarding (#490)
- Establishes the `/settings/` URL namespace as the home for domain-aware config editors (vs. `/config/`'s raw text editor for any allowlisted file)
- Fixes a latent caching bug along the way: `load_reject_reasons` had a module-level cache + `web/filters/registry.py` captured chip values at import time. Without these, saved YAML changes would not have surfaced until container restart — making AC #2 ("no recompose required") false. Now they take effect on the next request.

## How it works end-to-end

- **GET** `/settings/reject-reasons/` renders editable rows from current YAML (Alpine `x-data`, server-seeded with `tojson`).
- **POST** validates server-side (`save_reject_reasons` rejects empty, comma-in-reason, duplicate, title_signal not in reasons) and writes via tempfile + `os.replace`. On failure, file is unchanged and inline HTMX partial shows the error. On success, partial confirms save.
- Loader (`load_reject_reasons`) is no-cache; tiny YAML, parse-per-call cost is microseconds. Dropdown rendering (Jinja global `reject_reason_options()` in `app.py:46-52`) and filter chip values (`ColumnSpec.enum_values` now accepts a callable, resolved per-request via new `resolved_enum_values` property) both refresh per request.

## What's covered by tests

- 9 new tests in `TestSaveRejectReasons` + 1 in `TestLoadRejectReasons` (cache-removed) → `tests/test_config_loader.py`
- 5 new tests for callable `enum_values` → `tests/test_filter_spec.py`
- 5 POST/GET tests → `tests/test_settings_reject_reasons.py`
- 2 cache-and-chips no-restart regression tests → `tests/test_reject_reasons_cache_and_chips.py`
- 3 parametrized AC #3 regression tests (orphan reason in feedback_log doesn't break /board/dashboard, /stats/, /board/rejected/) → `tests/test_reject_reasons_removed_in_history.py`

24 new tests total. Full suite: 1874 passed, 1 skipped, 0 failures.

## AC #5 interpretation note

The issue body's AC #5 says "Saving an empty list falls back to `_DEFAULT_REJECT_REASONS` (current loader behavior — pin it as a test)." This PR reads that as a **regression-test ask** for the loader's existing fallback, not a UX requirement that the writer accept empty saves. The writer **rejects** empty saves with a validation error (better UX, prevents accidental nuke). The loader's fallback for missing/empty file is unchanged and pinned by `test_load_reject_reasons_falls_back_to_defaults_when_file_missing` and `test_empty_reasons_returns_defaults`. This deviation from a literal AC reading is documented in the implementation plan and Session note on #490.

## Test plan

- [ ] `uv run pytest` — full suite green (1874 passed, 1 skipped on this branch)
- [ ] `uv run ruff check && uv run ruff format --check && uv run mypy src/` — all clean
- [ ] Manual on `findajob-test` after merge: save a new reason in `/settings/reject-reasons/`, verify it appears in `/board/dashboard/` reject dropdown and `/board/rejected/` filter chips on next page load (no container restart)
- [ ] Manual: validation paths (comma, duplicate, empty after strip) show error banner without writing the file
- [ ] AC #3 regression: remove a reason that has historical `feedback_log` rows; verify `/board/dashboard/`, `/stats/`, `/board/rejected/` all render 200

## Migration required

None — no schema, config, crontab, mount, or compose changes. `config/reject_reasons.yaml` was already gitignored and per-stack; existing stacks pick up the editor on `docker compose pull` + `docker compose up -d` without operator action. (Auth-gate verifier still runs post-deploy per the v0.20.1 hard rule.)

## Release ceremony

This PR will tag as v0.20.2 on merge. Cohort deploy per `docs/release-process.md`: operator + `findajob-test` on `:latest`, tester cohort (alice, papa, dave, judy, tango) bumps from `:v0.20.1` to `:v0.20.2` on the existing `:v0.20` moving alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)