### PR TITLE
docs: #362 (Task 6) — rejection detection in usage.md + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,11 @@ responds in the same request — no poll cycle, no mirror table.
 | Promote | `POST /board/jobs/{fp}/promote` | Review button |
 | Reactivate | `POST /board/jobs/{fp}/reactivate` | Waitlist button |
 | Edit user_notes | `POST /board/jobs/{fp}/notes` | Applied notes input (800ms debounce) |
+| Confirm rejection email | `POST /board/rejections-review/{id}/confirm` | Rejections-review queue (#362) |
+| Dismiss rejection email | `POST /board/rejections-review/{id}/dismiss` | Rejections-review queue (#362) |
+| Reattribute rejection email | `POST /board/rejections-review/{id}/reattribute` | Rejections-review queue (#362) |
+
+The rejections-review row is keyed by `rejection_suggestions.id` rather than `jobs.fingerprint` — the suggestion is the source row, the job_id is found via `matched_job_id` (or operator-supplied on reattribute). Confirm/reattribute call `handle_not_selected(..., changed_by='gmail_rejection_detector')` so the audit trail tags the transition.
 
 **REJECT_REASON dropdown**: 11 options (includes "Low Fit Score"). Behavior depends on STATUS:
 - If STATUS = `Not Selected`: company rejection → `stage=not_selected`, NO `feedback_log`, folder stays in `_applied/` with `NOT_SELECTED_` marker file
@@ -204,6 +209,8 @@ responds in the same request — no poll cycle, no mirror table.
 ### Gmail Integration
 
 Gmail ingestion uses IMAP + app password, configured per-stack at `/config/gmail/`. Transparency contract codified as executable assertions in `tests/test_transparency_invariants.py` — failures there mean the disclosure banner is lying.
+
+The same IMAP integration also drives **rejection detection** (#362): every 30 minutes, `scripts/detect_rejections.py` scans Gmail against `config.rejection_sender_allowlist` (Greenhouse, Ashby, Lever, Workday-style ATS senders) and writes pending rows to `rejection_suggestions` for operator review at `/board/rejections-review/`. Cron entry `detect-rejections` in `ops/scheduled-jobs.yaml`. Operator confirms via the review-queue UI; never auto-flips. Spec: §4.x of `docs/superpowers/specs/2026-05-01-362-rejection-detection-design.md` (operator-private). Company-name aliases live in `config/company_aliases.yaml` (allowlisted in `/config/`; matcher hot-reloads on every cycle).
 
 ### Auth Gate Must Be Verified Post-Deploy
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -249,6 +249,43 @@ Every rejection, including rejections *from* you (stage = `rejected`) and reject
 
 ---
 
+## Auto-detected company rejections (`/board/rejections-review/`)
+
+When Gmail integration is configured, a background scan runs every 30 minutes against your inbox looking for company rejection emails (Greenhouse, Ashby, Lever, Workday-style, in-house ATS senders). Hits are matched against your active applications and surfaced as a review queue — **never auto-applied**. You confirm with one click and the row transitions to `not_selected` through the same `handle_not_selected` path the manual Reject button uses, with `audit_log.changed_by='gmail_rejection_detector'` so the trail distinguishes Gmail-confirmed from manual transitions later.
+
+**Where to find it:**
+
+- An info bar (📨 Rejection emails detected) appears above the dashboard queue when there are pending suggestions; click **review →** to jump to the queue.
+- Or navigate directly to `/board/rejections-review/`.
+
+**Per-card actions:**
+
+- **Confirm** — applies `not_selected` to the matched job. The matched-job stage must be `applied`/`interview`/`offer`; otherwise the endpoint 409s and you reattribute.
+- **Dismiss** — operator says "this isn't a rejection." The job's stage stays put; the suggestion is marked `dismissed`.
+- **Reattribute** — paste a different `jobs.id` if the matcher picked the wrong row (e.g. a duplicate application at the same company). Applies `not_selected` to the chosen job and records `user_chose_job_id` for traceability.
+
+Rows that the matcher couldn't auto-link to a current application surface as `unmatched` cards — Confirm is hidden, Reattribute or Dismiss are the only paths. The most common cause is **company-name aliasing**: the email's sender display name or body refers to a brand name that doesn't match `jobs.company`. To fix, add an entry to `config/company_aliases.yaml` via the `/config/` editor (the matcher hot-reloads on every cycle — no redeploy):
+
+```yaml
+# alias-or-display-name: canonical-DB-company
+cobot: collaborative robotics
+```
+
+**Schedule and triggers:**
+
+- Steady-state: every 30 minutes via supercronic (`detect-rejections` job in `ops/scheduled-jobs.yaml`). Per-stack timeout override via `FINDAJOB_DETECT_REJECTIONS_TIMEOUT` in `data/.env`.
+- First run on a stack: a backlog sweep over the prior 30 days (capped at 60) so existing inbox rejections aren't lost. Sentinel `gmail_state.json:rejection_backlog_scan_complete` flips on success.
+- A single ntfy notification fires when new suggestions land — opens directly to the review queue.
+
+**Caveats:**
+
+- **LinkedIn doesn't relay rejection emails** — applications submitted via LinkedIn's apply-on-LinkedIn flow get application receipts but not company-side rejections. This is a structural coverage gap, not a detector flaw. For LinkedIn-applied jobs, manual flips remain the path.
+- **HTML-only senders** (some Microsoft / Oracle / Smartrecruiters templates) are handled by a `bs4` fallback in the parser; if a particular sender shape produces empty bodies, you'll see it in `pipeline.jsonl` and the suggestion just won't surface — log a follow-up issue.
+- **Confirmed and dismissed rows are kept** as a write-once dedup log keyed by `gmail_message_id` (so re-running the scan doesn't re-suggest the same email). They don't appear in the queue but are queryable in `rejection_suggestions`.
+- **Already-handled rejections** (the operator already moved the job to `not_selected`/`rejected` before the detector caught up) emit a `rejection_email_corroborated` event in `pipeline.jsonl` and skip the queue, so the review surface stays focused on actionable rows.
+
+---
+
 ## The Materials viewer (`/materials/`)
 
 Three ways to get here:


### PR DESCRIPTION
## Summary

Sixth and final **code-only** task for #362. Docs catch up to Tasks 1–5 (already merged: #578/#579/#580/#581/#582).

**Operational steps from Task 6 (tag cut, dogfood deploy, cohort wave) are deferred to operator-driven release management** — they need to run on `docker.lan` against your stacks and don't fit a PR. This PR is docs-only and adds no schema, cron, or runtime changes.

## What changes

- **`docs/usage.md`** — new "Auto-detected company rejections (`/board/rejections-review/`)" section between the Rejected tab and the Materials viewer. Covers:
  - When the scan runs (every 30 min via supercronic; per-stack `FINDAJOB_DETECT_REJECTIONS_TIMEOUT` override).
  - Per-card actions: **Confirm** / **Dismiss** / **Reattribute** with the 409 guards explained.
  - Company-name aliasing via `config/company_aliases.yaml` (hot-reloaded; editable in `/config/`).
  - Known limitations: LinkedIn-applied jobs don't get rejection emails relayed (structural gap); HTML-only senders handled by `bs4` fallback; already-handled rejections emit `rejection_email_corroborated` to `pipeline.jsonl` without queue noise.
- **`CLAUDE.md`** — Board Routes table extends with the three new endpoints keyed by `rejection_suggestions.id` (rather than `jobs.fingerprint`), plus a note on the audit-tag attribution. Gmail Integration section gets a paragraph pointing at `scripts/detect_rejections.py` and `config/company_aliases.yaml`.

## What's NOT in this PR

- **`CHANGELOG.md`** — unchanged. The five per-task entries (#578/#579/#580/#581/#582) are already in `[Unreleased]` and will be rolled into the v0.22 release entry at tag-cut time per `docs/maintainers/release-process.md`.
- **`config/company_aliases.yaml`** documentation in `configure.md` — skipped because no other runtime YAML config (`excluded_employers`, `reject_reasons`, `prefilter_rules`) is documented there. The `.example` template ships with inline comments and the `/config/` editor is the runtime surface.

## Test plan

- [x] PII handcheck — clean
- [x] Pre-commit PII scan — passed (52 patterns × 44 added lines)
- [ ] CI green
- [ ] Operator-driven follow-up: tag v0.22.0 → dogfood verification on `findajob-test` → operator-stack verification on `findajob-brock` → cohort wave to testers (alice/papa/dave/judy/tango). Plan §Verification gate has the full checklist.

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-01-362-rejection-detection-design.md` (operator-private)
- Plan: `docs/superpowers/plans/2026-05-09-362-rejection-detection-c0.md` Task 6 (operator-private). Steps 1–3 (docs) are complete; Steps 4–7 (deploy + cohort wave + final commit) await your operational pass.

## Closing the arc

After this merges + a v0.22 tag cut, #362 can close. The whole feature lives across:
- migration #578 (Task 1, schema)
- pure-data classifier #579 (Task 2, fixture-driven)
- IMAP extension #580 (Task 3, transparency-tested)
- orchestration script #581 (Task 4, advisor-reviewed)
- web UI #582 (Task 5, HTMX-friendly review queue)
- this docs PR (Task 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)