### PR TITLE
fix(staging): green-check DEFAULT_LOG reads from logs/, not data/

### DIFF
--- a/src/findajob/staging/green.py
+++ b/src/findajob/staging/green.py
@@ -23,9 +23,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+from findajob.audit import LOG_PATH as _AUDIT_LOG_PATH
 from findajob.paths import BASE
 
-DEFAULT_LOG = Path(BASE) / "data" / "pipeline.jsonl"
+# Derive from audit.LOG_PATH so green-check reads the same file triage writes.
+# Hardcoding the path here drifted in #565's first deploy — pipeline events
+# live at logs/pipeline.jsonl, not data/pipeline.jsonl.
+DEFAULT_LOG = Path(_AUDIT_LOG_PATH)
 DEFAULT_SENTINEL = Path(BASE) / "data" / ".staging_clicker_last_status"
 DEFAULT_TRIAGE_MAX_AGE_HOURS = 26
 

--- a/tests/test_staging_green.py
+++ b/tests/test_staging_green.py
@@ -100,6 +100,18 @@ def test_main_any_fail_returns_nonzero(tmp_path: Path, monkeypatch: pytest.Monke
     assert rc != 0
 
 
+def test_default_log_matches_audit_log_path() -> None:
+    """Regression — `green.DEFAULT_LOG` must point at the file `audit.log_event`
+    actually writes, not at a sibling path that drifts. Hardcoding the path in
+    green.py drifted in #565's first deploy (used `data/pipeline.jsonl` while
+    audit writes to `logs/pipeline.jsonl`). Locking the relationship here so a
+    future refactor of audit's path doesn't silently break green-check.
+    """
+    from findajob import audit
+
+    assert str(green.DEFAULT_LOG) == audit.LOG_PATH
+
+
 def test_predicates_match_real_audit_log_event_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression for #611 — predicates must match what `findajob.audit.log_event`
     actually emits (`pipeline_started` / `pipeline_complete`), not synthetic event


### PR DESCRIPTION
## Summary

Third path-bug from #565's first staging deploy. `green.DEFAULT_LOG` was hardcoded as `Path(BASE) / "data" / "pipeline.jsonl"`, but `findajob.audit.log_event` writes to `Path(BASE) / "logs" / "pipeline.jsonl"`. Even after #611's event-name fix landed (PR #612), default-flag green-check still failed predicate-1 + predicate-2 because it was reading from a file that never exists.

Operator workaround was `python -m findajob.staging.green --log /app/logs/pipeline.jsonl`. Confirmed working with explicit flag; the bug was just in the default.

## Fix

Derive `DEFAULT_LOG` from `audit.LOG_PATH` directly — single source of truth. If audit's log path ever changes, green-check follows automatically.

```python
from findajob.audit import LOG_PATH as _AUDIT_LOG_PATH

DEFAULT_LOG = Path(_AUDIT_LOG_PATH)
```

New regression test `test_default_log_matches_audit_log_path` locks the equality. Future refactor of audit's path can't silently break green-check.

## Same meta-cause as #610 + #611

All three bugs from #565's surface area come from the same place: staging modules tested only against synthetic fixtures with explicit paths, never against the real production default-path codepath. PR #612 added a regression test for event-name drift; this PR adds one for path drift.

## Pre-flight

- `uv run pytest tests/test_staging_green.py -v` — 11/11 pass (was 10, +1 new test)
- `uv run mypy src/findajob/staging/` — clean
- `uv run ruff check . && ruff format --check .` — clean

## Test plan

- [ ] CI green
- [ ] Pull latest on `findajob-staging`
- [ ] Run `python -m findajob.staging.green` (no flags) — expect `OK: all 4 predicates green`
- [ ] Close #565 once a release ships through the corrected gate

## Related

#565 (parent), #611 (event-name fix), #612 (PR for #610+#611). After this lands, all three production bugs from the staging surface are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)