### PR TITLE
test(board_actions): #511 — notes endpoint concurrency + N-POST audit invariant

### DIFF
--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -691,6 +691,15 @@ def _fetch_user_notes(client: TestClient, fingerprint: str) -> str | None:
     return row[0] if row else None
 
 
+def _count_total_audit_rows(client: TestClient) -> int:
+    """Counts every audit_log row regardless of jobs.id JOIN — catches mis-keyed
+    orphan writes that _fetch_audit's JOIN would silently drop."""
+    conn = sqlite3.connect(client._db_path)
+    (n,) = conn.execute("SELECT COUNT(*) FROM audit_log").fetchone()
+    conn.close()
+    return n
+
+
 class TestNotes:
     def test_happy_path_saves_note(self, client: TestClient):
         response = client.post(
@@ -738,6 +747,55 @@ class TestNotes:
             data={"notes": "anything"},
         )
         assert response.status_code == 404
+
+    def test_repeated_posts_produce_zero_audit_rows(self, client: TestClient):
+        """Audit silence holds regardless of POST count — the keystroke-debounced
+        UX would explode audit_log otherwise. Counts total audit rows rather than
+        joining via jobs.id so a mis-keyed orphan write also fails the assertion."""
+        for i in range(5):
+            response = client.post(
+                "/board/jobs/fp_applied/notes",
+                data={"notes": f"note v{i}"},
+            )
+            assert response.status_code == 200
+
+        assert _fetch_user_notes(client, "fp_applied") == "note v4"
+        assert _count_total_audit_rows(client) == 0
+
+    def test_concurrent_writes_consistent_no_error(self, client: TestClient):
+        """Overlapping POSTs must both 200, leave a valid final state (one of the
+        two payloads), and never surface a SQLite-locking error to the client.
+        Locks the server-side contract the JS 800ms debounce relies on; M3+
+        refactors that introduce non-trivial work in the handler must preserve it."""
+        import threading
+
+        barrier = threading.Barrier(2)
+        results: list[tuple[int, str]] = []
+        lock = threading.Lock()
+
+        def post_note(value: str) -> None:
+            barrier.wait()
+            resp = client.post(
+                "/board/jobs/fp_applied/notes",
+                data={"notes": value},
+            )
+            with lock:
+                results.append((resp.status_code, value))
+
+        t1 = threading.Thread(target=post_note, args=("note from thread A",))
+        t2 = threading.Thread(target=post_note, args=("note from thread B",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert len(results) == 2
+        assert all(status == 200 for status, _ in results), f"non-200 responses: {results}"
+
+        final = _fetch_user_notes(client, "fp_applied")
+        assert final in {"note from thread A", "note from thread B"}, f"final state not from either POST: {final!r}"
+
+        assert _count_total_audit_rows(client) == 0
 
 
 # ── /waitlist handler ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #511. Locks two contracts the existing `TestNotes` did not cover:

- **N-POST audit silence.** Five sequential POSTs to `/board/jobs/{fp}/notes` produce zero `audit_log` rows total. The handler's existing single-POST `test_no_audit_log_entry` doesn't rule out a per-POST audit write that's mis-keyed and JOIN-invisible.
- **Concurrent-write robustness.** Two threads POSTing different bodies simultaneously both return 200, leave the row in a valid final state (one of the two payloads), and never surface a SQLite-locking error to the client. `threading.Barrier` synchronizes start so both requests overlap inside the handler.

Both assertions use a new `_count_total_audit_rows` helper that runs raw `COUNT(*)` on `audit_log`. Verified by mutation: injecting an `INSERT INTO audit_log (...)` into the notes handler causes both new tests to fail (the existing `_fetch_audit` JOIN helper would have silently passed because the orphan write's `job_id` doesn't match `jobs.id`).

This locks the server contract the JS 800ms debounce relies on; M3+ refactors that add non-trivial work in the handler (logging, telemetry, validation) must preserve audit silence and concurrency safety.

## Test plan

- [x] `uv run pytest tests/test_board_actions.py::TestNotes -v` — 8 passed (6 existing + 2 new)
- [x] `uv run pytest tests/test_board_actions.py` — 79 passed
- [x] `uv run ruff check tests/test_board_actions.py` — clean
- [x] `uv run ruff format --check tests/test_board_actions.py` — clean
- [x] Mutation test: injected audit_log INSERT into notes handler → both new tests fail; existing `test_no_audit_log_entry` passes (confirming the JOIN-helper gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)