### PR TITLE
test(schema): #513 #514 — fresh + legacy schema baseline tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
-_(no entries yet)_
+### Added
+- **#513 #514 schema baseline regression tests.** Two paired tests lock the schema contract before the M3+ structural refactor work: `tests/test_schema_baseline_fresh.py` asserts that a fresh `init_db.py` against an empty tmpdir matches a committed JSON snapshot at `tests/fixtures/schema_baseline_fresh.json`; `tests/test_schema_baseline_legacy.py` asserts that a v0.10.0-shape fixture run through the production deployment arc (`init_db.py` + `migrate_schema()`) ends up structurally identical to the fresh baseline. The snapshot captures `sqlite_master.sql` text per object (whitespace + comment normalized) alongside structured PRAGMA output, so `CHECK` constraints and partial-index `WHERE` clauses are part of the contract — not just columns and FKs. To regenerate the snapshot when a schema change is intentional: `UPDATE_SCHEMA_SNAPSHOT=1 uv run pytest tests/test_schema_baseline_fresh.py`. Drift now fails the test and forces an explicit migration decision in the same PR.
 
 ## [0.20.3] — 2026-05-07
 

--- a/tests/_schema_introspect.py
+++ b/tests/_schema_introspect.py
@@ -1,0 +1,138 @@
+"""Schema introspection helper for baseline/legacy schema tests.
+
+Returns a deterministic, JSON-serializable representation of an open SQLite
+connection's schema. Captures both:
+
+- Structured PRAGMA output (``table_info`` + ``foreign_key_list``) — easy
+  to diff column-by-column when a structural change lands.
+- Normalized ``sqlite_master.sql`` text per object — covers ``CHECK``
+  constraints and partial-index ``WHERE`` clauses that PRAGMA omits.
+
+Used by ``tests/test_schema_baseline_fresh.py`` (#513) and
+``tests/test_schema_baseline_legacy.py`` (#514).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Any
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_LINE_COMMENT_RE = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_PUNCT_PADDING_RE = re.compile(r"\s*([(),;])\s*")
+
+
+def _normalize_sql(sql: str | None) -> str | None:
+    """Strip SQL comments + normalize whitespace; preserve everything structural.
+
+    SQL comments aren't part of the schema contract — a fresh ``CREATE
+    TABLE`` block with inline ``-- explanatory`` comments and a legacy
+    table reshaped via ``ALTER TABLE ADD COLUMN`` (which strips comments
+    and chooses its own whitespace style) must compare equal. We:
+
+    - strip ``--`` line comments and ``/* */`` block comments
+    - remove whitespace adjacent to ``(``, ``)``, ``,``, ``;`` so punctuation
+      style differences don't trigger false-positive diffs
+    - collapse remaining whitespace runs to a single space.
+
+    Limitation: the punctuation-padding rule operates on raw text, so a
+    string-literal default containing one of ``(),;`` (e.g.
+    ``DEFAULT 'a, b'``) would have its internal whitespace mangled. The
+    current schema has no such defaults; revisit this if a future column
+    adds one. Detecting string literals up-front (``r"'(?:[^']|'')*'"``)
+    is the principled fix.
+    """
+    if sql is None:
+        return None
+    sql = _BLOCK_COMMENT_RE.sub(" ", sql)
+    sql = _LINE_COMMENT_RE.sub(" ", sql)
+    sql = _PUNCT_PADDING_RE.sub(r"\1", sql)
+    return _WHITESPACE_RE.sub(" ", sql).strip()
+
+
+def introspect(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Return a deterministic dict describing the schema of ``conn``."""
+    objects: list[dict[str, Any]] = []
+    rows = conn.execute(
+        "SELECT type, name, tbl_name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+    ).fetchall()
+    for type_, name, tbl_name, sql in rows:
+        obj: dict[str, Any] = {
+            "type": type_,
+            "name": name,
+            "tbl_name": tbl_name,
+            "sql": _normalize_sql(sql),
+        }
+        if type_ == "table":
+            obj["columns"] = [
+                {
+                    "cid": cid,
+                    "name": cname,
+                    "type": ctype,
+                    "notnull": cnotnull,
+                    "dflt_value": cdflt,
+                    "pk": cpk,
+                }
+                for cid, cname, ctype, cnotnull, cdflt, cpk in conn.execute(f'PRAGMA table_info("{name}")').fetchall()
+            ]
+            obj["foreign_keys"] = [
+                {
+                    "id": fid,
+                    "seq": fseq,
+                    "table": ftable,
+                    "from": ffrom,
+                    "to": fto,
+                    "on_update": fon_update,
+                    "on_delete": fon_delete,
+                    "match": fmatch,
+                }
+                for (
+                    fid,
+                    fseq,
+                    ftable,
+                    ffrom,
+                    fto,
+                    fon_update,
+                    fon_delete,
+                    fmatch,
+                ) in conn.execute(f'PRAGMA foreign_key_list("{name}")').fetchall()
+            ]
+        objects.append(obj)
+    return {
+        "sqlite_version": sqlite3.sqlite_version,
+        "objects": objects,
+    }
+
+
+def diff_summary(actual: dict[str, Any], expected: dict[str, Any]) -> str:
+    """Produce a readable summary of where two introspection dicts differ.
+
+    Returns the empty string when they match. Otherwise lists, in order:
+    sqlite_version mismatch, added objects, removed objects, changed objects
+    (with a per-field breakdown).
+    """
+    lines: list[str] = []
+    if actual.get("sqlite_version") != expected.get("sqlite_version"):
+        lines.append(
+            f"sqlite_version: actual={actual.get('sqlite_version')!r} expected={expected.get('sqlite_version')!r}"
+        )
+    actual_by_key = {(o["type"], o["name"]): o for o in actual.get("objects", [])}
+    expected_by_key = {(o["type"], o["name"]): o for o in expected.get("objects", [])}
+    added = sorted(actual_by_key.keys() - expected_by_key.keys())
+    removed = sorted(expected_by_key.keys() - actual_by_key.keys())
+    common = sorted(actual_by_key.keys() & expected_by_key.keys())
+    for key in added:
+        lines.append(f"+ added {key[0]} {key[1]!r}")
+    for key in removed:
+        lines.append(f"- removed {key[0]} {key[1]!r}")
+    for key in common:
+        a, e = actual_by_key[key], expected_by_key[key]
+        if a == e:
+            continue
+        lines.append(f"~ changed {key[0]} {key[1]!r}:")
+        for field in sorted(set(a) | set(e)):
+            if a.get(field) != e.get(field):
+                lines.append(f"    {field}: actual={a.get(field)!r} expected={e.get(field)!r}")
+    return "\n".join(lines)

--- a/tests/_schema_introspect.py
+++ b/tests/_schema_introspect.py
@@ -53,7 +53,16 @@ def _normalize_sql(sql: str | None) -> str | None:
 
 
 def introspect(conn: sqlite3.Connection) -> dict[str, Any]:
-    """Return a deterministic dict describing the schema of ``conn``."""
+    """Return a deterministic dict describing the schema of ``conn``.
+
+    The returned shape is ``{"objects": [...]}`` — sorted, JSON-serializable.
+    SQLite version is intentionally **not** captured: it is metadata about
+    the runtime, not the schema, and its inclusion in earlier drafts caused
+    CI / local SQLite-version skew to false-positive the equality check.
+    Any genuine change in how SQLite stores ``sqlite_master.sql`` between
+    versions still surfaces — through the ``sql`` field of the affected
+    objects, which is the actual contract.
+    """
     objects: list[dict[str, Any]] = []
     rows = conn.execute(
         "SELECT type, name, tbl_name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
@@ -100,24 +109,17 @@ def introspect(conn: sqlite3.Connection) -> dict[str, Any]:
                 ) in conn.execute(f'PRAGMA foreign_key_list("{name}")').fetchall()
             ]
         objects.append(obj)
