### PR TITLE
fix(ops): #625 — warn at startup when data dir is on non-native FS (macOS Docker Desktop unsupported)

### DIFF
--- a/docs/getting-started/install-docker.md
+++ b/docs/getting-started/install-docker.md
@@ -10,6 +10,14 @@ This is the install + operations guide for external users running findajob from 
 - You have [Dockge](https://github.com/louislam/dockge) installed (or docker compose CLI access).
 - You want to run findajob from the prebuilt image at `ghcr.io/brockamer/findajob` rather than building from source.
 
+## Supported platforms
+
+findajob is supported on **Linux Docker hosts** (any distro running native Docker Engine on a native filesystem — ext4, xfs, btrfs, zfs, overlay, tmpfs). The pipeline is a long-running batch process that writes to SQLite in WAL mode; this requires the bind-mount layer to honor POSIX file-locking semantics correctly.
+
+**Docker Desktop on macOS and Windows is not supported.** Both ship bind mounts through gRPC-FUSE / VirtioFS / 9p, which have known incompatibilities with SQLite WAL mode and can corrupt `pipeline.db` mid-write (#625). The container's entrypoint emits a stderr warning at startup when it detects a non-native filesystem under `state/data/`, but it will still try to run — corruption is observed in practice but does not always reproduce immediately.
+
+If you want to run findajob on a Mac or Windows machine, host it inside a **Linux VM** (any hypervisor) and install Docker Engine inside the VM. The bind mount then sits on the VM's native ext4 (or equivalent) and works correctly.
+
 ## Prerequisites on the Docker host
 
 - Docker Engine 24+ and Docker Compose v2
@@ -25,8 +33,9 @@ See [configure.md](configure.md). API keys and personal config end up in `state/
 Pick any directory for your stack — Docker Compose's bind mounts are relative to wherever `compose.yaml` lives, so the location is your choice:
 
 - Linux server: `/opt/stacks/findajob-<you>/` is the conventional system-path layout (will need `sudo`).
-- macOS: `~/docker/findajob-<you>/` or any path under your home directory works fine.
-- Anywhere else under your home directory works too — pick what fits your other Docker stacks.
+- Anywhere under your home directory works too — pick what fits your other Docker stacks.
+
+> If you're on macOS or Windows, your Docker host needs to be a Linux VM, not Docker Desktop — see [Supported platforms](#supported-platforms) above. Then choose a stack directory *inside the VM*.
 
 ```bash
 # Replace <stack-dir> with your chosen path, e.g. /opt/stacks/findajob-<you> or ~/docker/findajob-<you>

--- a/ops/entrypoint.sh
+++ b/ops/entrypoint.sh
@@ -57,6 +57,27 @@ mkdir -p \
     "$JSP_BASE/candidate_context" \
     "$JSP_BASE/.backups"
 
+# --- 2.5. Warn if the data dir lives on a non-native filesystem (#625) ----
+# Docker Desktop (macOS / Windows) bind-mounts host paths via gRPC-FUSE,
+# VirtioFS, or 9p, which have known SQLite-WAL incompatibilities that can
+# corrupt pipeline.db mid-write. Native Linux mounts (ext4 / xfs / btrfs /
+# zfs / overlay / tmpfs) are the supported configuration. Warn but do not
+# abort — a malformed-DB at runtime is recoverable; refusing to start is not.
+if FS_TYPE="$(stat -f -c %T "$JSP_BASE/data" 2>/dev/null)"; then
+    case "$FS_TYPE" in
+        fuseblk|fuse.*|virtiofs|9p|drvfs)
+            cat >&2 <<EOF
+WARNING (#625): $JSP_BASE/data is on filesystem type '$FS_TYPE'.
+This usually means Docker Desktop on macOS or Windows, which is NOT a
+supported platform for findajob. SQLite WAL mode interacts badly with
+Docker Desktop's bind-mount layer and can corrupt pipeline.db mid-write.
+See docs/getting-started/install-docker.md (Supported platforms).
+Run findajob on a Linux Docker host.
+EOF
+            ;;
+    esac
+fi
+
 # --- 3. Seed bundled tracked config into $JSP_BASE/config -----------------
 # Copy contents (not the directory) so tracked files land alongside any
 # operator-personal files that already exist.


### PR DESCRIPTION
## Summary

- External user @NeverNathaniel reported `SQLITE_CORRUPT` mid-batch in `triage.py` on macOS Docker Desktop (#625).
- Root cause: Docker Desktop bind-mounts via gRPC-FUSE / VirtioFS, which has known SQLite-WAL incompatibilities. No corruption observed on any supported Linux-on-Linux platform.
- Decision: macOS / Windows Docker Desktop is **not a supported platform**. Document it + emit a startup warning.

## Changes

- `ops/entrypoint.sh`: new step 2.5 calls `stat -f -c %T "$JSP_BASE/data"` and emits a one-paragraph stderr warning when the filesystem type matches `fuseblk` / `fuse.*` / `virtiofs` / `9p` / `drvfs`. Warns but does NOT abort — a malformed-DB at runtime is recoverable; refusing to start is not.
- `docs/getting-started/install-docker.md`: new "Supported platforms" section near the top; existing macOS mention in §1 reworded to point at the new note.

Closes #625.

## Test plan

- [x] Verified `case` statement matches `fuseblk` / `fuse.grpcfuse` / `fuse.virtiofs` / `virtiofs` / `9p` / `drvfs` and stays silent on `ext2/ext3` / `xfs` / `btrfs` / `overlayfs` / `tmpfs`.
- [x] Verified warning stays silent on the dev VM (tmpfs / ext4 equivalents).
- [ ] After merge: confirm the warning does not fire on any supported tester stack post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)