### PR TITLE
fix(jobs_api14): #679 — distinct jobsapi_403 log event with body excerpt + RapidAPI headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+- **#679 fix(jobs_api14): distinct `jobsapi_403` log event with response body excerpt + RapidAPI headers.** Pre-#679 the `_call_with_retry` path treated 403 the same as every other non-OK status — `raise_for_status()` raised `HTTPError`, the generic `except requests.RequestException` caught it, and `log_event("jobsapi_error", ..., error=str(e))` logged only the URL+status string from `requests.HTTPError`. The actual 403 response body (which carries the RapidAPI failure mode — `"You are not subscribed to this API."`, `"You have exceeded the quota for this API."`, etc.) was discarded before reaching the log. Surfaced during the #648 Fly deploy: 128/128 fetch attempts 403'd with no diagnostic signal beyond "Forbidden for url:". This fix adds a 403-specific branch in `_call_with_retry` that logs `jobsapi_403` carrying `status`, `body_excerpt` (first 500 chars of `response.text`), and four RapidAPI headers (`x-ratelimit-requests-remaining`, `x-ratelimit-requests-limit`, `retry-after`, `x-rapidapi-region`). The generic `jobsapi_error` path is unchanged for non-403 errors. `docs/troubleshooting.md` gains a sentence under "No new jobs appearing on the Dashboard" explaining the `"not subscribed"` body case and pointing operators at <https://rapidapi.com> to subscribe the API on the key's account. `live_test` (onboarding spot-check) is intentionally not modified — its 401/403 path already returns an `auth` bucket; the fetch-time signal is what was missing. **No `migration-required`** — purely additive observability + docs. Closes #679.
+
 ## [0.25.1] — 2026-05-15
 
 ### Fixed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,7 +58,7 @@ jq -c 'select(.event == "pipeline_complete")' state/logs/pipeline.jsonl | tail -
 
 **Events present but no new jobs?** A source is silent. The health check's "silent feed failure" alert tells you which one. Causes by source:
 
-- **RapidAPI (`jobsapi`)**: key missing, quota exhausted, or `config/jsearch_queries.txt` empty/malformed.
+- **RapidAPI (`jobsapi`)**: key missing, quota exhausted, `config/jsearch_queries.txt` empty/malformed, or the key's account isn't subscribed to the API. A `jobsapi_403` event with `body_excerpt` containing `"not subscribed"` means the RapidAPI account that owns the key has no active subscription on the API listing. Fix: log into <https://rapidapi.com>, open the API listing (e.g. <https://rapidapi.com/Pat92/api/jobs-api14>), click **Subscribe to Test** → **BASIC** (free).
 - **Gmail**: OAuth token expired → re-authenticate inside the container: `docker compose exec scheduler /app/scripts/gmail_auth.py`. OAuth client must be "Desktop app" type, not TV/limited-input.
 - **Greenhouse**: `config/feed_urls.txt` slug 404s when the company removes a careers page — prune dead slugs.
 

--- a/src/findajob/fetchers/adapters/jobs_api14.py
+++ b/src/findajob/fetchers/adapters/jobs_api14.py
@@ -221,6 +221,19 @@ class JobsApi14Adapter:
                 log_event("rapidapi_rate_limit", source=self.name, query=query, wait=wait)
                 time.sleep(wait)
                 response = requests.get(self._ENDPOINT, headers=headers, params=params, timeout=30)
+            if response.status_code == 403:
+                log_event(
+                    "jobsapi_403",
+                    source="linkedin",
+                    query=query,
+                    status=403,
+                    body_excerpt=response.text[:500],
+                    x_ratelimit_requests_remaining=response.headers.get("x-ratelimit-requests-remaining"),
+                    x_ratelimit_requests_limit=response.headers.get("x-ratelimit-requests-limit"),
+                    retry_after=response.headers.get("retry-after"),
+                    x_rapidapi_region=response.headers.get("x-rapidapi-region"),
+                )
+                return None
             response.raise_for_status()
             data = response.json()
             if data.get("hasError"):

--- a/tests/test_jobs_api14_adapter.py
+++ b/tests/test_jobs_api14_adapter.py
@@ -448,6 +448,39 @@ def test_fetch_logs_pages_counter(monkeypatch: pytest.MonkeyPatch) -> None:
     assert kwargs["count"] == 2
 
 
