### PR TITLE
fix(rejection_detector): #585 — _INTEREST_RE + _POSITION_RE miss three real shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+- **#585 fix(rejection_detector): `_INTEREST_RE` + `_POSITION_RE` miss three real rejection-email shapes.** Discovered post-#362 first-run backlog scan against operator's actual Gmail on 2026-05-09: 4 of 5 surfaced suggestions had wrong or missing extracted company. Three classifier-extraction defects + one role-extraction defect were the cause (the fourth issue is corroboration-coupling, tracked separately as #586). `_INTEREST_RE` now accepts (a) the "Thanks" subject shorthand alongside "Thank you" via `(?:thanks?\s+you|thanks)`; (b) up to 3 adverb words between "Thank you" and "for" via `(?:\s+\w+){0,3}` so "Thank you **so much** for your interest in COMPANY" stops being silently rejected; (c) ` as `, ` and `, ` for our/the ` in the terminator alternation so lazy `.+?` capture terminates at the company boundary instead of running to end-of-sentence on shapes like "interest in COMPANY as the next step in your career". `_POSITION_RE` adds `for our` alongside `for the position` / `application for` so role extraction works on bodies like "for our Infrastructure Engineer, Lab Manager role" — previously these emitted None for `extracted_role` and forced the matcher into ambiguous when the company had multiple active applications. Four new redacted `.eml` fixtures landed under `tests/fixtures/rejection_emails/` (lever/thanks_subject_role_in_body.eml, greenhouse/so_much_interjection.eml, ashby/as_the_next_step.eml, ashby/for_our_role.eml), each with a paired regression test that asserts BOTH `confidence='high'` AND that the extraction returned a usable, non-leaking value — the older confidence-only tests passed silently while extraction returned junk like `'Cobot as the next step in your career'`. All 24 classifier tests + 97 rejection-detector + adjacent tests pass.
+
 ## [0.22.0] — 2026-05-09
 
 ### Migration required

--- a/src/findajob/rejection_detector/classifier.py
+++ b/src/findajob/rejection_detector/classifier.py
@@ -94,13 +94,39 @@ def _suggest_reason(body_lower: str) -> str:
     return "Company passed"
 
 
+# Three real-corpus shapes drove the v0.22.1 relaxations (#585):
+#   • Subject "Thanks for your interest in COMPANY" — the literal "thank you"
+#     prefix missed the "Thanks" shorthand, so subject extraction fell through
+#     to a body that often began "Thank you for your interest in <ROLE> with
+#     <COMPANY>" and over-captured the role token. The Thanks?(?:\s+you)?
+#     alternation accepts both shapes.
+#   • Body "Thank you so much for your interest in COMPANY" — adverb
+#     interjections between "you" and "for" broke the original literal match.
+#     The (?:\s+\w+){0,3} optional-adverb run matches "so much", "very much",
+#     "very very much" without losing the anchor on "for your".
+#   • Body "interest in COMPANY as the next step in your career" — no comma
+#     or period between the company and the role-context continuation, so the
+#     lazy .+? captured the whole sentence. The new terminator alternation
+#     adds " as ", " and ", " for our/the " so the capture stops at the
+#     company boundary.
+# `_POSITION_RE` separately gained "for our" alongside "for the position" /
+# "application for" so role extraction works on bodies like "for our
+# Infrastructure Engineer, Lab Manager role" — previously these emitted
+# None for extracted_role and forced the matcher into ambiguous when the
+# company had multiple active applications.
 _INTEREST_RE = re.compile(
-    r"(?:thank you for your (?:interest|application) in|"
-    r"update on your application (?:for the position )?(?:at|to))\s+(.+?)(?:[.,!?\n]|$)",
+    r"(?:"
+    r"(?:thanks?\s+you|thanks)(?:\s+\w+){0,3}\s+for\s+your\s+(?:interest|application)\s+in"
+    r"|"
+    r"update\s+on\s+your\s+application(?:\s+for\s+the\s+position)?\s+(?:at|to)"
+    r")"
+    r"\s+(.+?)"
+    r"(?:[.,!?\n]|\s+as\s+|\s+and\s+|\s+for\s+(?:our|the)\s+|$)",
     re.IGNORECASE,
 )
 _POSITION_RE = re.compile(
-    r"(?:for the position(?: of)?|application for(?: the)?(?: position(?: of)?)?)\s+(.+?)(?:\s+at\s+|[.,!?\n]|$)",
+    r"(?:for the position(?: of)?|for our|application for(?: the)?(?: position(?: of)?)?)"
+    r"\s+(.+?)(?:\s+at\s+|[.,!?\n]|$)",
     re.IGNORECASE,
 )
 

