### PR TITLE
refactor(prep_naming): #556 — consolidate abbrev_title() duplication (M3+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Refactor
+- **#556 refactor(prep_naming): consolidate `abbrev_title()` duplication (M3+).** First M3+ punch-list item from the closed M3 epic (#537). `abbrev_title()` was duplicated between `findajob.prep.orchestrator` (typed) and `scripts/rename_folders.py` (untyped); both copies kept in sync by code review rather than code structure. Consolidated to `findajob.prep_naming` (the natural home — same domain as `safe_filename_part`, both build folder-safe filename components). Both call sites import from there. `tests/test_prep_import_safety.py::test_orchestrator_exposes_main_and_abbrev_title` renamed to `test_orchestrator_exposes_main` (orchestrator's deliberate public symbol is `main`; `abbrev_title` is now an import); `test_abbrev_title_behavior` updated to import from the canonical location, mirroring the no-re-export-theater discipline established by the M3 cleanup PR (#544).
+
 ## [0.21.0] — 2026-05-08
 
 Minor bump shipping the structural-refactor close-out arc and governance scaffolding for open-source launch readiness. The five-milestone refactor track from `5-refactor-roadmap.md` is now complete: M1 (docs cleanup, #499–#508 series), M3 (script→package extractions for triage, notify, prep, interview — #537 series), M4 (centralized `findajob.db.connect` helper + `utils.py` split — #546 / #548 / #550), M5 (versioned migration runner — #552), M6 (`background_tasks` observability table replacing filesystem sentinels — #554), M7 (strict mypy gate for `findajob.*` — #563). Plus standard OSS scaffolding: `CONTRIBUTING.md` (#505), `SECURITY.md` (#506), `.github/ISSUE_TEMPLATE/` + `PULL_REQUEST_TEMPLATE.md` (#507).

--- a/scripts/rename_folders.py
+++ b/scripts/rename_folders.py
@@ -16,18 +16,12 @@ import sqlite3
 
 from findajob.db import connect
 from findajob.paths import BASE
+from findajob.prep_naming import abbrev_title
 
 DB_PATH = f"{BASE}/data/pipeline.db"
 COMPANIES = f"{BASE}/companies"
 
 DATETIME_PAT = re.compile(r"^(.+)_(\d{4}-\d{2}-\d{2})_(\d{6})$")
-
-
-def abbrev_title(title, max_words=3):
-    title = re.sub(r"\s*\(.*?\)", "", title)
-    title = re.sub(r"[^\w\s-]", "", title)
-    words = [w for w in title.split() if w][:max_words]
-    return "_".join(words) if words else "Job"
 
 
 def main():

--- a/src/findajob/prep/orchestrator.py
+++ b/src/findajob/prep/orchestrator.py
@@ -6,10 +6,8 @@ file read at import time).
 
 `run_role()` was consolidated to `findajob.llm.role_runner` and
 `notify()` to `findajob.notifications.ntfy.quick_notify` in M3's cleanup
-PR; this module imports both rather than redefining them.
-
-`abbrev_title()` is still duplicated with `scripts/rename_folders.py` —
-M3+ cleanup target.
+PR; this module imports both rather than redefining them. `abbrev_title()`
+was consolidated to `findajob.prep_naming` in #556.
 """
 
 import json
@@ -31,20 +29,12 @@ from findajob.notifications.ntfy import quick_notify
 from findajob.paths import BASE, PANDOC, load_env
 from findajob.prep.docx_postprocess import _add_cover_letter_spacing, _linkify_contact_info
 from findajob.prep.quarantine import quarantine_stale_prep_folders
-from findajob.prep_naming import build_prep_filenames
+from findajob.prep_naming import abbrev_title, build_prep_filenames
 from findajob.profile import load_voice_samples, read_file_prefix
 
 DB_PATH = f"{BASE}/data/pipeline.db"
 PROFILE_PATH = f"{BASE}/candidate_context/profile.md"
 MASTER_RESUME_PATH = f"{BASE}/candidate_context/master_resume.md"
-
-
-def abbrev_title(title: str, max_words: int = 3) -> str:
-    """Return a folder-safe abbreviated title: first N significant words joined with underscores."""
-    title = re.sub(r"\s*\(.*?\)", "", title)  # strip parentheticals
-    title = re.sub(r"[^\w\s-]", "", title)  # remove punctuation
-    words = [w for w in title.split() if w][:max_words]
-    return "_".join(words) if words else "Job"
 
 
 def main() -> None:

--- a/src/findajob/prep_naming.py
+++ b/src/findajob/prep_naming.py
@@ -14,6 +14,14 @@ import re
 _UNSAFE_FNAME_CHARS: re.Pattern[str] = re.compile(r"[^\w\s\-&.,]")
 
 
+def abbrev_title(title: str, max_words: int = 3) -> str:
+    """Return a folder-safe abbreviated title: first N significant words joined with underscores."""
+    title = re.sub(r"\s*\(.*?\)", "", title)  # strip parentheticals
+    title = re.sub(r"[^\w\s-]", "", title)  # remove punctuation
+    words = [w for w in title.split() if w][:max_words]
+    return "_".join(words) if words else "Job"
+
+
 def safe_filename_part(s: str | None, max_len: int = 80) -> str:
     """Sanitize a string for use as a filename component.
 