-    return {
-        "sqlite_version": sqlite3.sqlite_version,
-        "objects": objects,
-    }
+    return {"objects": objects}
 
 
 def diff_summary(actual: dict[str, Any], expected: dict[str, Any]) -> str:
     """Produce a readable summary of where two introspection dicts differ.
 
     Returns the empty string when they match. Otherwise lists, in order:
-    sqlite_version mismatch, added objects, removed objects, changed objects
-    (with a per-field breakdown).
+    added objects, removed objects, changed objects (with a per-field
+    breakdown).
     """
     lines: list[str] = []
-    if actual.get("sqlite_version") != expected.get("sqlite_version"):
-        lines.append(
-            f"sqlite_version: actual={actual.get('sqlite_version')!r} expected={expected.get('sqlite_version')!r}"
-        )
     actual_by_key = {(o["type"], o["name"]): o for o in actual.get("objects", [])}
     expected_by_key = {(o["type"], o["name"]): o for o in expected.get("objects", [])}
     added = sorted(actual_by_key.keys() - expected_by_key.keys())

--- a/tests/fixtures/_legacy_v0_10_setup.py
+++ b/tests/fixtures/_legacy_v0_10_setup.py
@@ -1,0 +1,178 @@
+"""Deterministic v0.10.0-shape SQLite fixture generator (#514).
+
+The exact DDL is captured here as a literal string — the source is::
+
+    git show v0.10.0:scripts/init_db.py
+
+v0.10.0 is the canonical "first containerized release" baseline (per
+issue #514). Migration arc since v0.10.0 includes:
+
+- ``cost_calibration`` table added then dropped (handled inline in current
+  ``scripts/init_db.py`` — no-op against v0.10.0 since the table was never
+  there).
+- ``notifications`` table + 3 indexes added (handled by ``CREATE TABLE
+  IF NOT EXISTS`` in current ``init_db.py``).
+- ``idx_cost_log_job_id`` added (handled by ``CREATE INDEX IF NOT EXISTS``).
+- ``onboarding_sessions`` gained ``tester_openrouter_key``,
+  ``tester_rapidapi_key``, ``cumulative_cost_usd`` and lost
+  ``tester_google_key`` (handled by ``migrate_schema()`` in
+  ``findajob.onboarding.session_store``).
+
+Embedding the DDL as a literal — rather than checking in a binary
+``.db`` file — keeps git diff useful: any future "fix" to the captured
+shape shows up as a code review on the historical record, not as an
+opaque blob change.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+V0_10_0_DDL = """
+CREATE TABLE IF NOT EXISTS jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    loose_fingerprint TEXT,
+    url TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    location TEXT DEFAULT '',
+    source TEXT NOT NULL,
+    raw_jd_text TEXT,
+
+    relevance_score INTEGER CHECK(relevance_score BETWEEN 1 AND 10),
+    interview_likelihood INTEGER CHECK(interview_likelihood BETWEEN 1 AND 10),
+    strengths_alignment TEXT,
+    industry_sector TEXT,
+    comp_estimate TEXT DEFAULT '',
+    ai_notes TEXT,
+    score_status TEXT CHECK(score_status IN ('scored', 'manual_review', 'needs_info')),
+    score_flag_reason TEXT,
+    remote_status TEXT DEFAULT 'Unknown',
+
+    network_depth INTEGER DEFAULT 0,
+    known_contacts TEXT DEFAULT '',
+    stage TEXT DEFAULT 'discovered' CHECK(stage IN (
+        'discovered', 'enriched', 'scored', 'manual_review',
+        'prep_in_progress', 'materials_drafted', 'waitlisted', 'applied',
+        'response_received', 'interview', 'offer', 'rejected', 'withdrawn'
+    )),
+    stage_updated TEXT,
+    status TEXT DEFAULT 'active' CHECK(status IN (
+        'active', 'manual_review', 'skipped', 'applied',
+        'rejected', 'interviewing', 'offer'
+    )),
+    apply_flag INTEGER DEFAULT 0,
+    reject_reason TEXT DEFAULT '',
+    prep_folder_path TEXT,
+    gdrive_folder_url TEXT,
+    fit_score REAL,
+    probability_score REAL,
+    user_notes TEXT DEFAULT '',
+
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    dupe_of TEXT DEFAULT '',
+    synthetic INTEGER NOT NULL DEFAULT 0,
+    speculative_briefing_folder TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_fingerprint ON jobs(fingerprint);
+CREATE INDEX IF NOT EXISTS idx_jobs_loose_fingerprint ON jobs(loose_fingerprint);
+CREATE INDEX IF NOT EXISTS idx_jobs_stage ON jobs(stage);
+CREATE INDEX IF NOT EXISTS idx_jobs_apply_flag ON jobs(apply_flag);
+CREATE INDEX IF NOT EXISTS idx_jobs_updated ON jobs(updated_at);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    field_changed TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_at TEXT DEFAULT (datetime('now')),
+    changed_by TEXT DEFAULT 'system'
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_job_id ON audit_log(job_id);
+
+CREATE TABLE IF NOT EXISTS cost_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT,
+    operation TEXT NOT NULL,
+    model TEXT NOT NULL,
+    latency_ms INTEGER,
+    success INTEGER DEFAULT 1,
+    error_message TEXT,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cost_usd REAL,
+    logged_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS feedback_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    relevance_score INTEGER,
+    reject_reason TEXT NOT NULL,
+    jd_excerpt TEXT DEFAULT '',
+    created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS duplicate_groups (
+    canonical_fingerprint TEXT NOT NULL,
+    duplicate_job_id TEXT NOT NULL,
+    detected_at TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (canonical_fingerprint, duplicate_job_id)
+);
+
+CREATE TABLE IF NOT EXISTS speculative_requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    company TEXT NOT NULL,
+    hint TEXT,
+    personal_notes TEXT,
+    status TEXT NOT NULL DEFAULT 'researching' CHECK(status IN (
+        'researching', 'ready_for_review', 'approved', 'trashed', 'failed'
+    )),
+    error_message TEXT,
+    briefing_md TEXT,
+    role_cards_json TEXT,
+    briefing_folder TEXT,
+    submitted_at TEXT NOT NULL DEFAULT (datetime('now')),
+    research_completed_at TEXT,
+    approved_at TEXT,
+    approved_role_count INTEGER,
+    briefing_prompt_version TEXT,
+    synth_prompt_version TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_speculative_status ON speculative_requests(status);
+CREATE INDEX IF NOT EXISTS idx_speculative_company_submitted ON speculative_requests(company, submitted_at);
+
+CREATE TABLE IF NOT EXISTS onboarding_sessions (
+    id TEXT PRIMARY KEY,
+    history_json TEXT NOT NULL,
+    captured_blocks_json TEXT NOT NULL DEFAULT '{}',
+    started_at TEXT NOT NULL,
+    last_turn_at TEXT NOT NULL,
+    completed_at TEXT,
+    error_state TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_onboarding_sessions_completed ON onboarding_sessions(completed_at);
+"""
+
+
+def write_v0_10_0_db(db_path: Path) -> None:
+    """Create a v0.10.0-shape SQLite DB at ``db_path``. No data — schema only."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if db_path.exists():
+        db_path.unlink()
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(V0_10_0_DDL)
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/fixtures/schema_baseline_fresh.json
+++ b/tests/fixtures/schema_baseline_fresh.json
@@ -1,0 +1,955 @@
+{
+  "objects": [
+    {
+      "name": "idx_audit_job_id",
+      "sql": "CREATE INDEX idx_audit_job_id ON audit_log(job_id)",
+      "tbl_name": "audit_log",
+      "type": "index"
+    },
+    {
+      "name": "idx_cost_log_job_id",
+      "sql": "CREATE INDEX idx_cost_log_job_id ON cost_log(job_id)",
+      "tbl_name": "cost_log",
+      "type": "index"
+    },
+    {
+      "name": "idx_jobs_apply_flag",
+      "sql": "CREATE INDEX idx_jobs_apply_flag ON jobs(apply_flag)",
+      "tbl_name": "jobs",
+      "type": "index"
+    },
+    {
+      "name": "idx_jobs_fingerprint",
+      "sql": "CREATE INDEX idx_jobs_fingerprint ON jobs(fingerprint)",
+      "tbl_name": "jobs",
+      "type": "index"
+    },
+    {
+      "name": "idx_jobs_loose_fingerprint",
+      "sql": "CREATE INDEX idx_jobs_loose_fingerprint ON jobs(loose_fingerprint)",
+      "tbl_name": "jobs",
+      "type": "index"
+    },
+    {
+      "name": "idx_jobs_stage",
+      "sql": "CREATE INDEX idx_jobs_stage ON jobs(stage)",
+      "tbl_name": "jobs",
+      "type": "index"
+    },
+    {
+      "name": "idx_jobs_updated",
+      "sql": "CREATE INDEX idx_jobs_updated ON jobs(updated_at)",
+      "tbl_name": "jobs",
+      "type": "index"
+    },
+    {
+      "name": "idx_notifications_kind",
+      "sql": "CREATE INDEX idx_notifications_kind ON notifications(kind)",
+      "tbl_name": "notifications",
+      "type": "index"
+    },
+    {
+      "name": "idx_notifications_sent_at",
+      "sql": "CREATE INDEX idx_notifications_sent_at ON notifications(sent_at DESC)",
+      "tbl_name": "notifications",
+      "type": "index"
+    },
+    {
+      "name": "idx_notifications_unread",
+      "sql": "CREATE INDEX idx_notifications_unread ON notifications(read_at)WHERE read_at IS NULL",
+      "tbl_name": "notifications",
+      "type": "index"
+    },
+    {
+      "name": "idx_onboarding_sessions_completed",
+      "sql": "CREATE INDEX idx_onboarding_sessions_completed ON onboarding_sessions(completed_at)",
+      "tbl_name": "onboarding_sessions",
+      "type": "index"
+    },
+    {
+      "name": "idx_speculative_company_submitted",
+      "sql": "CREATE INDEX idx_speculative_company_submitted ON speculative_requests(company,submitted_at)",
+      "tbl_name": "speculative_requests",
+      "type": "index"
+    },
+    {
+      "name": "idx_speculative_status",
+      "sql": "CREATE INDEX idx_speculative_status ON speculative_requests(status)",
+      "tbl_name": "speculative_requests",
+      "type": "index"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "job_id",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": null,
+          "name": "field_changed",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "old_value",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "new_value",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 5,
+          "dflt_value": "datetime('now')",
+          "name": "changed_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": "'system'",
+          "name": "changed_by",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "audit_log",
+      "sql": "CREATE TABLE audit_log(id INTEGER PRIMARY KEY AUTOINCREMENT,job_id TEXT NOT NULL,field_changed TEXT NOT NULL,old_value TEXT,new_value TEXT,changed_at TEXT DEFAULT(datetime('now')),changed_by TEXT DEFAULT 'system')",
+      "tbl_name": "audit_log",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "job_id",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": null,
+          "name": "operation",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "model",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "latency_ms",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 5,
+          "dflt_value": "1",
+          "name": "success",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 6,
+          "dflt_value": null,
+          "name": "error_message",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 7,
+          "dflt_value": null,
+          "name": "input_tokens",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 8,
+          "dflt_value": null,
+          "name": "output_tokens",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 9,
+          "dflt_value": null,
+          "name": "cost_usd",
+          "notnull": 0,
+          "pk": 0,
+          "type": "REAL"
+        },
+        {
+          "cid": 10,
+          "dflt_value": "datetime('now')",
+          "name": "logged_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "cost_log",
+      "sql": "CREATE TABLE cost_log(id INTEGER PRIMARY KEY AUTOINCREMENT,job_id TEXT,operation TEXT NOT NULL,model TEXT NOT NULL,latency_ms INTEGER,success INTEGER DEFAULT 1,error_message TEXT,input_tokens INTEGER,output_tokens INTEGER,cost_usd REAL,logged_at TEXT DEFAULT(datetime('now')))",
+      "tbl_name": "cost_log",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "canonical_fingerprint",
+          "notnull": 1,
+          "pk": 1,
+          "type": "TEXT"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "duplicate_job_id",
+          "notnull": 1,
+          "pk": 2,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": "datetime('now')",
+          "name": "detected_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "duplicate_groups",
+      "sql": "CREATE TABLE duplicate_groups(canonical_fingerprint TEXT NOT NULL,duplicate_job_id TEXT NOT NULL,detected_at TEXT DEFAULT(datetime('now')),PRIMARY KEY(canonical_fingerprint,duplicate_job_id))",
+      "tbl_name": "duplicate_groups",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "job_id",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": null,
+          "name": "title",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "company",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "relevance_score",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 5,
+          "dflt_value": null,
+          "name": "reject_reason",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": "''",
+          "name": "jd_excerpt",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 7,
+          "dflt_value": "datetime('now')",
+          "name": "created_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "feedback_log",
+      "sql": "CREATE TABLE feedback_log(id INTEGER PRIMARY KEY AUTOINCREMENT,job_id TEXT NOT NULL,title TEXT NOT NULL,company TEXT NOT NULL,relevance_score INTEGER,reject_reason TEXT NOT NULL,jd_excerpt TEXT DEFAULT '',created_at TEXT DEFAULT(datetime('now')))",
+      "tbl_name": "feedback_log",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "TEXT"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "fingerprint",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": null,
+          "name": "loose_fingerprint",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "url",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "title",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 5,
+          "dflt_value": null,
+          "name": "company",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": "''",
+          "name": "location",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 7,
+          "dflt_value": null,
+          "name": "source",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 8,
+          "dflt_value": null,
+          "name": "raw_jd_text",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 9,
+          "dflt_value": null,
+          "name": "relevance_score",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 10,
+          "dflt_value": null,
+          "name": "interview_likelihood",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 11,
+          "dflt_value": null,
+          "name": "strengths_alignment",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 12,
+          "dflt_value": null,
+          "name": "industry_sector",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 13,
+          "dflt_value": "''",
+          "name": "comp_estimate",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 14,
+          "dflt_value": null,
+          "name": "ai_notes",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 15,
+          "dflt_value": null,
+          "name": "score_status",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 16,
+          "dflt_value": null,
+          "name": "score_flag_reason",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 17,
+          "dflt_value": "'Unknown'",
+          "name": "remote_status",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 18,
+          "dflt_value": "0",
+          "name": "network_depth",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 19,
+          "dflt_value": "''",
+          "name": "known_contacts",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 20,
+          "dflt_value": "'discovered'",
+          "name": "stage",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 21,
+          "dflt_value": null,
+          "name": "stage_updated",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 22,
+          "dflt_value": "'active'",
+          "name": "status",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 23,
+          "dflt_value": "0",
+          "name": "apply_flag",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 24,
+          "dflt_value": "''",
+          "name": "reject_reason",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 25,
+          "dflt_value": null,
+          "name": "prep_folder_path",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 26,
+          "dflt_value": null,
+          "name": "gdrive_folder_url",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 27,
+          "dflt_value": null,
+          "name": "fit_score",
+          "notnull": 0,
+          "pk": 0,
+          "type": "REAL"
+        },
+        {
+          "cid": 28,
+          "dflt_value": null,
+          "name": "probability_score",
+          "notnull": 0,
+          "pk": 0,
+          "type": "REAL"
+        },
+        {
+          "cid": 29,
+          "dflt_value": "''",
+          "name": "user_notes",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 30,
+          "dflt_value": "datetime('now')",
+          "name": "created_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 31,
+          "dflt_value": "datetime('now')",
+          "name": "updated_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 32,
+          "dflt_value": "''",
+          "name": "dupe_of",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 33,
+          "dflt_value": "0",
+          "name": "synthetic",
+          "notnull": 1,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 34,
+          "dflt_value": null,
+          "name": "speculative_briefing_folder",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "jobs",
+      "sql": "CREATE TABLE jobs(id TEXT PRIMARY KEY,fingerprint TEXT UNIQUE NOT NULL,loose_fingerprint TEXT,url TEXT NOT NULL,title TEXT NOT NULL,company TEXT NOT NULL,location TEXT DEFAULT '',source TEXT NOT NULL,raw_jd_text TEXT,relevance_score INTEGER CHECK(relevance_score BETWEEN 1 AND 10),interview_likelihood INTEGER CHECK(interview_likelihood BETWEEN 1 AND 10),strengths_alignment TEXT,industry_sector TEXT,comp_estimate TEXT DEFAULT '',ai_notes TEXT,score_status TEXT CHECK(score_status IN('scored','manual_review','needs_info')),score_flag_reason TEXT,remote_status TEXT DEFAULT 'Unknown',network_depth INTEGER DEFAULT 0,known_contacts TEXT DEFAULT '',stage TEXT DEFAULT 'discovered' CHECK(stage IN('discovered','enriched','scored','manual_review','prep_in_progress','materials_drafted','waitlisted','applied','response_received','interview','offer','rejected','withdrawn')),stage_updated TEXT,status TEXT DEFAULT 'active' CHECK(status IN('active','manual_review','skipped','applied','rejected','interviewing','offer')),apply_flag INTEGER DEFAULT 0,reject_reason TEXT DEFAULT '',prep_folder_path TEXT,gdrive_folder_url TEXT,fit_score REAL,probability_score REAL,user_notes TEXT DEFAULT '',created_at TEXT DEFAULT(datetime('now')),updated_at TEXT DEFAULT(datetime('now')),dupe_of TEXT DEFAULT '',synthetic INTEGER NOT NULL DEFAULT 0,speculative_briefing_folder TEXT)",
+      "tbl_name": "jobs",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 1,
+          "dflt_value": "datetime('now')",
+          "name": "sent_at",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": null,
+          "name": "kind",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "title",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "body",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 5,
+          "dflt_value": "'default'",
+          "name": "priority",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": null,
+          "name": "tags",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 7,
+          "dflt_value": "'sent'",
+          "name": "delivery_status",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 8,
+          "dflt_value": null,
+          "name": "delivery_error",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 9,
+          "dflt_value": null,
+          "name": "cta_url",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 10,
+          "dflt_value": null,
+          "name": "read_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "notifications",
+      "sql": "CREATE TABLE notifications(id INTEGER PRIMARY KEY AUTOINCREMENT,sent_at TEXT NOT NULL DEFAULT(datetime('now')),kind TEXT NOT NULL,title TEXT NOT NULL,body TEXT NOT NULL,priority TEXT NOT NULL DEFAULT 'default',tags TEXT,delivery_status TEXT NOT NULL DEFAULT 'sent' CHECK(delivery_status IN('sent','failed','in_app_only')),delivery_error TEXT,cta_url TEXT,read_at TEXT)",
+      "tbl_name": "notifications",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "TEXT"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "history_json",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": "'{}'",
+          "name": "captured_blocks_json",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "started_at",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "last_turn_at",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 5,
+          "dflt_value": null,
+          "name": "completed_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": null,
+          "name": "error_state",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 7,
+          "dflt_value": "NULL",
+          "name": "tester_openrouter_key",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 8,
+          "dflt_value": "NULL",
+          "name": "tester_rapidapi_key",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 9,
+          "dflt_value": "0",
+          "name": "cumulative_cost_usd",
+          "notnull": 1,
+          "pk": 0,
+          "type": "REAL"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "onboarding_sessions",
+      "sql": "CREATE TABLE onboarding_sessions(id TEXT PRIMARY KEY,history_json TEXT NOT NULL,captured_blocks_json TEXT NOT NULL DEFAULT '{}',started_at TEXT NOT NULL,last_turn_at TEXT NOT NULL,completed_at TEXT,error_state TEXT,tester_openrouter_key TEXT DEFAULT NULL,tester_rapidapi_key TEXT DEFAULT NULL,cumulative_cost_usd REAL NOT NULL DEFAULT 0)",
+      "tbl_name": "onboarding_sessions",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "company",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": null,
+          "name": "hint",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "personal_notes",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": "'researching'",
+          "name": "status",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 5,
+          "dflt_value": null,
+          "name": "error_message",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": null,
+          "name": "briefing_md",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 7,
+          "dflt_value": null,
+          "name": "role_cards_json",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 8,
+          "dflt_value": null,
+          "name": "briefing_folder",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 9,
+          "dflt_value": "datetime('now')",
+          "name": "submitted_at",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 10,
+          "dflt_value": null,
+          "name": "research_completed_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 11,
+          "dflt_value": null,
+          "name": "approved_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 12,
+          "dflt_value": null,
+          "name": "approved_role_count",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 13,
+          "dflt_value": null,
+          "name": "briefing_prompt_version",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 14,
+          "dflt_value": null,
+          "name": "synth_prompt_version",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "speculative_requests",
+      "sql": "CREATE TABLE speculative_requests(id INTEGER PRIMARY KEY AUTOINCREMENT,company TEXT NOT NULL,hint TEXT,personal_notes TEXT,status TEXT NOT NULL DEFAULT 'researching' CHECK(status IN('researching','ready_for_review','approved','trashed','failed')),error_message TEXT,briefing_md TEXT,role_cards_json TEXT,briefing_folder TEXT,submitted_at TEXT NOT NULL DEFAULT(datetime('now')),research_completed_at TEXT,approved_at TEXT,approved_role_count INTEGER,briefing_prompt_version TEXT,synth_prompt_version TEXT)",
+      "tbl_name": "speculative_requests",
+      "type": "table"
+    }
+  ],
+  "sqlite_version": "3.46.1"
+}

--- a/tests/fixtures/schema_baseline_fresh.json
+++ b/tests/fixtures/schema_baseline_fresh.json
@@ -950,6 +950,5 @@
       "tbl_name": "speculative_requests",
       "type": "table"
     }