+def test_call_with_retry_logs_jobsapi_403_with_body_excerpt_and_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JOBS_API14_KEY", "test-key")
+    fake_403 = MagicMock(status_code=403)
+    fake_403.text = '{"message":"You are not subscribed to this API."}'
+    fake_403.headers = {
+        "x-ratelimit-requests-remaining": "0",
+        "x-ratelimit-requests-limit": "500",
+        "x-rapidapi-region": "AWS - us-east-1",
+    }
+
+    adapter = JobsApi14Adapter()
+    with (
+        patch("findajob.fetchers.adapters.jobs_api14.requests.get", return_value=fake_403),
+        patch("findajob.fetchers.adapters.jobs_api14.log_event") as mock_log,
+    ):
+        result = adapter._call_with_retry(
+            headers={"x-rapidapi-key": "test-key", "x-rapidapi-host": "jobs-api14.p.rapidapi.com"},
+            params={"query": "engineer"},
+            query="engineer",
+        )
+
+    assert result is None
+    log_calls = {c.args[0]: c for c in mock_log.call_args_list}
+    assert "jobsapi_403" in log_calls, f"expected jobsapi_403 event, got: {list(log_calls)}"
+    assert "jobsapi_error" not in log_calls
+    kwargs = log_calls["jobsapi_403"].kwargs
+    assert kwargs["status"] == 403
+    assert "not subscribed" in kwargs["body_excerpt"]
+    assert kwargs["x_ratelimit_requests_remaining"] == "0"
+    assert kwargs["x_ratelimit_requests_limit"] == "500"
+    assert kwargs["x_rapidapi_region"] == "AWS - us-east-1"
+
+
 def test_live_test_does_not_paginate(monkeypatch: pytest.MonkeyPatch) -> None:
     """live_test stays single-page even when JOBS_API14_MAX_PAGES is raised.
 


### PR DESCRIPTION
## Summary

- `_call_with_retry` in `src/findajob/fetchers/adapters/jobs_api14.py` now logs a distinct `jobsapi_403` event carrying `status`, `body_excerpt` (first 500 chars of `response.text`), and four RapidAPI headers (`x-ratelimit-requests-remaining`, `x-ratelimit-requests-limit`, `retry-after`, `x-rapidapi-region`).
- Generic `jobsapi_error` path unchanged for non-403 errors.
- `docs/troubleshooting.md` gets a sentence under "No new jobs appearing on the Dashboard" explaining the `"not subscribed"` body case and pointing at rapidapi.com.
- Same-PR test asserts the new event fires with all fields on a 403 and that `jobsapi_error` does NOT fire.

## Why

#648 surfaced 128/128 jobs-api14 fetch attempts 403'ing from the Fly stack with no diagnostic signal beyond `"Forbidden for url:"`. The actual 403 response body — which carries the failure mode — was being discarded by `requests.HTTPError → except RequestException → log error=str(e)`. With this fix, a curl-equivalent payload reaches the log. Today's #679 investigation captured the body `"You are not subscribed to this API."` outside the code path (via curl); future 403s of any RapidAPI flavor (quota, region, IP block, subscription, wrong-key-on-different-account) become greppable instead of indistinguishable from any other RequestException.

`live_test` (onboarding spot-check) is intentionally not modified — its 401/403 path already returns an `auth` bucket. The fetch-time signal is what was missing.

## Test plan

- [x] `pytest tests/test_jobs_api14_adapter.py -v` — 33 passed
- [x] `ruff check` + `ruff format --check` clean on touched files
- [x] Captured a real 403 response body + headers via curl during the #679 investigation (matches the shape the new event records); the curl bypassed the Python code path, but the response contract is confirmed
- [ ] First post-deploy 403 emits `log_event("jobsapi_403", ...)` to `pipeline.jsonl` — fires automatically on the next deployed-image triage cycle that encounters a 403; no manual trigger needed
- [ ] Follow-up filed: #684 (`.env` bash-sourcing fragility surfaced during investigation). `live_test` 401/403 path losing diagnostic signal is the other pre-existing gap surfaced today — TBD whether worth filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