--- a/tests/fixtures/rejection_emails/ashby/as_the_next_step.eml
+++ b/tests/fixtures/rejection_emails/ashby/as_the_next_step.eml
@@ -1,0 +1,21 @@
+From: AcmeRoboCo Hiring Team <no-reply@ashbyhq.com>
+To: jane.doe@example.com
+Subject: AcmeRoboCo Application Update
+Message-ID: <ashby-rej-asthenext-001@ashbyhq.com>
+Date: Thu, 30 Apr 2026 18:25:38 +0000
+Content-Type: text/plain; charset=utf-8
+
+Jane,
+
+Thank you for your interest in AcmeRoboCo as the next step in your
+career. We appreciate the time you put into your application and your
+interest in AcmeRoboCo. Unfortunately, we will not be proceeding with
+your candidacy for the Deployment Engineer role at this time.
+
+We wish we could talk to every candidate who applies, but timing can
+hinder that. We are growing, and new opportunities arise often, so
+please keep an eye on our careers page for company updates and our
+hiring pipeline.
+
+Sincerely,
+The AcmeRoboCo Team

--- a/tests/fixtures/rejection_emails/ashby/for_our_role.eml
+++ b/tests/fixtures/rejection_emails/ashby/for_our_role.eml
@@ -1,0 +1,21 @@
+From: AcmeCloudCo Hiring Team <no-reply@ashbyhq.com>
+To: jane.doe@example.com
+Subject: Thank you for your interest in AcmeCloudCo
+Message-ID: <ashby-rej-forour-001@ashbyhq.com>
+Date: Thu, 16 Apr 2026 15:50:36 +0000
+Content-Type: text/plain; charset=utf-8
+
+Hi Jane,
+
+Thank you for your application to and interest in AcmeCloudCo for our
+Infrastructure Engineer, Lab Manager role. After careful
+consideration, we have decided to move forward with other candidates
+whose skills and experience more closely match the requirements of
+the position.
+
+Thank you again for your interest in AcmeCloudCo. If you see other
+roles on our careers page that look promising, we would welcome your
+application.
+
+Best,
+AcmeCloudCo Recruiting Team

--- a/tests/fixtures/rejection_emails/greenhouse/so_much_interjection.eml
+++ b/tests/fixtures/rejection_emails/greenhouse/so_much_interjection.eml
@@ -1,0 +1,22 @@
+From: AcmeAI Recruiting <no-reply@us.greenhouse-mail.io>
+To: jane.doe@example.com
+Subject: AcmeAI Follow-Up for Staff Engineer | Jane Doe
+Message-ID: <gh-rej-somuch-001@us.greenhouse-mail.io>
+Date: Thu, 01 May 2026 18:51:18 +0000
+Content-Type: text/plain; charset=utf-8
+
+Hi Jane,
+
+Thank you so much for your interest in AcmeAI and for the time and
+effort you have invested in our process. After consideration, we have
+decided not to move forward with your application for the Staff
+Engineer role.
+
+We want to be clear that this is only an update for the Staff Engineer
+role, and if you applied to other roles at AcmeAI, you may still hear
+back from us if we see strong alignment with our needs.
+
+It's our policy to wish you continued success in your search.
+
+Best regards,
+AcmeAI Recruiting

--- a/tests/fixtures/rejection_emails/lever/thanks_subject_role_in_body.eml
+++ b/tests/fixtures/rejection_emails/lever/thanks_subject_role_in_body.eml
@@ -1,0 +1,21 @@
+From: NimbusCo Recruiting <no-reply@hire.lever.co>
+To: jane.doe@example.com
+Subject: Thanks for your interest in NimbusCo, Jane
+Message-ID: <lever-rej-thanks-001@hire.lever.co>
+Date: Tue, 28 Apr 2026 16:26:03 +0000
+Content-Type: text/plain; charset=utf-8
+
+Hi Jane,
+
+Thank you for your interest in the Program Manager, Operations
+Infrastructure role with NimbusCo. At this time, we have decided to
+pursue other candidates whose backgrounds and experience more closely
+align with our needs.
+
+We realize it is a time commitment to engage any company in the
+application process, and we sincerely appreciate your efforts. We
+appreciate your interest in NimbusCo and wish you success in your
+job search.
+
+Best regards,
+NimbusCo Talent Team