-  ],
-  "sqlite_version": "3.46.1"
+  ]
 }

--- a/tests/test_schema_baseline_fresh.py
+++ b/tests/test_schema_baseline_fresh.py
@@ -1,0 +1,77 @@
+"""#513 — fresh schema baseline test.
+
+Locks the contract: a fresh ``init_db.py`` against an empty tmpdir produces
+a schema (tables, indexes, columns, FKs, CHECK constraints, partial-index
+WHERE clauses) that exactly matches the committed JSON snapshot at
+``tests/fixtures/schema_baseline_fresh.json``. Drift fails the test and
+forces an explicit migration decision in the same PR.
+
+To regenerate the snapshot after a legitimate schema change::
+
+    UPDATE_SCHEMA_SNAPSHOT=1 uv run pytest tests/test_schema_baseline_fresh.py
+
+Re-run without the env var to confirm the new snapshot is committed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests._schema_introspect import diff_summary, introspect
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INIT_DB_SCRIPT = REPO_ROOT / "scripts" / "init_db.py"
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "fixtures" / "schema_baseline_fresh.json"
+
+
+def _fresh_schema_snapshot(tmp_path: Path) -> dict:
+    """Run ``scripts/init_db.py`` against an empty tmpdir and introspect."""
+    db_path = tmp_path / "fresh.db"
+    subprocess.run(
+        [sys.executable, str(INIT_DB_SCRIPT), str(db_path)],
+        check=True,
+        capture_output=True,
+    )
+    conn = sqlite3.connect(db_path)
+    try:
+        return introspect(conn)
+    finally:
+        conn.close()
+
+
+def test_fresh_init_matches_snapshot(tmp_path: Path) -> None:
+    actual = _fresh_schema_snapshot(tmp_path)
+
+    if os.environ.get("UPDATE_SCHEMA_SNAPSHOT") == "1":
+        SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        SNAPSHOT_PATH.write_text(
+            json.dumps(actual, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        pytest.skip(f"snapshot regenerated at {SNAPSHOT_PATH.relative_to(REPO_ROOT)}")
+
+    if not SNAPSHOT_PATH.exists():
+        pytest.fail(
+            f"baseline snapshot missing at {SNAPSHOT_PATH.relative_to(REPO_ROOT)}; "
+            "regenerate with `UPDATE_SCHEMA_SNAPSHOT=1 uv run pytest "
+            "tests/test_schema_baseline_fresh.py`"
+        )
+
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+    if actual != expected:
+        diff = diff_summary(actual, expected)
+        pytest.fail(
+            "schema diverged from baseline snapshot. If this change is "
+            "intentional, regenerate the snapshot with "
+            "`UPDATE_SCHEMA_SNAPSHOT=1 uv run pytest "
+            "tests/test_schema_baseline_fresh.py` and commit it in the same PR.\n\n"
+            f"{diff}"
+        )

--- a/tests/test_schema_baseline_legacy.py
+++ b/tests/test_schema_baseline_legacy.py
@@ -1,0 +1,76 @@
+"""#514 — legacy schema baseline test.
+
+Locks the contract: a v0.10.0-shape SQLite fixture, run through the
+current ``scripts/init_db.py`` followed by ``migrate_schema()`` (the same
+arc production stacks execute on container restart), produces a schema
+identical to the fresh-init baseline snapshot from #513. Any divergence
+means the legacy upgrade path is broken.
+
+The deployment arc being mirrored:
+
+1. Container entrypoint runs ``scripts/init_db.py`` — handles inline
+   ALTER TABLE additions on ``jobs``, drops ``cost_calibration`` if
+   present, and runs ``CREATE TABLE/INDEX IF NOT EXISTS`` for everything
+   else.
+2. FastAPI startup hook calls
+   ``findajob.onboarding.session_store.migrate_schema(conn)`` — adds
+   layered ``onboarding_sessions`` columns and drops removed ones.
+
+This test executes both steps in order, then compares to the fresh
+baseline.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from findajob.onboarding.session_store import migrate_schema
+from tests._schema_introspect import diff_summary, introspect
+from tests.fixtures._legacy_v0_10_setup import write_v0_10_0_db
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INIT_DB_SCRIPT = REPO_ROOT / "scripts" / "init_db.py"
+SNAPSHOT_PATH = REPO_ROOT / "tests" / "fixtures" / "schema_baseline_fresh.json"
+
+
+def test_legacy_v0_10_0_upgrades_to_fresh_baseline(tmp_path: Path) -> None:
+    if not SNAPSHOT_PATH.exists():
+        pytest.fail(
+            "fresh baseline snapshot is missing — generate it first via "
+            "`UPDATE_SCHEMA_SNAPSHOT=1 uv run pytest "
+            "tests/test_schema_baseline_fresh.py`"
+        )
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+    db_path = tmp_path / "legacy.db"
+    write_v0_10_0_db(db_path)
+
+    subprocess.run(
+        [sys.executable, str(INIT_DB_SCRIPT), str(db_path)],
+        check=True,
+        capture_output=True,
+    )
+
+    conn = sqlite3.connect(db_path)
+    try:
+        migrate_schema(conn)
+        actual = introspect(conn)
+    finally:
+        conn.close()
+
+    if actual != expected:
+        diff = diff_summary(actual, expected)
+        pytest.fail(
+            "v0.10.0 → current upgrade path produced a schema that diverges "
+            "from the fresh baseline. Either a migration is missing from "
+            "init_db.py / migrate_schema(), or the legacy fixture in "
+            "tests/fixtures/_legacy_v0_10_setup.py has drifted from the actual "
+            "v0.10.0 shape (verify with `git show v0.10.0:scripts/init_db.py`).\n\n"
+            f"{diff}"
+        )


