### PR TITLE
refactor(actions): #707 — commit=False kwarg for atomic reattribute

### DIFF
--- a/src/findajob/actions.py
+++ b/src/findajob/actions.py
@@ -5,9 +5,13 @@ All state transitions that move a job between stages, move its prep folder,
 or drop marker files live here. Invoked from `scripts/watchdog.py` and from
 the web POST handlers in `findajob.web.routes.board_actions`.
 
-Every function takes an open `sqlite3.Connection` as its first argument and
-commits itself. Functions return a `bool` indicating whether a folder was
-moved (or, for `reset_prep_to_scored`, whether the reset actually happened).
+Every function takes an open `sqlite3.Connection` as its first argument and,
+by default, commits itself. The ``un_*`` helpers and ``handle_not_selected``
+accept a kwarg-only ``commit=False`` so callers can compose multiple writes
+into one transaction (used by ``reattribute_from_archive`` for atomic
+source-and-target updates). Functions return a `bool` indicating whether a
+folder was moved (or, for `reset_prep_to_scored`, whether the reset actually
+happened).
 """
 
 import glob
@@ -115,6 +119,7 @@ def handle_not_selected(
     reason: str,
     *,
     changed_by: str | None = None,
+    commit: bool = True,
 ) -> bool:
     """Company rejected the application. Sets stage=not_selected, drops a marker file.
 
