### PR TITLE
refactor(typing): #563 — strict mypy gate for findajob.*; closes M7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,14 @@ dev = [
     "mypy>=1.20.0",
     "httpx>=0.27.0",
     "playwright>=1.40",
+    # Type stubs for the runtime deps that mypy needs to type-check
+    # against. Added in M7 when the strict gate landed for
+    # findajob.* — without these, the strict gate flags every
+    # `import requests` / `import yaml` / etc. as `import-untyped`.
+    "types-requests>=2.31.0",
+    "types-PyYAML>=6.0",
+    "types-Markdown>=3.7",
+    "types-jsonschema>=4.26.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -34,9 +42,51 @@ testpaths = ["tests"]
 pythonpath = ["."]
 
 [tool.mypy]
-ignore_missing_imports = true
+# Default config — applies to scripts/ and any module not covered by
+# an override below. Lenient because scripts/ are entry-point shims;
+# the strict gate lives on findajob.* (per M7).
+#
+# Module-level strictness flags (warn_unused_ignores,
+# warn_redundant_casts, no_implicit_optional, strict_equality) are set
+# globally here because mypy only allows per-module overrides for
+# import-resolution flags. The pre-M7 config disabled all of them; M7
+# turns them on and keeps them on for everything mypy checks.
 check_untyped_defs = true
+ignore_missing_imports = true
 disable_error_code = ["import-untyped"]
+warn_unused_ignores = true
+warn_redundant_casts = true
+no_implicit_optional = true
+strict_equality = true
+
+# Strict gate for the findajob package. Removes the broad
+# import-untyped silencer so missing stubs surface; per M7 the strict
+# gate is scoped to findajob.* so scripts/ stay on the lenient default.
+# Per M7 acceptance: no new `# type: ignore` comments — install stubs
+# or scope per-module overrides instead.
+[[tool.mypy.overrides]]
+module = "findajob.*"
+ignore_missing_imports = false
+disable_error_code = []
+
+# `python-docx` ships no type stubs upstream; the prep DOCX
+# post-processor imports it. Scoping the ignore here keeps the strict
+# gate for the rest of findajob.* without a ``# type: ignore`` at the
+# import line (per M7 "no new ignores" acceptance — scoping via
+# pyproject is the M7-blessed path).
+[[tool.mypy.overrides]]
+module = ["docx", "docx.*"]
+ignore_missing_imports = true
+
+# `findajob.notifications.scoreboard` imports the script-side
+# `analyze_feedback` module (which lives in scripts/, off mypy's
+# package path). Issue #558 tracks extracting it into
+# `findajob.analyze_feedback`; until then, scope the missing-import
+# error here rather than introduce a ``# type: ignore`` at the import
+# site.
+[[tool.mypy.overrides]]
+module = "analyze_feedback"
+ignore_missing_imports = true
 
 [tool.ruff]
 target-version = "py312"

--- a/src/findajob/fetchers/__init__.py
+++ b/src/findajob/fetchers/__init__.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 import time
+from typing import Any
 
 from findajob.audit import log_event
 from findajob.classification import JD_MAX_CHARS, strip_jd_boilerplate
@@ -422,7 +423,9 @@ def fetch_jobsapi_jobs(queries_path):
     date_posted = _date_posted_for_install()
     log_event("jobsapi_date_posted", value=date_posted)
 
-    sources = [
+    # Heterogeneous dict — string fields, a lambda, etc. ``Any`` keeps
+    # the existing intent without forcing every consumer to narrow.
+    sources: list[dict[str, Any]] = [
         {
             "name": "linkedin",
             "url": "https://jobs-api14.p.rapidapi.com/v2/linkedin/search",
@@ -447,7 +450,7 @@ def fetch_jobsapi_jobs(queries_path):
                 response = req.get(
                     source["url"],
                     headers=headers,
-                    params=source["params"](query),  # type: ignore[operator]
+                    params=source["params"](query),
                     timeout=30,
                 )
                 if response.status_code == 429:
@@ -457,7 +460,7 @@ def fetch_jobsapi_jobs(queries_path):
                     response = req.get(
                         source["url"],
                         headers=headers,
-                        params=source["params"](query),  # type: ignore[operator]
+                        params=source["params"](query),
                         timeout=30,
                     )
                 response.raise_for_status()


### PR DESCRIPTION
## Summary

Closes M7 (#563). Per refactor roadmap §9 (the **optional** milestone).

Drops `ignore_missing_imports` + `disable_error_code = ["import-untyped"]` for the `findajob.*` namespace. `scripts.*` stays on the lenient default — entry-point shims, M7 explicitly defers them.

## Why now

Six structural milestones closed cleanly today (M2-M6); the codebase is in unusually good shape for this. Pre-existing `# type: ignore` count is only ~9 in `findajob.*` — no blowout risk. Open-Source Launch Readiness (#377) gets a tighter type-gate as a downstream win.

## What changed

**`pyproject.toml`:**
- Strictness flags (`warn_unused_ignores`, `warn_redundant_casts`, `no_implicit_optional`, `strict_equality`) move to global `[tool.mypy]`. mypy only allows per-module overrides for import-resolution flags, so the strictness ones go global. Pre-M7 config disabled all of them; M7 turns them on project-wide.
- New `[[tool.mypy.overrides]]` for `findajob.*`: `ignore_missing_imports = false`, `disable_error_code = []`.
- Dev deps add type stubs: `types-requests`, `types-PyYAML`, `types-Markdown`, `types-jsonschema`.
- Two third-party imports without upstream stubs scoped via per-module overrides (not `# type: ignore` at import sites, per M7 acceptance):
  - `docx` / `docx.*` — python-docx ships no stubs.
  - `analyze_feedback` — script-side module pending #558 extraction.

**`findajob.fetchers.__init__.py`:**
- Two real type errors surfaced under the strict gate: heterogeneous dict was inferred as `dict[str, object]` so `source["url"]` failed `arg-type` against `requests.get`. Fixed by annotating the list as `list[dict[str, Any]]`.
- Two `# type: ignore[operator]` comments removed (redundant under the typed shape — per M7 acceptance, ignores can be REMOVED, just not added).

## Verification

- `uv run mypy src/findajob/` — **Success: no issues found in 113 source files**
- `uv run ruff check src/ scripts/ tests/` — All checks passed
- `uv run ruff format --check` — formatted
- `uv run pytest -q` — **1971 passed**, 1 skipped (pre-existing)
- ~9 pre-existing `# type: ignore` comments in `findajob/` unchanged (all valid — `warn_unused_ignores` would have flagged any redundant ones).

## Out of M7 scope (per roadmap)

- `scripts/` modules — stay on the lenient gate.
- Adding type annotations not already present — M7 is "remove guardrails, fix what falls out", not "annotate everything."
- Third-party type stubs that don't exist upstream — scoped per-module instead.

## What this closes for the roadmap

This is the seventh structural milestone. **All milestones in `5-refactor-roadmap.md` are now closed.** The remaining cleanup work tracked on the board (issues #495, #556-#562) is a defined punch-list of concrete follow-ups, not open-ended refactor scope.

## Test plan

- [x] `uv run pytest -q` shows 1971 passed, no regressions
- [x] `uv run mypy src/findajob/` clean under the strict gate
- [x] `uv run ruff check` + `ruff format --check` clean
- [x] No new `# type: ignore` comments — only removed
- [x] Strict gate scoped to `findajob.*` only; `scripts.*` continue on the lenient default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