### PR DESCRIPTION
## Summary

- Lock the schema contract before M3+ structural refactor work, so structural drift surfaces as an explicit, regenerable diff.
- `#513` — fresh baseline: subprocess-runs `scripts/init_db.py` against a tmpdir, asserts equal to a committed JSON snapshot at `tests/fixtures/schema_baseline_fresh.json`.
- `#514` — legacy upgrade path: builds a v0.10.0-shape fixture (DDL captured literal from `git show v0.10.0:scripts/init_db.py`), runs `init_db.py` + `migrate_schema()` (mirroring the FastAPI startup hook at `src/findajob/web/app.py:99`), asserts equal to the fresh snapshot.
- Bundled into one PR per Recommended Session 4 prompt — the pair shares a single introspection helper at `tests/_schema_introspect.py` and was paired by design in audit 4 §2 contracts #3a + #3b.

## Why this shape

PRAGMA output (`table_info`, `foreign_key_list`) is structured and easy to diff column-by-column, but it **omits CHECK constraints and partial-index WHERE clauses**. The snapshot includes both PRAGMA output AND whitespace-normalized `sqlite_master.sql` text per object — necessary so (e.g.) `#498`'s planned removal of the `'needs_info'` enum value will fail this test instead of silently passing.

The normalizer strips SQL comments and whitespace adjacent to punctuation, so a fresh `CREATE TABLE` block (with `--` inline comments) and a legacy `ALTER TABLE ADD COLUMN` chain (which strips comments) compare equal. Limitation noted in the docstring: string-literal defaults containing `,()` would be mangled — current schema has none.

## Snapshot regeneration

When a schema change is intentional, regenerate in the same PR:

```bash
UPDATE_SCHEMA_SNAPSHOT=1 uv run pytest tests/test_schema_baseline_fresh.py
```

Re-run without the env var to confirm the snapshot is committed.

## Verification

- `uv run pytest tests/` — 1877 existing tests pass + 2 new (`test_fresh_init_matches_snapshot`, `test_legacy_v0_10_0_upgrades_to_fresh_baseline`).
- `uv run ruff check` + `uv run ruff format --check` — clean.
- Manual sanity: corrupted one CHECK enum value in the snapshot; test failed with a diff naming the changed table and showing both sql values. Restored.

## Documentation Impact

None for tracked docs. The snapshot regeneration command is documented in the test docstrings + this PR body. CLAUDE.md doesn't enumerate per-test contracts; the M2 epic body (#509) tracks the contract list.

CHANGELOG `[Unreleased]` — entry added under `### Added` describing the two tests, why the snapshot includes raw SQL text, and the regeneration env var.

## Closes

- Closes #513
- Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