@@ -128,6 +133,11 @@ def handle_not_selected(
             ``'gmail_rejection_detector'`` from the rejections-review confirm
             endpoint per spec §4.5.2 so the audit trail distinguishes
             operator-confirmed Gmail-detected rejections from manual flips.
+        commit: When False, skip the internal ``conn.commit()`` and propagate
+            ``commit=False`` to the inner ``write_audit`` calls so the caller
+            can compose this with another helper inside a single transaction
+            (used by ``reattribute_from_archive`` for atomic source-and-target
+            updates). Default True preserves existing single-call behavior.
     """
     now = datetime.now(UTC).isoformat()
     old_stage = job["stage"]
@@ -145,9 +155,10 @@ def handle_not_selected(
         open(os.path.join(folder, f"NOT_SELECTED_{safe_reason}_{date_str}.txt"), "w").close()
         log_event("marker_added_not_selected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
 
-    conn.commit()
-    write_audit(conn, job["id"], "stage", old_stage, "not_selected", changed_by=changed_by)
-    write_audit(conn, job["id"], "reject_reason", "", reason, changed_by=changed_by)
+    if commit:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", old_stage, "not_selected", changed_by=changed_by, commit=commit)
+    write_audit(conn, job["id"], "reject_reason", "", reason, changed_by=changed_by, commit=commit)
     log_event("job_not_selected", job_id=job["id"], company=job["company"], title=job["title"], reason=reason)
     return False
 
@@ -297,12 +308,24 @@ def _apply_overwrite_fields(set_parts: list[str], params: list, overwrite_fields
             params.append(overwrite_fields[key])
 
 
-def un_reject_job(conn: sqlite3.Connection, job: Any, overwrite_fields: dict[str, str]) -> None:
+def un_reject_job(
+    conn: sqlite3.Connection,
+    job: Any,
+    overwrite_fields: dict[str, str],
+    *,
+    commit: bool = True,
+) -> None:
     """Reverse a user rejection: restore to scored, delete feedback_log rows.
 
     Clears reject_reason, sets relevance_score=8, overwrites non-blank
     submitted fields, moves prep folder from _rejected/ back to companies/.
     Deletes feedback_log rows so the scorer's feedback loop stays clean.
+
+    Args:
+        commit: When False, skip the internal ``conn.commit()`` and propagate
+            ``commit=False`` to the inner ``write_audit`` calls so the caller
+            can compose this with another helper inside a single transaction.
+            Default True preserves existing single-call behavior.
     """
     now = datetime.now(UTC).isoformat()
 
@@ -321,13 +344,14 @@ def un_reject_job(conn: sqlite3.Connection, job: Any, overwrite_fields: dict[str
         conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
         log_event("folder_moved_from_rejected", job_id=job["id"], folder=os.path.basename(folder))
 
-    conn.commit()
-    write_audit(conn, job["id"], "stage", "rejected", "scored")
-    write_audit(conn, job["id"], "reject_reason", job["reject_reason"] or "", "")
+    if commit:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", "rejected", "scored", commit=commit)
+    write_audit(conn, job["id"], "reject_reason", job["reject_reason"] or "", "", commit=commit)
     log_event("job_un_rejected", job_id=job["id"], company=job["company"], title=job["title"])
 
 
-def un_not_selected_job(conn: sqlite3.Connection, job: Any) -> str:
+def un_not_selected_job(conn: sqlite3.Connection, job: Any, *, commit: bool = True) -> str:
     """Reverse a company-not-selected stage: restore the prior stage from
     audit_log, clear the reject_reason, delete all NOT_SELECTED_*.txt marker
     files from the job's folder.
@@ -340,6 +364,13 @@ def un_not_selected_job(conn: sqlite3.Connection, job: Any) -> str:
     Unlike un_reject_job, there is no feedback_log row to delete (company
     rejections never wrote one) and no folder move (handle_not_selected
     keeps the folder in companies/_applied/).
+
+    Args:
+        commit: When False, skip the internal ``conn.commit()`` and propagate
+            ``commit=False`` to the inner ``write_audit`` calls so the caller
+            can compose this with another helper inside a single transaction
+            (used by ``reattribute_from_archive`` for atomic source-and-target
+            updates). Default True preserves existing single-call behavior.
     """
     now = datetime.now(UTC).isoformat()
 
@@ -367,9 +398,10 @@ def un_not_selected_job(conn: sqlite3.Connection, job: Any) -> str:
                 marker=os.path.basename(marker_path),
             )
 
-    conn.commit()
-    write_audit(conn, job["id"], "stage", "not_selected", restored_stage, changed_by="user")
-    write_audit(conn, job["id"], "reject_reason", job["reject_reason"] or "", "", changed_by="user")
+    if commit:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", "not_selected", restored_stage, changed_by="user", commit=commit)
+    write_audit(conn, job["id"], "reject_reason", job["reject_reason"] or "", "", changed_by="user", commit=commit)
     log_event(
         "job_un_not_selected",
         job_id=job["id"],
@@ -380,7 +412,7 @@ def un_not_selected_job(conn: sqlite3.Connection, job: Any) -> str:
     return restored_stage
 
 
-def un_withdraw_job(conn: sqlite3.Connection, job: Any) -> str:
+def un_withdraw_job(conn: sqlite3.Connection, job: Any, *, commit: bool = True) -> str:
     """Reverse a withdraw: restore the prior stage from audit_log
     (typically applied/interview/offer).
 
@@ -393,6 +425,12 @@ def un_withdraw_job(conn: sqlite3.Connection, job: Any) -> str:
     never wrote one) and no folder to touch (withdraw doesn't move folders).
     Unlike un_reject_job, no feedback_log row exists (withdraw doesn't
     write to feedback_log). Pure stage restoration.
+
+    Args:
+        commit: When False, skip the internal ``conn.commit()`` and propagate
+            ``commit=False`` to the inner ``write_audit`` call so the caller
+            can compose this with another helper inside a single transaction.
+            Default True preserves existing single-call behavior.
     """
     now = datetime.now(UTC).isoformat()
 
@@ -408,8 +446,9 @@ def un_withdraw_job(conn: sqlite3.Connection, job: Any) -> str:
         "UPDATE jobs SET stage=?, updated_at=? WHERE id=?",
         (restored_stage, now, job["id"]),
     )
-    conn.commit()
-    write_audit(conn, job["id"], "stage", "withdrawn", restored_stage, changed_by="user")
+    if commit:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", "withdrawn", restored_stage, changed_by="user", commit=commit)
     log_event(
         "job_un_withdrawn", job_id=job["id"], company=job["company"], title=job["title"], restored_stage=restored_stage
     )

--- a/src/findajob/audit.py
+++ b/src/findajob/audit.py
@@ -42,6 +42,7 @@ def write_audit(
     new_value: object,
     *,
     changed_by: str | None = None,
+    commit: bool = True,
 ) -> None:
     if changed_by is not None:
         conn.execute(
@@ -59,4 +60,5 @@ def write_audit(
             "INSERT INTO audit_log (job_id, field_changed, old_value, new_value) VALUES (?, ?, ?, ?)",
             (job_id, field_changed, str(old_value) if old_value is not None else None, str(new_value)),
         )
-    conn.commit()
+    if commit:
+        conn.commit()

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -1023,6 +1023,11 @@ def reattribute_from_archive(
     stage, deletes marker files), then handle_not_selected on target with
     changed_by='archive_reattribute'.
 
+    Both helpers run with ``commit=False`` and a single trailing
+    ``db.commit()`` so source-restore + target-mark land atomically — if
+    either raises mid-call, neither is persisted and the operator sees the
+    error rather than a half-applied reattribution.
+
     Atomic: 404 on unknown source or target; 409 if source stage !=
     'not_selected' or if target_fingerprint missing/blank.
     """
@@ -1048,7 +1053,12 @@ def reattribute_from_archive(
 
     final_reason = (reason or "").strip() or "Reattributed"
 
-    un_not_selected_job(db, source)
-    handle_not_selected(db, target, final_reason, changed_by="archive_reattribute")
+    try:
+        un_not_selected_job(db, source, commit=False)
+        handle_not_selected(db, target, final_reason, changed_by="archive_reattribute", commit=False)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
 
     return HTMLResponse("")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -801,3 +801,103 @@ def test_handle_rejection_skips_feedback_log_for_synthetic(tmp_path, monkeypatch
     real_after = conn.execute("SELECT stage FROM jobs WHERE id=?", (real_id,)).fetchone()
     assert syn_after["stage"] == "rejected"
     assert real_after["stage"] == "rejected"
+
+
+# ── commit=False atomic-composition kwarg (#707) ────────────────────────────
+
+
+class TestActionsCommitFalse:
+    """Every helper that grew a ``commit=True`` kwarg in #707 must, when
+    called with ``commit=False``, leave its UPDATEs and audit INSERTs inside
+    an open transaction so the caller can compose multiple helpers and commit
+    (or rollback) atomically. The contract is verified by issuing
+    ``conn.rollback()`` after the call and asserting every write disappeared.
+    """
+
+    def test_un_reject_job_commit_false_is_rollback_safe(self, db, tmp_path):
+        folder = tmp_path / "companies" / "_rejected" / "Acme_Ops_commit_false"
+        folder.mkdir(parents=True)
+        job = insert_job(db, stage="rejected", folder=str(folder), score=2)
+        db.execute("UPDATE jobs SET reject_reason='Wrong Level' WHERE id=?", (job["id"],))
+        db.execute(
+            "INSERT INTO feedback_log (job_id, title, company, relevance_score, reject_reason, jd_excerpt) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (job["id"], job["title"], job["company"], 2, "Wrong Level", ""),
+        )
+        db.commit()
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        actions.un_reject_job(db, job, overwrite_fields={}, commit=False)
+        # Pre-rollback: caller sees the staged change
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "scored"
+
+        db.rollback()
+
+        # Post-rollback: every write reversed — UPDATE, feedback_log DELETE, audit INSERTs
+        row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "rejected"
+        assert row["reject_reason"] == "Wrong Level"
+        fb_count = db.execute("SELECT COUNT(*) FROM feedback_log WHERE job_id=?", (job["id"],)).fetchone()[0]
+        assert fb_count == 1, "DELETE on feedback_log must roll back too"
+        audits = db.execute("SELECT * FROM audit_log WHERE job_id=?", (job["id"],)).fetchall()
+        assert len(audits) == 0
+
+    def test_un_not_selected_job_commit_false_is_rollback_safe(self, db):
+        job = insert_job(db, stage="not_selected")
+        db.execute(
+            "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+            "VALUES (?, 'stage', 'applied', 'not_selected', datetime('now'), 'user')",
+            (job["id"],),
+        )
+        db.execute("UPDATE jobs SET reject_reason='Company passed' WHERE id=?", (job["id"],))
+        db.commit()
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        seed_audit_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
+
+        actions.un_not_selected_job(db, job, commit=False)
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "applied"
+
+        db.rollback()
+
+        row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "not_selected"
+        assert row["reject_reason"] == "Company passed"
+        # Only the seed audit row survives — no new audit rows from the rolled-back call
+        post_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
+        assert post_count == seed_audit_count
+
+    def test_un_withdraw_job_commit_false_is_rollback_safe(self, db):
+        job = insert_job(db, stage="withdrawn")
+        db.execute(
+            "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+            "VALUES (?, 'stage', 'applied', 'withdrawn', datetime('now'), 'user')",
+            (job["id"],),
+        )
+        db.commit()
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        seed_audit_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
+
+        actions.un_withdraw_job(db, job, commit=False)
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "applied"
+
+        db.rollback()
+
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "withdrawn"
+        post_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
+        assert post_count == seed_audit_count
+
+    def test_handle_not_selected_commit_false_is_rollback_safe(self, db, tmp_path):
+        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_commit_false"
+        folder.mkdir(parents=True)
+        job = insert_job(db, stage="applied", folder=str(folder))
+
+        actions.handle_not_selected(db, job, "Too Senior", commit=False)
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "not_selected"
+
+        db.rollback()
+
+        row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "applied"
+        assert row["reject_reason"] == ""
+        audits = db.execute("SELECT * FROM audit_log WHERE job_id=?", (job["id"],)).fetchall()
+        assert len(audits) == 0

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,69 @@
+"""Unit tests for findajob.audit.write_audit.
+
+write_audit is the only audit-log writer; every action helper in
+findajob.actions calls it. The commit=False kwarg landed in #707 so callers
+that need to compose multiple writes into one transaction (e.g.,
+reattribute_from_archive) can run write_audit + UPDATE in the same atomic
+block.
+"""
+
+import sqlite3
+
+import pytest
+
+from findajob.audit import write_audit
+
+SCHEMA = """
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    field_changed TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_at TEXT DEFAULT (datetime('now')),
+    changed_by TEXT DEFAULT 'system'
+);
+"""
+
+
+@pytest.fixture()
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    yield conn
+    conn.close()
+
+
+class TestWriteAudit:
+    def test_commit_true_default_persists_row(self, db):
+        write_audit(db, "job_abc", "stage", "scored", "applied")
+
+        # A rollback after the call must NOT undo the row — the default commit landed it.
+        db.rollback()
+        rows = db.execute("SELECT * FROM audit_log WHERE job_id='job_abc'").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["field_changed"] == "stage"
+        assert rows[0]["old_value"] == "scored"
+        assert rows[0]["new_value"] == "applied"
+
+    def test_commit_false_leaves_row_in_open_transaction(self, db):
+        """commit=False writes the INSERT to the connection but skips conn.commit().
+        The caller is then free to compose more writes and commit (or rollback) atomically."""
+        write_audit(db, "job_abc", "stage", "scored", "applied", commit=False)
+
+        # Same connection sees the row (open transaction)
+        rows = db.execute("SELECT * FROM audit_log WHERE job_id='job_abc'").fetchall()
+        assert len(rows) == 1
+
+        # Caller-issued rollback discards it
+        db.rollback()
+        rows = db.execute("SELECT * FROM audit_log WHERE job_id='job_abc'").fetchall()
+        assert len(rows) == 0
+
+    def test_commit_false_with_changed_by(self, db):
+        """commit=False composes with the changed_by kwarg (both paths through the if/else)."""
+        write_audit(db, "job_abc", "stage", "applied", "rejected", changed_by="user", commit=False)
+        db.rollback()
+        rows = db.execute("SELECT * FROM audit_log WHERE job_id='job_abc'").fetchall()
+        assert len(rows) == 0

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -2007,6 +2007,66 @@ class TestReattributeFromArchive:
         )
         assert response.status_code == 409
 
+    def test_handle_not_selected_failure_rolls_back_source_restore(self, client: TestClient, monkeypatch):
+        """#707 — both helpers run with commit=False inside a single
+        transaction; if handle_not_selected raises mid-call, db.rollback() in
+        the route's except branch undoes the source un-not-selected too. The
+        operator sees the error and can retry, rather than discovering a
+        half-applied reattribution with source restored and target unchanged.
+        """
+        from findajob.web.routes import board_actions
+
+        conn = sqlite3.connect(client._db_path)
+        src_id = _insert_job(conn, fingerprint="fp_src_rollback", stage="not_selected")
+        conn.execute("UPDATE jobs SET reject_reason='Company passed' WHERE id=?", (src_id,))
+        conn.execute(
+            "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+            "VALUES (?, 'stage', 'applied', 'not_selected', datetime('now'), 'user')",
+            (src_id,),
+        )
+        _insert_job(conn, fingerprint="fp_tgt_rollback", stage="applied")
+        conn.commit()
+        conn.close()
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("simulated handle_not_selected failure")
+
+        monkeypatch.setattr(board_actions, "handle_not_selected", _raise)
+
+        # TestClient with default raise_server_exceptions=True re-raises the
+        # unhandled RuntimeError from the route.
+        with pytest.raises(RuntimeError, match="simulated handle_not_selected failure"):
+            client.post(
+                "/board/jobs/fp_src_rollback/reattribute-from-archive",
+                data={"target_fingerprint": "fp_tgt_rollback", "reason": "Mis-matched"},
+            )
+
+        # Source unchanged: still not_selected with original reject_reason
+        conn = sqlite3.connect(client._db_path)
+        src_row = conn.execute("SELECT stage, reject_reason FROM jobs WHERE fingerprint='fp_src_rollback'").fetchone()
+        assert src_row[0] == "not_selected"
+        assert src_row[1] == "Company passed"
+
+        # Target unchanged: still applied
+        tgt_row = conn.execute("SELECT stage FROM jobs WHERE fingerprint='fp_tgt_rollback'").fetchone()
+        assert tgt_row[0] == "applied"
+
+        # Only the seed audit row exists on the source — no transition rows landed
+        src_audits = conn.execute(
+            "SELECT al.new_value FROM audit_log al JOIN jobs j ON j.id = al.job_id "
+            "WHERE j.fingerprint='fp_src_rollback' ORDER BY al.id"
+        ).fetchall()
+        # Seed row is the only entry; transition rows from the rolled-back call don't appear
+        assert src_audits == [("not_selected",)]
+
+        # No audit rows on the target either
+        tgt_audits = conn.execute(
+            "SELECT al.new_value FROM audit_log al JOIN jobs j ON j.id = al.job_id "
+            "WHERE j.fingerprint='fp_tgt_rollback'"
+        ).fetchall()
+        assert tgt_audits == []
+        conn.close()
+
 
 # ── /board/jobs/search handler ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds kwarg-only `commit: bool = True` to `findajob.audit.write_audit`, the three un-* helpers (`un_reject_job`, `un_not_selected_job`, `un_withdraw_job`), and `handle_not_selected`. Defaults preserve every existing caller's behavior.
- Each helper propagates `commit=commit` to its internal `write_audit` calls and skips its own `conn.commit()` when False, so caller-driven composition is fully atomic at the DB layer.
- `reattribute_from_archive` route wraps the two helper calls in try/except/rollback with a single trailing `db.commit()`. Closes the half-applied-reattribution gap PR #706 documented as a known limitation.

## Why the scope grew past the issue's original wording

The issue body originally scoped the refactor to the three un-* helpers only. Caller-inventory dispatch (Sonnet) surfaced that **`write_audit` itself commits internally** (`src/findajob/audit.py:62`), so the helpers' explicit `conn.commit()` calls aren't the real transaction boundary. The narrow refactor would have shifted the atomicity bug from "between two helpers" to "between an UPDATE and its audit row" — same shape, slightly worse because the audit log starts disagreeing with the DB. Scope expanded to also include `write_audit` and `handle_not_selected`. Other handle-* siblings (`handle_rejection`, `handle_waitlist`, `handle_reactivate`, `promote_to_scored`, `reset_prep_to_scored`) keep `commit=True` defaults — no current caller chains them with un-* helpers. The issue body was updated to match before any code landed.

## Known caveat — filesystem side effects not atomic

The helpers do filesystem work (move folders, write `NOT_SELECTED_*.txt` marker files) before the commit decision. `db.rollback()` doesn't undo these. For reattribute specifically: if `handle_not_selected` raises after `un_not_selected_job` already deleted the source's marker files, the source DB row reverts to `not_selected` cleanly but the marker files stay gone.

Worth filing as a follow-up. The DB is the authoritative state (markers are forensic-only, no production code consumes them as signal), so the gap is recoverable but real.

## Test plan

- [x] `tests/test_audit.py` (new) — 3 cases for `write_audit(commit=False)`
- [x] `tests/test_actions.py::TestActionsCommitFalse` — 4 cases, one per helper: call with `commit=False`, issue `conn.rollback()`, assert every DB write (UPDATE, DELETE, audit INSERT) reverted
- [x] `tests/test_board_actions.py::TestReattributeFromArchive::test_handle_not_selected_failure_rolls_back_source_restore` — monkeypatches `board_actions.handle_not_selected` to raise; asserts source row, target row, and audit_log all unchanged from pre-call state
- [x] Local gate: `ruff check`, `ruff format --check`, `mypy src/findajob/`, full `pytest` on affected suites (`test_audit.py` + `test_actions.py` + `test_actions_resurface.py` + `test_board_actions.py` = 213 passing; + transitive suites 86 passing)
- [ ] Browser-tested: no — internal-API refactor with no operator-observable surface change; default `commit=True` preserves every existing route's behavior. Rollback test exercises the new code path end-to-end through the FastAPI TestClient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)