### PR TITLE
refactor(db): #546 — introduce findajob.db.connect helper

### DIFF
--- a/src/findajob/db.py
+++ b/src/findajob/db.py
@@ -1,0 +1,90 @@
+"""Centralized SQLite connection helper.
+
+One function — :func:`connect` — replaces the 32 ``sqlite3.connect(...)``
+call sites that had been splayed across ``src/findajob/`` and
+``scripts/``. Three connection patterns existed in the wild:
+
+1. **Plain write** (most common) — ``sqlite3.connect(path, timeout=30)``.
+2. **Cross-stack read-only** — ``sqlite3.connect(uri, uri=True)`` with
+   ``f"file:{path}?mode=ro&immutable=1"``. Used by the operator-mode
+   admin dashboard reading other stacks' DBs under a foreign uid; the
+   ``immutable=1`` flag skips the WAL/shm sidecars (which the foreign
+   uid can't read). Without it, opens fail with "unable to open
+   database file" — see ``feedback_immutable_for_cross_stack_sqlite``
+   in operator memory.
+3. **FastAPI per-request** — ``sqlite3.connect(path,
+   check_same_thread=False)``. Required because BaseHTTPMiddleware
+   wraps the inner app in a separate anyio task; FastAPI's ``Depends``
+   resolution and the route handler can land on different threadpool
+   workers under concurrent load (#486).
+
+The helper exposes all four axes (``ro``, ``cross_stack``, ``timeout``,
+``check_same_thread``) explicitly rather than inferring them. Identical
+SQL behavior is the M4 acceptance criterion — the helper is a
+*replacement*, not a re-design.
+
+What this helper deliberately does NOT do:
+
+- No ``row_factory`` defaulting. Some callers want ``sqlite3.Row``,
+  others use tuple-style access. Setting one quietly breaks the other.
+- No ``PRAGMA journal_mode=WAL``. Currently called explicitly only in
+  ``triage/orchestrator.py``; preserving call-site behavior keeps SQL
+  semantics identical.
+- No connection-context-manager wrapping. Callers choose ``with`` or
+  ``try/finally``.
+
+Future helpers for transactions, cursor management, or pooling can be
+added here, but cross-cutting policy belongs in ``findajob.actions``
+or domain modules — this module is *only* the connection door.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def connect(
+    path: str | Path,
+    *,
+    ro: bool = False,
+    cross_stack: bool = False,
+    timeout: float = 30.0,
+    check_same_thread: bool = True,
+) -> sqlite3.Connection:
+    """Open a SQLite connection with the appropriate URI/flags for the use case.
+
+    Args:
+        path: Filesystem path to the database file.
+        ro: Open read-only (``mode=ro``). Write attempts raise
+            ``sqlite3.OperationalError``.
+        cross_stack: Open with ``mode=ro&immutable=1`` for foreign-uid
+            reads (operator-mode admin dashboard). Implies ``ro=True``;
+            passing ``cross_stack=True`` without ``ro=True`` raises
+            ``ValueError``. The ``immutable=1`` flag tells SQLite the
+            DB is a fixed snapshot — no WAL/shm sidecar reads, no
+            locking. Tradeoff: in-flight WAL writes from the producer
+            stack are invisible until the next checkpoint.
+        timeout: Busy-handler timeout in seconds. Default 30 matches
+            the dominant pattern; web nav-chip queries pass
+            ``timeout=5``.
+        check_same_thread: Default ``True``. Pass ``False`` for the
+            FastAPI per-request connection where Depends + handler may
+            land on different threadpool workers (#486).
+
+    Returns:
+        An open ``sqlite3.Connection``.
+
+    Raises:
+        ValueError: If ``cross_stack=True`` without ``ro=True``. Codifies
+            the operator-dashboard read-only invariant from CLAUDE.md.
+    """
+    if cross_stack and not ro:
+        raise ValueError("cross_stack=True requires ro=True")
+    if cross_stack:
+        uri = f"file:{path}?mode=ro&immutable=1"
+        return sqlite3.connect(uri, uri=True, timeout=timeout, check_same_thread=check_same_thread)
+    if ro:
+        uri = f"file:{path}?mode=ro"
+        return sqlite3.connect(uri, uri=True, timeout=timeout, check_same_thread=check_same_thread)
+    return sqlite3.connect(str(path), timeout=timeout, check_same_thread=check_same_thread)

--- a/tests/test_db_connect.py
+++ b/tests/test_db_connect.py
@@ -1,0 +1,186 @@
+"""#546 — Unit tests for ``findajob.db.connect`` helper.
+
+Locks the four-axis API contract that M4.E1.I2's call-site sweep will
+adopt across all 32 ``sqlite3.connect`` sites:
+
+- Plain-write returns a writable connection.
+- ``ro=True`` opens read-only (write attempts raise OperationalError).
+- ``cross_stack=True`` constructs ``mode=ro&immutable=1`` URI with
+  ``uri=True``. Required for foreign-uid reads of tester DBs from the
+  operator-mode admin dashboard — see
+  ``feedback_immutable_for_cross_stack_sqlite``.
+- ``cross_stack=True`` without ``ro=True`` raises ``ValueError`` —
+  codifies the operator-dashboard read-only invariant from CLAUDE.md.
+- ``timeout`` and ``check_same_thread`` are plumbed through.
+
+The URI-shape assertions monkeypatch ``sqlite3.connect`` to capture the
+arguments the helper passes — the only portable way to verify URI
+construction since SQLite exposes no introspection for the open-flags.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from findajob.db import connect
+
+
+def _make_db(path: Path) -> None:
+    """Create a SQLite DB file with a single table for read/write tests."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute("CREATE TABLE t (n INTEGER)")
+        conn.execute("INSERT INTO t (n) VALUES (1)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_plain_connect_is_writable(tmp_path: Path) -> None:
+    db = tmp_path / "test.db"
+    _make_db(db)
+
+    conn = connect(db)
+    try:
+        conn.execute("INSERT INTO t (n) VALUES (2)")
+        conn.commit()
+        rows = conn.execute("SELECT n FROM t ORDER BY n").fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [(1,), (2,)]
+
+
+def test_ro_connect_blocks_writes(tmp_path: Path) -> None:
+    db = tmp_path / "test.db"
+    _make_db(db)
+
+    conn = connect(db, ro=True)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            conn.execute("INSERT INTO t (n) VALUES (99)")
+    finally:
+        conn.close()
+
+
+def test_cross_stack_uri_carries_immutable_flag(tmp_path: Path) -> None:
+    """``cross_stack=True`` must produce a URI containing both
+    ``mode=ro`` AND ``immutable=1``, with ``uri=True`` in kwargs.
+
+    This is the load-bearing assertion for cross-stack reads — without
+    ``immutable=1``, SQLite tries to open the WAL/shm sidecars for
+    journal coordination, and a foreign uid (operator container vs
+    tester container) can't read those sidecars. The helper is the
+    single enforcement point per M4 acceptance criterion #3.
+    """
+    db = tmp_path / "test.db"
+    _make_db(db)
+
+    captured: dict = {}
+    real_connect = sqlite3.connect
+
+    def fake_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return real_connect(*args, **kwargs)  # type: ignore[arg-type]
+
+    with patch("findajob.db.sqlite3.connect", side_effect=fake_connect):
+        conn = connect(db, ro=True, cross_stack=True)
+        conn.close()
+
+    uri = captured["args"][0]
+    assert isinstance(uri, str)
+    assert uri.startswith("file:")
+    assert "mode=ro" in uri
+    assert "immutable=1" in uri
+    assert captured["kwargs"]["uri"] is True
+
+
+def test_ro_without_cross_stack_omits_immutable(tmp_path: Path) -> None:
+    """Same-stack read-only opens with ``mode=ro`` but NOT
+    ``immutable=1`` — same-stack readers benefit from WAL coherence."""
+    db = tmp_path / "test.db"
+    _make_db(db)
+
+    captured: dict = {}
+    real_connect = sqlite3.connect
+
+    def fake_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return real_connect(*args, **kwargs)  # type: ignore[arg-type]
+
+    with patch("findajob.db.sqlite3.connect", side_effect=fake_connect):
+        conn = connect(db, ro=True)
+        conn.close()
+
+    uri = captured["args"][0]
+    assert "mode=ro" in uri
+    assert "immutable=1" not in uri
+    assert captured["kwargs"]["uri"] is True
+
+
+def test_cross_stack_without_ro_raises_value_error(tmp_path: Path) -> None:
+    """The guard that codifies CLAUDE.md's operator-dashboard
+    read-only invariant. Cross-stack writes are forbidden by topology
+    (foreign uid + producer's WAL sidecar permissions) AND by policy
+    (admin dashboard is read-only, no POST handlers)."""
+    db = tmp_path / "test.db"
+    _make_db(db)
+
+    with pytest.raises(ValueError, match="cross_stack=True requires ro=True"):
+        connect(db, cross_stack=True)
+
+
+def test_kwargs_passthrough(tmp_path: Path) -> None:
+    """``timeout`` and ``check_same_thread`` reach the underlying
+    ``sqlite3.connect`` unchanged for every code path
+    (plain-write / ro / cross_stack)."""
+    db = tmp_path / "test.db"
+    _make_db(db)
+
+    captured: dict = {}
+    real_connect = sqlite3.connect
+
+    def fake_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        captured.clear()
+        captured["kwargs"] = kwargs
+        return real_connect(*args, **kwargs)  # type: ignore[arg-type]
+
+    with patch("findajob.db.sqlite3.connect", side_effect=fake_connect):
+        connect(db, timeout=5.0, check_same_thread=False).close()
+        assert captured["kwargs"]["timeout"] == 5.0
+        assert captured["kwargs"]["check_same_thread"] is False
+
+        connect(db, ro=True, timeout=7.0, check_same_thread=False).close()
+        assert captured["kwargs"]["timeout"] == 7.0
+        assert captured["kwargs"]["check_same_thread"] is False
+
+        connect(db, ro=True, cross_stack=True, timeout=3.0).close()
+        assert captured["kwargs"]["timeout"] == 3.0
+        assert captured["kwargs"]["check_same_thread"] is True
+
+
+def test_path_object_accepted(tmp_path: Path) -> None:
+    """The helper's ``path`` parameter is typed ``str | Path``;
+    callers pass either form. Verify both produce identical URIs for
+    the cross-stack path."""
+    db = tmp_path / "test.db"
+    _make_db(db)
+
+    captured: list[str] = []
+    real_connect = sqlite3.connect
+
+    def fake_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        captured.append(args[0])  # type: ignore[arg-type]
+        return real_connect(*args, **kwargs)  # type: ignore[arg-type]
+
+    with patch("findajob.db.sqlite3.connect", side_effect=fake_connect):
+        connect(db, ro=True, cross_stack=True).close()
+        connect(str(db), ro=True, cross_stack=True).close()
+
+    assert captured[0] == captured[1]


### PR DESCRIPTION
## Summary

First child of M4 (#545 epic). Closes #546.

Adds `findajob.db.connect()` — a centralized helper that replaces the three subtly-different `sqlite3.connect(...)` patterns currently scattered across 32 call sites in `src/findajob/` and `scripts/`. **Pure additive PR** — no call-site changes in this PR; the sweep lands in M4.E1.I2.

## Why

`feedback_immutable_for_cross_stack_sqlite` enforces the cross-stack `mode=ro&immutable=1` URI form at one place instead of 32. The `cross_stack=True` requires `ro=True` guard codifies CLAUDE.md's operator-dashboard read-only invariant at the type level — `ValueError`, not a doc note. Future contributors get one typed function answering "how do I open the DB" instead of three patterns to discover.

## Helper signature

```python
def connect(
    path: str | Path,
    *,
    ro: bool = False,
    cross_stack: bool = False,
    timeout: float = 30.0,
    check_same_thread: bool = True,
) -> sqlite3.Connection:
```

Four explicit axes covering every pattern in the wild:
- **Plain write** (~28 sites) → `connect(path)` or `connect(path, timeout=5)`
- **Cross-stack read** (1 site, admin) → `connect(path, ro=True, cross_stack=True)`
- **FastAPI per-request** (1 site, web/app.py) → `connect(path, check_same_thread=False)`
- **Read-only same-stack** (web nav queries) → `connect(path, ro=True, timeout=5)`

## What the helper deliberately does NOT do

- No `row_factory` defaulting — varies per site (Row vs tuple), call-site choice.
- No `PRAGMA journal_mode=WAL` — only `triage/orchestrator.py` runs it today; preserving as call-site behavior keeps SQL semantics identical to the pre-helper world.
- No connection-context-manager wrapping — caller's choice.

Identical SQL behavior is the M4 acceptance criterion: this is a *replacement*, not a redesign.

## Tests

`tests/test_db_connect.py` — 7 tests:

1. Plain write returns a writable connection.
2. `ro=True` raises `OperationalError` on write attempts.
3. `cross_stack=True` produces URI containing both `mode=ro` AND `immutable=1`, with `uri=True` kwarg. *(Mutation-verified: test fails when `immutable=1` is dropped.)*
4. `ro=True` without `cross_stack` produces `mode=ro` without `immutable=1` (same-stack readers benefit from WAL coherence).
5. `cross_stack=True` without `ro=True` raises `ValueError`. *(Mutation-verified: test fails when the guard is removed.)*
6. `timeout` and `check_same_thread` round-trip correctly across all three code paths.
7. `Path` and `str` path arguments produce identical URIs.

## What's NOT in this PR

- The 32 call-site sweep — M4.E1.I2's job.
- Updates to `tests/test_admin_sqlite_uri_invariants.py` — its current AST-walk shape is fine until E1.I2 sweeps the admin call site; the test's shape will need to migrate to "no `sqlite3.connect` outside `findajob/db.py`" form when that PR lands. Captured in #545's body.
- Schema changes (M5's job).
- Any reshape of the moved utils.py functions (M4.E2.I2).

## Verification

- `uv run mypy src/findajob/db.py` — Success: no issues
- `uv run ruff check src/findajob/db.py tests/test_db_connect.py` — All checks passed!
- `uv run ruff format --check ...` — already formatted
- `uv run pytest tests/test_db_connect.py -v` — 7 passed
- `uv run pytest -q` — 1926 passed, 1 skipped (pre-existing)

## Test plan

- [x] `uv run pytest tests/test_db_connect.py -v` passes
- [x] `uv run pytest -q` shows no regressions in the existing suite
- [x] `uv run mypy src/findajob/db.py` clean
- [x] `uv run ruff check` and `uv run ruff format --check` clean
- [x] Mutation-verified: tests catch real violations (dropping `immutable=1`, dropping the `ValueError` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