--- a/tests/test_rejection_detector_classifier.py
+++ b/tests/test_rejection_detector_classifier.py
@@ -110,3 +110,87 @@ def test_layer1_extracted_company_and_role() -> None:
     assert suggestion is not None
     assert suggestion.extracted_company is not None
     assert "ExampleCo" in suggestion.extracted_company
+
+
+# ─── #585: classifier extraction-bug regression fixtures ─────────────────────
+# Four real rejection-email shapes from operator's May-09 first-run backlog
+# that the original `_INTEREST_RE` / `_POSITION_RE` regexes misextracted.
+# Each fixture asserts BOTH confidence='high' AND that the extraction
+# returned a usable value — guards against silent extraction failure that
+# the older confidence-only tests would have missed.
+
+
+def test_thanks_subject_extracts_company_not_role_token() -> None:
+    """Subject 'Thanks for your interest in X, Name' must extract X.
+
+    Regression: the original `_INTEREST_RE` required literal 'thank you' so
+    the subject missed entirely. Body extraction then over-captured a role
+    token ('the Program Manager') from 'interest in the Program Manager...
+    role with COMPANY' — exactly the Zoox-shape failure in operator's queue.
+    """
+    raw = (FIXTURES / "lever" / "thanks_subject_role_in_body.eml").read_bytes()
+    suggestion = classify_email(raw)
+    assert suggestion is not None
+    assert suggestion.confidence == "high"
+    assert suggestion.extracted_company is not None
+    assert "NimbusCo" in suggestion.extracted_company
+    # The role token 'the Program Manager' MUST NOT leak into the company field.
+    assert "Program Manager" not in suggestion.extracted_company
+
+
+def test_so_much_adverb_interjection_still_extracts() -> None:
+    """Body 'Thank you so much for your interest in X' must still extract X.
+
+    Regression: the original regex required `for` to immediately follow
+    `you`; 'so much' between them broke the match — Anthropic-shape
+    failure where extracted_company stayed None on operator's queue.
+    """
+    raw = (FIXTURES / "greenhouse" / "so_much_interjection.eml").read_bytes()
+    suggestion = classify_email(raw)
+    assert suggestion is not None
+    assert suggestion.confidence == "high"
+    assert suggestion.extracted_company is not None
+    assert "AcmeAI" in suggestion.extracted_company
+    # The continuation 'AcmeAI and for the time' must NOT leak into the
+    # captured company value — the ' and ' alternation in the terminator
+    # class is the load-bearing piece.
+    assert "and for the time" not in suggestion.extracted_company
+
+
+def test_as_the_next_step_continuation_terminates_company() -> None:
+    """'interest in X as the next step in your career' must extract X, not the tail.
+
+    Regression: lazy `.+?` over-captured up to the period at end of
+    sentence because there was no comma/period between the company and the
+    role-context continuation — Cobot-shape failure on operator's queue
+    that surfaced as `extracted_company='Cobot as the next step in your career'`.
+    """
+    raw = (FIXTURES / "ashby" / "as_the_next_step.eml").read_bytes()
+    suggestion = classify_email(raw)
+    assert suggestion is not None
+    assert suggestion.confidence == "high"
+    assert suggestion.extracted_company is not None
+    assert "AcmeRoboCo" in suggestion.extracted_company
+    assert "as the next step" not in suggestion.extracted_company
+
+
+def test_for_our_role_extracts_role() -> None:
+    """Body 'for our [ROLE]' must extract the role.
+
+    Regression: the original `_POSITION_RE` only accepted 'for the
+    position' / 'application for' shapes — 'for our [ROLE]' produced
+    None for `extracted_role`, leaving the matcher with only a company
+    to disambiguate by, which collapses to 'ambiguous' when the company
+    has multiple active applications. Crusoe-shape failure on operator's
+    queue.
+    """
+    raw = (FIXTURES / "ashby" / "for_our_role.eml").read_bytes()
+    suggestion = classify_email(raw)
+    assert suggestion is not None
+    assert suggestion.confidence == "high"
+    assert suggestion.extracted_company is not None
+    assert "AcmeCloudCo" in suggestion.extracted_company
+    assert suggestion.extracted_role is not None
+    # Either 'Infrastructure Engineer' or 'Lab Manager' is acceptable —
+    # both are role tokens the matcher can use for disambiguation.
+    assert "Infrastructure Engineer" in suggestion.extracted_role or "Lab Manager" in suggestion.extracted_role


