### PR TITLE
fix(staging): #610 #611 — reset bind-mount safety + green-check event names

### DIFF
--- a/src/findajob/staging/green.py
+++ b/src/findajob/staging/green.py
@@ -1,13 +1,17 @@
 """Staging green-check (#565).
 
 Exits 0 iff all four predicates hold:
-  1. triage_completed event present in last 26h
-  2. zero ERROR-level events between the most recent triage_started and triage_completed
+  1. pipeline_complete event present in last 26h
+  2. zero ERROR-level events between the most recent pipeline_started and pipeline_complete
   3. findajob.web.verify_auth exits 0 (delegated to subprocess)
   4. clicker sentinel last invocation exited 0
 
 Designed to be invoked from inside the staging container by operator
 during the pre-tag checklist.
+
+Event names match what `scripts/triage.py` emits via `findajob.audit.log_event`
+(``pipeline_started`` / ``pipeline_complete``). The earlier draft of this module
+named them ``triage_*`` which never appeared in pipeline.jsonl — fixed in #611.
 """
 
 from __future__ import annotations
@@ -49,7 +53,7 @@ def _parse_ts(s: str) -> dt.datetime:
 def _predicate_triage_recent(log: Path, max_age_hours: int) -> bool:
     cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(hours=max_age_hours)
     for ev in reversed(_read_events(log)):
-        if ev.get("event") == "triage_completed":
+        if ev.get("event") == "pipeline_complete":
             try:
                 ts = _parse_ts(ev["ts"])
             except (KeyError, ValueError):
@@ -64,9 +68,9 @@ def _predicate_no_errors_during_last_triage(log: Path) -> bool:
     last_completed: int | None = None
     for i, ev in enumerate(events):
         name = ev.get("event")
-        if name == "triage_started":
+        if name == "pipeline_started":
             last_started = i
-        elif name == "triage_completed":
+        elif name == "pipeline_complete":
             last_completed = i
     if last_started is None or last_completed is None or last_completed < last_started:
         return False

--- a/src/findajob/staging/reset.py
+++ b/src/findajob/staging/reset.py
@@ -25,12 +25,31 @@ DEFAULT_FIXTURE = Path(__file__).parent / "persona_fixture"
 DEFAULT_TARGET = Path(BASE)
 
 
+def _wipe_contents(d: Path) -> None:
+    """Wipe contents of ``d`` but leave ``d`` itself intact.
+
+    Bind-mount safe: ``shutil.rmtree`` on a bind-mount root fails inside the
+    container with ``PermissionError`` because you can't remove the mount
+    point. This helper iterates children and removes each, leaving the
+    directory entry alone (#610).
+    """
+    for child in d.iterdir():
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+
 def reset_to_persona(fixture: Path, target: Path) -> None:
