### PR TITLE
feat(web): #702 — Waitlist from Review + Flag-for-Prep from Waitlist (#662 F8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ responds in the same request — no poll cycle, no mirror table.
 | Flag for Prep | `POST /board/jobs/{fp}/prep` | Dashboard dropdown |
 | Regenerate | `POST /board/jobs/{fp}/regenerate` | Dashboard dropdown — gated by `GET /board/jobs/{fp}/regenerate/confirm` modal (#700); Cancel restores cell via `GET /board/jobs/{fp}/regenerate/cell` |
 | Applied | `POST /board/jobs/{fp}/apply` | Dashboard dropdown |
-| Waitlist | `POST /board/jobs/{fp}/waitlist` | Dashboard dropdown |
+| Waitlist | `POST /board/jobs/{fp}/waitlist` | Dashboard dropdown + Review tab button (#702) |
 | Reject (w/ reason) | `POST /board/jobs/{fp}/reject` | Dashboard / Review / Waitlist reject cell |
 | Interviewing | `POST /board/jobs/{fp}/interview` | Applied dropdown |
 | Offer | `POST /board/jobs/{fp}/offer` | Applied dropdown |
@@ -190,6 +190,7 @@ responds in the same request — no poll cycle, no mirror table.
 | Not Selected (w/ reason) | `POST /board/jobs/{fp}/not-selected` | Applied dropdown + reject cell |
 | Promote | `POST /board/jobs/{fp}/promote` | Review button |
 | Reactivate | `POST /board/jobs/{fp}/reactivate` | Waitlist button |
+| Reactivate and prep | `POST /board/jobs/{fp}/reactivate-and-prep` | Waitlist tab "Flag for Prep" button (#702). Same spend-ceiling + queue-cap gates as `/prep`; writes two audit rows for traceability. |
 | Change reject reason | `POST /board/jobs/{fp}/change-reject-reason` | Rejected tab inline dropdown (#697) |
 | Un-not-selected | `POST /board/jobs/{fp}/un-not-selected` | Not Selected tab button (#698) |
 | Change not-selected reason | `POST /board/jobs/{fp}/change-not-selected-reason` | Not Selected tab inline dropdown (#698) |

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -571,6 +571,74 @@ def reactivate(
     return HTMLResponse("")
 
 
+@router.post("/board/jobs/{fingerprint}/reactivate-and-prep", response_class=HTMLResponse)
+def reactivate_and_prep(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Collapse the two-step waitlist→reactivate→prep flow (#702 G9).
+
+    Order of gates: 404 → idempotent-success-on-already-advanced → 409 →
+    402 (spend ceiling) → 429 (queue cap). Mutations only run after all
+    gates pass, so a tripped gate leaves the row at stage='waitlisted'.
+
+    Writes two audit rows for traceability — handle_reactivate writes
+    (waitlisted → scored | materials_drafted), then this route writes
+    (* → prep_in_progress).
+    """
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    # Idempotency: match /prep's silent-success on already-in-flight rows so
+    # a fast double-click doesn't surface a 409.
+    if job["stage"] in ("prep_in_progress", "materials_drafted"):
+        return HTMLResponse("")
+
+    if job["stage"] != "waitlisted":
+        raise HTTPException(status_code=409, detail="Job is not waitlisted")
+
+    refusal = check_launch_gate(db)
+    if refusal is not None:
+        raise HTTPException(
+            status_code=402,
+            detail=(
+                f"Monthly LLM spend ceiling reached: ${refusal.current_sum_usd:.2f} / "
+                f"${refusal.ceiling_usd:.2f}. Raise or disable the ceiling in /settings/."
+            ),
+        )
+
+    if _prep_in_flight(db) >= MAX_CONCURRENT_PREPS:
+        return _prep_queue_full_response()
+
+    handle_reactivate(db, job)
+
+    # Re-read intermediate stage so the audit row's old_value matches whatever
+    # handle_reactivate landed on (scored if no folder, materials_drafted if folder).
+    intermediate_stage = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()[0]
+
+    now = datetime.now(UTC).isoformat()
+    db.execute(
+        "UPDATE jobs SET stage='prep_in_progress', apply_flag=1, stage_updated=?, updated_at=? WHERE id=?",
+        (now, now, job["id"]),
+    )
+    db.commit()
+    write_audit(db, job["id"], "stage", intermediate_stage, "prep_in_progress")
+    log_event(
+        "web_reactivate_and_prep_dispatched",
+        job_id=job["id"],
+        company=job["company"],
+        title=job["title"],
+    )
+
+    # _launch_prep_subprocess wants the full job row with url
+    full_job = db.execute("SELECT id, title, company, url, stage FROM jobs WHERE id=?", (job["id"],)).fetchone()
+    _launch_prep_subprocess(db, full_job)
+
+    return HTMLResponse("")
+
+
 _PROMOTABLE_STAGES = ("manual_review", "scored")
 
 

--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -65,16 +65,32 @@
     </select>
     {% endif %}
   {% elif tab == 'review' %}
-    <button type="button"
-            class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
-            hx-post="/board/jobs/{{ fp }}/promote"
-            hx-target="closest tr"
-            hx-swap="outerHTML">Promote</button>
+    <div class="flex gap-1">
+      <button type="button"
+              class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+              hx-post="/board/jobs/{{ fp }}/promote"
+              hx-target="closest tr"
+              hx-swap="outerHTML">Promote</button>
+      <button type="button"
+              class="rounded bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-200"
+              hx-post="/board/jobs/{{ fp }}/waitlist"
+              hx-target="closest tr"
+              hx-swap="outerHTML"
+              title="Defer to Waitlist without promoting">Waitlist</button>
+    </div>
   {% elif tab == 'waitlist' %}
-    <button type="button"
-            class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
-            hx-post="/board/jobs/{{ fp }}/reactivate"
-            hx-target="closest tr"
-            hx-swap="outerHTML">Reactivate</button>
+    <div class="flex gap-1">
+      <button type="button"
+              class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+              hx-post="/board/jobs/{{ fp }}/reactivate"
+              hx-target="closest tr"
+              hx-swap="outerHTML">Reactivate</button>
+      <button type="button"
+              class="rounded bg-emerald-600 px-2 py-1 text-xs font-medium text-white hover:bg-emerald-500"
+              hx-post="/board/jobs/{{ fp }}/reactivate-and-prep"
+              hx-target="closest tr"
+              hx-swap="outerHTML"
+              title="Reactivate and start prep in one step">Flag for Prep</button>
+    </div>
   {% endif %}
 </td>

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -2316,3 +2316,183 @@ class TestRegenerateCell:
     def test_404_unknown_fingerprint(self, client: TestClient):
         response = client.get("/board/jobs/fp_nonexistent/regenerate/cell")
         assert response.status_code == 404
+# ── Review/Waitlist affordance buttons (#702 F8) ──────────────────────────
+
+
+class TestReviewTabRendersWaitlistButton:
+    def test_review_tab_shows_both_promote_and_waitlist_buttons(self, client: TestClient):
+        """Review tab status cell renders Waitlist alongside Promote (#702 G8 gap).
+        Today the only affordance was Promote; users with 'interesting-but-not-now'
+        manual_review rows had to promote-then-waitlist (two clicks)."""
+        response = client.get("/board/review")
+        assert response.status_code == 200
+        text = response.text
+
+        # The manual_review row from the fixture (fp_manual)
+        assert 'data-fingerprint="fp_manual"' in text
+
+        # Scope assertions to fp_manual's row so unrelated rows can't satisfy them
+        anchor = text.find('data-fingerprint="fp_manual"')
+        row_end = text.find("</tr>", anchor)
+        row = text[anchor:row_end]
+
+        assert "Promote" in row
+        assert "Waitlist" in row
+        assert 'hx-post="/board/jobs/fp_manual/promote"' in row
+        assert 'hx-post="/board/jobs/fp_manual/waitlist"' in row
+
+
+class TestWaitlistFromReview:
+    def test_manual_review_row_waitlists_via_existing_endpoint(self, client: TestClient):
+        """/waitlist already accepts any stage; the new Review-tab button just
+        wires a new caller. Verify the transition happens and audit row writes."""
+        response = client.post("/board/jobs/fp_manual/waitlist")
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_manual") == "waitlisted"
+
+        audit = _fetch_audit(client, "fp_manual")
+        assert any(a == ("stage", "manual_review", "waitlisted") for a in audit)
+
+
+class TestWaitlistTabRendersFlagForPrepButton:
+    def test_waitlist_tab_shows_both_reactivate_and_flag_for_prep(self, client: TestClient):
+        """Waitlist tab status cell renders Flag-for-Prep alongside Reactivate
+        (#702 G9 gap). Today operators had to reactivate-then-prep (two clicks)."""
+        response = client.get("/board/waitlist")
+        assert response.status_code == 200
+        text = response.text
+        assert 'data-fingerprint="fp_waitlisted"' in text
+
+        anchor = text.find('data-fingerprint="fp_waitlisted"')
+        row_end = text.find("</tr>", anchor)
+        row = text[anchor:row_end]
+
+        assert "Reactivate" in row
+        assert "Flag for Prep" in row
+        assert 'hx-post="/board/jobs/fp_waitlisted/reactivate"' in row
+        assert 'hx-post="/board/jobs/fp_waitlisted/reactivate-and-prep"' in row
+
+
+class TestReactivateAndPrep:
+    def test_happy_path_without_folder(self, client: TestClient, popen_calls):
+        """Waitlisted job with no prep folder: handle_reactivate flips waitlisted→scored,
+        then the route flips scored→prep_in_progress and spawns prep_application.py.
+        Two audit rows written for clean traceability."""
+        response = client.post("/board/jobs/fp_waitlisted/reactivate-and-prep")
+        assert response.status_code == 200
+        assert response.text == ""
+        assert _fetch_stage(client, "fp_waitlisted") == "prep_in_progress"
+
+        audit = _fetch_audit(client, "fp_waitlisted")
+        # Reactivate row + prep row, in order
+        assert ("stage", "waitlisted", "scored") in audit
+        assert ("stage", "scored", "prep_in_progress") in audit
+
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert len(prep_calls) == 1
+
+    def test_happy_path_with_folder(self, client: TestClient, popen_calls):
+        """Waitlisted job with a folder in _waitlisted/: handle_reactivate moves
+        the folder back to companies/ and flips to materials_drafted; route then
+        flips to prep_in_progress."""
+        wl_dir = client._tmp_path / "companies" / "_waitlisted"
+        wl_dir.mkdir(parents=True)
+        folder = wl_dir / "Acme_waitlist_prep"
+        folder.mkdir()
+        (folder / "resume.pdf").touch()
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "UPDATE jobs SET prep_folder_path=? WHERE fingerprint='fp_waitlisted'",
+            (str(folder),),
+        )
+        conn.commit()
+        conn.close()
+
+        response = client.post("/board/jobs/fp_waitlisted/reactivate-and-prep")
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_waitlisted") == "prep_in_progress"
+
+        audit = _fetch_audit(client, "fp_waitlisted")
+        assert ("stage", "waitlisted", "materials_drafted") in audit
+        assert ("stage", "materials_drafted", "prep_in_progress") in audit
+
+        # Folder moved back out of _waitlisted/
+        assert not folder.exists()
+
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert len(prep_calls) == 1
+
+    def test_409_for_non_waitlisted_stage(self, client: TestClient, popen_calls):
+        """Route is only valid from stage='waitlisted'. Direct URL access from
+        any other stage (scored, materials_drafted, applied, ...) returns 409."""
+        response = client.post("/board/jobs/fp_scored/reactivate-and-prep")
+        assert response.status_code == 409
+        assert _fetch_stage(client, "fp_scored") == "scored"
+        assert _fetch_audit(client, "fp_scored") == []
+        assert popen_calls == []
+
+    def test_idempotent_on_prep_in_progress(self, client: TestClient, popen_calls):
+        """Match /prep's silent-success on already-in-flight rows so a fast
+        double-click doesn't surface a 409. The route flips waitlisted→prep_in_progress
+        on the first click; a second click finds stage='prep_in_progress' and
+        returns empty (row was already advanced)."""
+        response = client.post("/board/jobs/fp_prep/reactivate-and-prep")
+        assert response.status_code == 200
+        assert response.text == ""
+        # Stage unchanged
+        assert _fetch_stage(client, "fp_prep") == "prep_in_progress"
+        # No new audit row, no new subprocess
+        assert _fetch_audit(client, "fp_prep") == []
+        assert popen_calls == []
+
+    def test_404_unknown_fingerprint(self, client: TestClient, popen_calls):
+        response = client.post("/board/jobs/fp_nonexistent/reactivate-and-prep")
+        assert response.status_code == 404
+        assert popen_calls == []
+
+    def test_429_when_queue_full(self, client: TestClient, popen_calls):
+        """Same 3-in-flight cap as /prep and /regenerate. Returns 429 and
+        does NOT advance the row's stage."""
+        conn = sqlite3.connect(client._db_path)
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, source, stage) "
+            "VALUES ('inflight1','fp_inflight1','u','T','C','test','prep_in_progress')"
+        )
+        conn.execute(
+            "INSERT INTO jobs (id, fingerprint, url, title, company, source, stage) "
+            "VALUES ('inflight2','fp_inflight2','u','T','C','test','prep_in_progress')"
+        )
+        # fp_prep is already prep_in_progress → 3 in flight
+        conn.commit()
+        conn.close()
+
+        response = client.post("/board/jobs/fp_waitlisted/reactivate-and-prep")
+        assert response.status_code == 429
+
+        # Stage unchanged, no audit rows, no subprocess
+        assert _fetch_stage(client, "fp_waitlisted") == "waitlisted"
+        assert _fetch_audit(client, "fp_waitlisted") == []
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert prep_calls == []
+
+    def test_402_when_spend_ceiling_reached(self, client: TestClient, popen_calls, monkeypatch):
+        """Same spend-ceiling launch gate as /prep and /regenerate. Returns 402
+        without advancing the row's stage."""
+        from findajob.spend_ceiling import LaunchGateRefusal
+        from findajob.web.routes import board_actions
+
+        monkeypatch.setattr(
+            board_actions,
+            "check_launch_gate",
+            lambda _db: LaunchGateRefusal(ceiling_usd=50.0, current_sum_usd=51.23),
+        )
+
+        response = client.post("/board/jobs/fp_waitlisted/reactivate-and-prep")
+        assert response.status_code == 402
+
+        # Stage unchanged
+        assert _fetch_stage(client, "fp_waitlisted") == "waitlisted"
+        assert _fetch_audit(client, "fp_waitlisted") == []
+        prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
+        assert prep_calls == []


### PR DESCRIPTION
## Summary

- Closes two-click cross-stage flows surfaced by audit #662 as gaps **G8** (waitlist unreachable from Review) and **G9** (prep unreachable from Waitlist after reactivate).
- Review tab gains a Waitlist button alongside Promote.
- Waitlist tab gains a Flag-for-Prep button alongside Reactivate, posting to a new `/reactivate-and-prep` route.
- Third of three remaining Wave-3 items in milestone "Board Transition Coherence" (#24); leaves only #699 (F3 apply/un-apply undo toast) open after this lands.

## Changes

- `src/findajob/web/routes/board_actions.py` — new `POST /reactivate-and-prep` route. Gate order: 404 → silent-success-on-already-advanced → 409 → 402 → 429 → mutate. Re-reads intermediate stage after `handle_reactivate` so the second audit row's `old_value` is correct whether the folder existed or not.
- `src/findajob/web/templates/board/_status_cell.html` — review and waitlist tabs wrap their existing button in a `flex gap-1` container and add the new secondary button.
- `tests/test_board_actions.py` — 10 new tests across `TestReviewTabRendersWaitlistButton`, `TestWaitlistFromReview`, `TestWaitlistTabRendersFlagForPrepButton`, `TestReactivateAndPrep` (happy path with folder + without folder, 409 ineligible stage, idempotent on `prep_in_progress`, 404, 429 queue full, 402 spend ceiling).
- `CLAUDE.md` — Board Routes table row for `/reactivate-and-prep` + note that `/waitlist` now also fires from Review tab.

## Out of scope (per issue body)

- Broader sweep candidates noted in the issue (Re-prep from Applied, direct Flag-for-Prep skipping promote from Review). File as follow-ups if operator hits the friction.

## Test plan

- [x] `uv run pytest tests/test_board_actions.py` — 153 passed locally.
- [x] `uv run pytest tests/` — full suite 2649 passed, 1 skipped.
- [x] `uv run ruff check src/ tests/` clean.
- [x] `uv run ruff format --check src/ tests/` clean.
- [x] `uv run mypy src/findajob/web/routes/board_actions.py` clean.
- [x] Advisor pass before writing: caught (a) handle_waitlist folder-safety check (verified — actions.py:177 guards the move); (b) idempotency on prep_in_progress should silent-success not 409 (matched /prep convention); (c) need a no-folder test path for /reactivate-and-prep (added — `test_happy_path_without_folder` verifies the `(waitlisted→scored)` audit pair vs `(waitlisted→materials_drafted)` in the with-folder case).
- [ ] **Browser smoke not run.** Button-rendering tests assert HTML containment (`Waitlist` + `hx-post="/.../waitlist"` inside `fp_manual`'s row, etc.) but not visual layout or HTMX swap behavior. Recommend a quick smoke on `findajob-clean` post-merge before tester wave rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)