### PR TITLE
fix(web): #490 Add Reason broken (x-data quote collision) + plain-language copy

### DIFF
--- a/src/findajob/web/templates/settings/reject_reasons.html
+++ b/src/findajob/web/templates/settings/reject_reasons.html
@@ -3,24 +3,30 @@
 {% block content %}
 <div class="max-w-2xl">
   <h1 class="text-2xl font-semibold mb-1">Reject reasons</h1>
+  <p class="text-sm text-slate-600 mb-2">
+    When you reject a job on your board, you pick a reason from a list.
+    This is that list — add, rename, or remove reasons so the choices
+    match how <em>you</em> think about why a job isn't a fit. Saved
+    changes show up the next time you load the board.
+  </p>
   <p class="text-sm text-slate-600 mb-6">
-    Edit the reject-reason taxonomy used on the board's reject button.
-    Changes apply on the next page load — no restart required.
-    Check <strong>title-signal</strong> for reasons that mean the scorer misread
-    the title (used by feedback analysis to find prefilter candidates).
+    Tick <strong>title-signal</strong> on a reason if it means "the job
+    title looked like a match but the actual job wasn't" — that tells
+    findajob to learn which kinds of job titles to filter out automatically
+    next time.
   </p>
 
+  {# JSON.parse from a <script> tag avoids the double-quote / x-data
+     attribute collision: tojson emits unescaped " inside the JSON, which
+     closes a double-quoted x-data attribute at the first " of "text".
+     A <script type="application/json"> block keeps the JSON intact, then
+     Alpine reads it via document.getElementById(...).textContent. #}
+  <script id="initial-rows" type="application/json">{{ rows | tojson }}</script>
   <div
     x-data="{
-      rows: {{ rows | tojson }}.map(function(r) {
-        return { text: r.text, title_signal: r.title_signal };
-      }),
-      addRow: function() {
-        this.rows.push({ text: '', title_signal: false });
-      },
-      removeRow: function(i) {
-        this.rows.splice(i, 1);
-      }
+      rows: JSON.parse(document.getElementById('initial-rows').textContent),
+      addRow() { this.rows.push({ text: '', title_signal: false }); },
+      removeRow(i) { this.rows.splice(i, 1); }
     }"
   >
     <form

--- a/tests/test_settings_reject_reasons.py
+++ b/tests/test_settings_reject_reasons.py
@@ -127,3 +127,41 @@ def test_post_empty_after_strip_returns_validation_error(client: TestClient, yam
     assert resp.status_code == 200
     assert "Could not save" in resp.text
     assert yaml_path.read_text() == original
+
+
+def test_initial_rows_in_script_block_not_inline_x_data(client: TestClient) -> None:
+    """Regression test for the Add Reason broken-on-first-deploy bug.
+
+    The seed JSON for Alpine's `rows` array MUST live in a
+    <script id="initial-rows" type="application/json"> block, NOT inline
+    inside the x-data="..." attribute. tojson emits unescaped " inside
+    the JSON; if that lands inline in a double-quoted x-data attribute,
+    the browser closes the attribute at the first " of "text" and Alpine
+    never sees addRow/removeRow — the Add Reason button does nothing.
+
+    The script-block pattern is:
+        <script id="initial-rows" type="application/json">{{ rows|tojson }}</script>
+        <div x-data="{ rows: JSON.parse(document.getElementById('initial-rows').textContent), ... }">
+
+    This test catches a regression to the broken inline form by asserting:
+      1. The script block is present
+      2. The x-data attribute does not contain a literal `[{` (which is
+         the start of the inlined JSON array — the broken-form smoking gun)
+    """
+    resp = client.get("/settings/reject-reasons/")
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Pin: JSON seed lives in a script block.
+    assert '<script id="initial-rows" type="application/json">' in body, (
+        "Initial rows must be in a <script type=application/json> block, "
+        "not inline in x-data — see test docstring for the bug class."
+    )
+    # Pin: x-data does not contain inlined JSON array.
+    # Find the x-data attribute and verify no [{ in its value.
+    import re
+
+    match = re.search(r'x-data\s*=\s*"([^"]*)"', body)
+    assert match, "x-data attribute not found"
+    x_data_value = match.group(1)
+    assert "[{" not in x_data_value, f"x-data must not contain inline JSON array. Got: {x_data_value!r}"


### PR DESCRIPTION
## Summary

Hotfix on top of v0.20.2 (#491). Two issues reported by alice within 30 min of deploy:

1. **Add Reason button does nothing.** `{{ rows | tojson }}` inlined in `x-data="..."` — JSON's `"` characters close the double-quoted HTML attribute at the first `"text"`, browser never gives Alpine the `addRow`/`removeRow` definitions. Standard Jinja+Alpine pitfall I should have caught (visual gap I flagged in Task 10's manual-verification deferral — exactly the bug class TestClient can't see).
2. **Intro paragraph was developer jargon.** Words like "taxonomy", "scorer", "prefilter candidates", "no recompose required" mean nothing to non-technical users.

## Fixes

1. JSON seed moved into `<script id="initial-rows" type="application/json">` block; `x-data` reads it via `JSON.parse(document.getElementById('initial-rows').textContent)`. Standard Alpine pattern for non-trivial init data.
2. Intro rewritten in plain language: "When you reject a job on your board, you pick a reason from a list. This is that list…"

## Regression test

New `test_initial_rows_in_script_block_not_inline_x_data` pins the contract: asserts the `<script>` block is present AND the `x-data` attribute does NOT contain inline `[{` (the smoking gun for the broken form). Catches future regressions to the inline pattern.

## Test plan

- [ ] `uv run pytest tests/test_settings_reject_reasons.py -v` — 6/6 pass
- [ ] Manual on alice's stack post-deploy: click "+ Add reason" — new empty row appears
- [ ] Manual: x-click an existing row's `×` button — row removes
- [ ] Manual: edit + Save — green confirmation banner appears

## Migration required

None. Template-only fix on a per-stack-gitignored config editor; no schema, env, or compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)