--- a/tests/test_prep_import_safety.py
+++ b/tests/test_prep_import_safety.py
@@ -41,26 +41,27 @@ def test_orchestrator_loads_without_env_read(monkeypatch):
     assert calls == [], f"importing findajob.prep.orchestrator called load_env() {len(calls)} time(s); expected 0"
 
 
-def test_orchestrator_exposes_main_and_abbrev_title():
-    """`main` and `abbrev_title` are the deliberate public symbols.
+def test_orchestrator_exposes_main():
+    """`main` is the deliberate public symbol of the orchestrator.
 
-    `notify` was removed in the M3 cleanup PR — callers now import
+    `abbrev_title` was consolidated to `findajob.prep_naming` in #556 —
+    callers (this module + `scripts/rename_folders.py`) now import from
+    there. `notify` was removed in the M3 cleanup PR — callers now import
     `quick_notify` from `findajob.notifications.ntfy`.
     """
-    from findajob.prep.orchestrator import abbrev_title, main
+    from findajob.prep.orchestrator import main
 
     assert callable(main)
-    assert callable(abbrev_title)
 
 
 def test_abbrev_title_behavior():
-    """Behavior preserved from scripts/prep_application.py.
+    """Behavior preserved across the M3+ consolidation (#556).
 
-    Folder convention: `{Company}_{AbbrevTitle}_{YYYY-MM-DD}_{HHMMSS}` —
-    title abbreviated to first 3 words, underscored. CLAUDE.md "Output
-    Folder Format" rule.
+    Canonical home is `findajob.prep_naming` — co-located with
+    `safe_filename_part`. Folder convention from CLAUDE.md:
+    `{Company}_{AbbrevTitle}_{YYYY-MM-DD}_{HHMMSS}`.
     """
-    from findajob.prep.orchestrator import abbrev_title
+    from findajob.prep_naming import abbrev_title
 
     assert abbrev_title("Senior Software Engineer") == "Senior_Software_Engineer"
     assert abbrev_title("Senior Software Engineer III") == "Senior_Software_Engineer"


### PR DESCRIPTION
## Summary

First M3+ punch-list item from the closed M3 epic (#537). `abbrev_title()` was duplicated between `findajob.prep.orchestrator` (typed) and `scripts/rename_folders.py` (untyped); both copies kept in sync by code review rather than code structure. Consolidated to `findajob.prep_naming` — natural home, co-located with `safe_filename_part` (both build folder-safe filename components).

## Changes

- **`src/findajob/prep_naming.py`** — added `abbrev_title()` with type annotations and docstring (canonical home).
- **`src/findajob/prep/orchestrator.py`** — removed local definition; imports `abbrev_title` from `findajob.prep_naming`. Module docstring updated to note the consolidation in #556 (no longer says "still duplicated").
- **`scripts/rename_folders.py`** — removed local definition; imports `abbrev_title` from `findajob.prep_naming`.
- **`tests/test_prep_import_safety.py`** — `test_orchestrator_exposes_main_and_abbrev_title` renamed to `test_orchestrator_exposes_main` (orchestrator's deliberate public symbol is `main`; `abbrev_title` is now an import). `test_abbrev_title_behavior` updated to import from the canonical location. Mirrors the no-re-export-theater discipline established by the M3 cleanup PR (#544).
- **`CHANGELOG.md`** — `[Unreleased] / Refactor` entry added.

No behavior change. No schema, config, crontab, mount, or compose changes — not migration-required.

## Verification

- [x] `uv run pytest -q` — **1971 passed**, 1 skipped (pre-existing)
- [x] `uv run ruff check src/ scripts/ tests/` — All checks passed
- [x] `uv run ruff format --check` — 288 files formatted
- [x] `uv run mypy src/findajob/` — no issues found in 113 source files
- [x] `grep -rn "def abbrev_title" src/ scripts/` — exactly one definition (`prep_naming.py`)

## Test plan

- [x] Run pytest, ruff, mypy locally
- [ ] CI green
- [ ] Auto-merge after green

Closes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)