-    """Wipe target/data/ and copy fixture/* into target/.
+    """Wipe target/data/ contents and copy fixture/* into target/.
 
     Subdirs other than data/ are replaced only when the fixture supplies them
-    (rmtree dst → copytree src). Pre-existing target subdirs not present in
-    the fixture survive. Callers must ensure the fixture is complete.
+    (wipe contents → re-copy from fixture). Pre-existing target subdirs not
+    present in the fixture survive. Callers must ensure the fixture is complete.
+
+    Bind-mount safety (#610): wipes ``data/`` (and other subdirs the fixture
+    supplies) by removing CONTENTS, not the directory itself — so this works
+    when target subdirectories are Docker bind mounts.
 
     Raises FileNotFoundError if fixture missing,
     NotADirectoryError if target exists but is not a directory.
@@ -43,14 +62,21 @@ def reset_to_persona(fixture: Path, target: Path) -> None:
 
     target_data = target / "data"
     if target_data.exists():
-        shutil.rmtree(target_data)
+        _wipe_contents(target_data)
 
     for entry in fixture.iterdir():
         dst = target / entry.name
         if entry.is_dir():
             if dst.exists():
-                shutil.rmtree(dst)
-            shutil.copytree(entry, dst)
+                _wipe_contents(dst)
+            else:
+                dst.mkdir(parents=True)
+            for inner in entry.iterdir():
+                inner_dst = dst / inner.name
+                if inner.is_dir():
+                    shutil.copytree(inner, inner_dst)
+                else:
+                    shutil.copy2(inner, inner_dst)
         else:
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(entry, dst)

--- a/tests/test_staging_green.py
+++ b/tests/test_staging_green.py
@@ -19,15 +19,15 @@ def _write_jsonl(path: Path, events: list[dict]) -> None:
     path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
 
 
-def test_triage_completed_recent_passes(tmp_path: Path) -> None:
+def test_pipeline_complete_recent_passes(tmp_path: Path) -> None:
     log = tmp_path / "pipeline.jsonl"
-    _write_jsonl(log, [{"ts": _ts(2), "event": "triage_completed"}])
+    _write_jsonl(log, [{"ts": _ts(2), "event": "pipeline_complete"}])
     assert green._predicate_triage_recent(log, max_age_hours=26) is True
 
 
-def test_triage_completed_too_old_fails(tmp_path: Path) -> None:
+def test_pipeline_complete_too_old_fails(tmp_path: Path) -> None:
     log = tmp_path / "pipeline.jsonl"
-    _write_jsonl(log, [{"ts": _ts(48), "event": "triage_completed"}])
+    _write_jsonl(log, [{"ts": _ts(48), "event": "pipeline_complete"}])
     assert green._predicate_triage_recent(log, max_age_hours=26) is False
 
 
@@ -36,9 +36,9 @@ def test_no_errors_during_triage_passes(tmp_path: Path) -> None:
     _write_jsonl(
         log,
         [
-            {"ts": _ts(3), "event": "triage_started"},
+            {"ts": _ts(3), "event": "pipeline_started"},
             {"ts": _ts(2.5), "event": "fetched_jobs", "level": "INFO"},
-            {"ts": _ts(2), "event": "triage_completed"},
+            {"ts": _ts(2), "event": "pipeline_complete"},
         ],
     )
     assert green._predicate_no_errors_during_last_triage(log) is True
@@ -49,9 +49,9 @@ def test_errors_during_triage_fails(tmp_path: Path) -> None:
     _write_jsonl(
         log,
         [
-            {"ts": _ts(3), "event": "triage_started"},
+            {"ts": _ts(3), "event": "pipeline_started"},
             {"ts": _ts(2.5), "event": "adapter_failure", "level": "ERROR"},
-            {"ts": _ts(2), "event": "triage_completed"},
+            {"ts": _ts(2), "event": "pipeline_complete"},
         ],
     )
     assert green._predicate_no_errors_during_last_triage(log) is False
@@ -79,8 +79,8 @@ def test_main_all_pass_returns_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     _write_jsonl(
         log,
         [
-            {"ts": _ts(3), "event": "triage_started"},
-            {"ts": _ts(2), "event": "triage_completed"},
+            {"ts": _ts(3), "event": "pipeline_started"},
+            {"ts": _ts(2), "event": "pipeline_complete"},
         ],
     )
     sentinel = tmp_path / ".staging_clicker_last_status"
@@ -92,9 +92,29 @@ def test_main_all_pass_returns_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPa
 
 def test_main_any_fail_returns_nonzero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     log = tmp_path / "pipeline.jsonl"
-    _write_jsonl(log, [{"ts": _ts(48), "event": "triage_completed"}])  # too old
+    _write_jsonl(log, [{"ts": _ts(48), "event": "pipeline_complete"}])  # too old
     sentinel = tmp_path / ".staging_clicker_last_status"
     sentinel.write_text(json.dumps({"exit_code": 0, "mode": "prep", "timestamp": _ts(1)}))
     monkeypatch.setattr(green, "_predicate_verify_auth_zero", lambda: True)
     rc = green.main(["--log", str(log), "--sentinel", str(sentinel)])
     assert rc != 0
+
+
+def test_predicates_match_real_audit_log_event_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression for #611 — predicates must match what `findajob.audit.log_event`
+    actually emits (`pipeline_started` / `pipeline_complete`), not synthetic event
+    names invented in this test file. Catches future event-name drift between
+    triage.py emission and green-check expectation.
+    """
+    from findajob import audit
+
+    log_path = tmp_path / "pipeline.jsonl"
+    monkeypatch.setattr(audit, "LOG_PATH", str(log_path))
+
+    audit.log_event("pipeline_started")
+    audit.log_event("scoring_started", total=100, workers=6)
+    audit.log_event("scoring_complete", total=100, scored=100, errors=0)
+    audit.log_event("pipeline_complete", new=100, dupes=0, scored=100, noise_skipped=0)
+
+    assert green._predicate_triage_recent(log_path, max_age_hours=26) is True
+    assert green._predicate_no_errors_during_last_triage(log_path) is True

--- a/tests/test_staging_reset.py
+++ b/tests/test_staging_reset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -53,3 +54,64 @@ def test_reset_refuses_target_is_file(tmp_path: Path) -> None:
     target.write_text("not a dir")
     with pytest.raises(NotADirectoryError):
         reset.reset_to_persona(fixture=fixture, target=target)
+
+
+def test_reset_succeeds_when_subdirs_cannot_be_removed(tmp_path: Path) -> None:
+    """Regression for #610 — reset must work when target/data and other target
+    subdirs cannot be removed (e.g., they are Docker bind-mount roots).
+
+    Simulated by monkeypatching ``shutil.rmtree`` to raise ``PermissionError``
+    when called on directories that exist as non-empty children of the target,
+    matching what happens inside a container when target/data is a bind mount.
+    The fix is for ``reset_to_persona`` to wipe contents (iterdir + per-child
+    removal) instead of removing the directory itself.
+    """
+    import shutil
+
+    fixture = tmp_path / "fixture"
+    target = tmp_path / "stack"
+
+    # Build fixture with the canonical persona shape (config/, data/, candidate_context/)
+    (fixture / "config").mkdir(parents=True)
+    (fixture / "data").mkdir(parents=True)
+    (fixture / "candidate_context").mkdir(parents=True)
+    (fixture / "config" / "active_sources.txt").write_text("jobs-api14\n")
+    (fixture / "data" / ".onboarding-complete").write_text("")
+    (fixture / "candidate_context" / "profile.md").write_text("# Persona")
+
+    # Pre-create target subdirs and put stale junk in data/ (simulating a
+    # populated bind mount). The bind-mount nature is captured by the rmtree
+    # protection below — _wipe_contents uses iterdir+remove-children, which
+    # never tries to rmtree the protected directories themselves.
+    (target / "data").mkdir(parents=True)
+    (target / "config").mkdir(parents=True)
+    (target / "candidate_context").mkdir(parents=True)
+    (target / "data" / "stale_pipeline.db").write_text("STALE")
+    (target / "config" / "stale_active_sources.txt").write_text("STALE")
+
+    protected_dirs = {target / "data", target / "config", target / "candidate_context"}
+    real_rmtree = shutil.rmtree
+
+    def guarded_rmtree(path: Any, *args: Any, **kwargs: Any) -> None:
+        if Path(path) in protected_dirs:
+            raise PermissionError(f"[Errno 13] Permission denied (simulated bind mount): {path}")
+        real_rmtree(path, *args, **kwargs)
+
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(reset.shutil, "rmtree", guarded_rmtree)
+    try:
+        reset.reset_to_persona(fixture=fixture, target=target)
+    finally:
+        monkey.undo()
+
+    # All bind-mount-target dirs survived (we never rmtree'd them)
+    assert (target / "data").is_dir()
+    assert (target / "config").is_dir()
+    assert (target / "candidate_context").is_dir()
+    # Stale contents wiped
+    assert not (target / "data" / "stale_pipeline.db").exists()
+    assert not (target / "config" / "stale_active_sources.txt").exists()
+    # Persona contents installed
+    assert (target / "data" / ".onboarding-complete").exists()
+    assert (target / "config" / "active_sources.txt").read_text() == "jobs-api14\n"
+    assert (target / "candidate_context" / "profile.md").read_text() == "# Persona"


### PR DESCRIPTION
## Summary

Two production bugs in #565's staging surface that unit tests (using `tmp_path`) didn't catch but the first real staging stack standup hit immediately.

- **Closes #611** — `green` predicates 1/2 keyed on the wrong event names (`triage_*` vs the real `pipeline_*` that `scripts/triage.py` emits via `findajob.audit.log_event`). Green-check exited 1 on a healthy stack.
- **Closes #610** — `reset.reset_to_persona()` called `shutil.rmtree` on `target/data`, which fails with EACCES inside a container when target/data is a Docker bind mount. Workaround during initial standup was host-side `find -mindepth 1 -delete` + `docker cp persona_fixture/.`.

## Changes

- `src/findajob/staging/green.py` — predicate event names: `triage_completed` → `pipeline_complete`, `triage_started` → `pipeline_started`. Module docstring updated to reflect canonical names + reference #611 for context.
- `src/findajob/staging/reset.py` — new `_wipe_contents(d)` helper (iterate + remove children, leaves directory itself); `reset_to_persona` switches from `shutil.rmtree(d)` to `_wipe_contents(d)` everywhere; outer for-loop changes to per-child copy instead of `copytree(entry, dst)` so it works against existing (bind-mounted) target subdirs.
- `tests/test_staging_green.py` — fixture event names updated to `pipeline_*`. **New regression test** `test_predicates_match_real_audit_log_event_output` calls `findajob.audit.log_event` directly and asserts the predicate matches — catches future event-name drift.
- `tests/test_staging_reset.py` — **New regression test** `test_reset_succeeds_when_subdirs_cannot_be_removed` simulates bind-mount layout by monkeypatching `shutil.rmtree` to raise `PermissionError` on protected dirs; asserts reset still installs the persona without trying to remove the mount points.

## Pre-flight

- `uv run pytest tests/test_staging_green.py tests/test_staging_reset.py -v` — 14/14 pass
- `uv run mypy src/findajob/staging/ tests/test_staging_*.py` — no issues
- `uv run ruff check . && ruff format --check .` — clean

## Meta-lesson (saved as memory for future staging work)

Both bugs surfaced because the staging modules were tested only against synthetic tmpdir fixtures, never against real production behavior. The two new regression tests close that gap directly:
- For event-name drift: write the log via `audit.log_event` (production codepath), then assert the consumer reads it.
- For bind-mount reality: simulate the constraint via `monkeypatch` and assert the code copes.

When extracting fragile-coupling-prone code into a new module, at least one regression test should exercise the real upstream-or-downstream codepath, not just the local one.

## Test plan

- [ ] CI green
- [ ] Operator pulls latest image on `findajob-staging` (`docker compose pull && up -d`)
- [ ] Re-run `python -m findajob.staging.green` — expect `OK: all 4 predicates green`
- [ ] Re-run `python -m findajob.staging.reset` against staging — expect exit 0, no permission error
- [ ] Close #565 once a release ships through the corrected gate end-to-end (AC #5)

## Related

- #565 — parent issue (the staging tier itself)
- #609 — PR that introduced both surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)