### PR DESCRIPTION
## Summary

Closes #585. Discovered live post-#362 first-run backlog against operator's actual Gmail on 2026-05-09 — 4 of 5 surfaced suggestions had wrong or missing extracted company. Root cause: three regex defects in `findajob.rejection_detector.classifier`. Pre-#585 tests passed silently because they only asserted `confidence='high'`, not extraction quality.

## What changed

- **`src/findajob/rejection_detector/classifier.py`** — patched `_INTEREST_RE` + `_POSITION_RE`:
  - `(?:thanks?\s+you|thanks)` accepts the "Thanks" subject shorthand alongside "Thank you"
  - `(?:\s+\w+){0,3}` allows up to 3 adverb words between "Thank you" and "for" (e.g. "so much")
  - Terminator alternation gains `\s+as\s+`, `\s+and\s+`, `\s+for\s+(?:our|the)\s+` so the lazy `.+?` capture stops at the company boundary on continuation patterns
  - `_POSITION_RE` adds `for our` alongside `for the position` / `application for`
  - Top-of-block comment documents which corpus shape drove each relaxation
- **4 new redacted fixtures** under `tests/fixtures/rejection_emails/` covering the four real shapes from operator's queue (anonymized to `NimbusCo` / `AcmeAI` / `AcmeRoboCo` / `AcmeCloudCo`).
- **4 new tests** in `tests/test_rejection_detector_classifier.py`. Each asserts BOTH `confidence='high'` AND that the extracted company contains the expected token AND that the captured value does NOT leak the role/continuation tail (the failure mode the older confidence-only tests would have missed).
- **CHANGELOG** `### Fixed` entry under `[Unreleased]`.

## Behavior validation against the live corpus

| Shape | Pre-#585 surfaced extracted_company | Post-#585 expected |
|---|---|---|
| Zoox-shape (Lever, "Thanks" subject + role-with-company body) | `the Program Manager` (junk) | `NimbusCo` (clean) |
| Anthropic-shape (Greenhouse, "so much" body interjection) | `None` (silent failure) | `AcmeAI` (clean) |
| Cobot-shape (Ashby, "as the next step" continuation) | `Cobot as the next step in your career` (junk) | `AcmeRoboCo` (clean) |
| Crusoe-shape (Ashby, "for our" role context) | `Crusoe` ✓ but `extracted_role=None` | `AcmeCloudCo` + role |

## Test plan

- [x] `uv run pytest tests/test_rejection_detector_classifier.py -q` — 24 passed
- [x] `uv run pytest tests/test_rejection_detector_classifier.py tests/test_rejection_detector_matcher.py tests/test_rejection_detector_parser.py tests/test_detect_rejections_script.py tests/test_routes_rejections_review.py tests/test_actions.py -q` — 97 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] `uv run mypy src/findajob/rejection_detector/classifier.py` — clean
- [x] PII handcheck on all 7 touched files — clean (no operator/tester real names; only the anonymized fixture names)
- [ ] CI green
- [ ] Post-merge: next 30-min `detect-rejections` cron tick on operator's stack will re-evaluate any new emails using the patched extraction. Existing pending rows from the v0.22.0 first-run backlog were already resolved (1 confirmed + 4 dismissed) so there's no in-flight retroactive fix needed.

## Out of scope (sibling issue)

#586 tracks the deeper architectural coupling — when extraction fails entirely, the corroboration path can't recognize that an already-handled rejection exists, so noise leaks into the queue. This PR fixes the *immediate* extraction failures; #586 fixes the broader resilience story.

## Spec / plan

Spec body markers + extraction discussion is in operator-private spec §3.2 + §4.2. The new fixture corpus serves as the durable test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)