### PR TITLE
chore(ops): bump fly.toml.example pin v0.23.3 → v0.24.0

### DIFF
--- a/ops/fly.toml.example
+++ b/ops/fly.toml.example
@@ -21,7 +21,7 @@ primary_region = "iad"
 # when rolling to a new release and re-run ops/fly-deploy.sh (or just
 # `fly deploy --config ops/fly.toml`).
 [build]
-  image = "ghcr.io/brockamer/findajob:v0.23.3"
+  image = "ghcr.io/brockamer/findajob:v0.24.0"
 
 # Non-secret env. Mirrors compose.yaml.example's environment block, with
 # one critical difference: JSP_BASE points at /app/state, not /app. Fly


### PR DESCRIPTION
## Summary

- One-line bump of the tracked Fly deployment template's image pin to `:v0.24.0`.
- v0.24.0 is the first image carrying the single-volume entrypoint (#643) + `JSP_BASE`-derived `web/app.py` defaults, so any fresh Fly deploy needs this or later.

## Test plan

- [x] Single-line diff, no behavior change for existing stacks (compose stacks don't read `ops/fly.toml.example`)
- [ ] First Fly deploy from the bumped template confirms `:v0.24.0` is pullable and verify_auth passes — covered by the pending `findajob-brockfly` E2E walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)