### PR TITLE
feat(web): #699 — apply + un-apply with 30s undo toast (#662 F3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,8 @@ responds in the same request — no poll cycle, no mirror table.
 |---|---|---|
 | Flag for Prep | `POST /board/jobs/{fp}/prep` | Dashboard dropdown |
 | Regenerate | `POST /board/jobs/{fp}/regenerate` | Dashboard dropdown — gated by `GET /board/jobs/{fp}/regenerate/confirm` modal (#700); Cancel restores cell via `GET /board/jobs/{fp}/regenerate/cell` |
-| Applied | `POST /board/jobs/{fp}/apply` | Dashboard dropdown |
+| Applied | `POST /board/jobs/{fp}/apply` | Dashboard dropdown. Response carries the `_undo_toast.html` partial as `hx-swap-oob` into `#undo-toast` (#699). |
+| Un-apply | `POST /board/jobs/{fp}/un-apply` | Undo button inside the 30s undo toast (#699). 409 once the audit_log row '… → applied' is older than 30 seconds — gate is SQL-side `datetime('now', '-30 seconds')` for clock-drift safety. |
 | Waitlist | `POST /board/jobs/{fp}/waitlist` | Dashboard dropdown + Review tab button (#702) |
 | Reject (w/ reason) | `POST /board/jobs/{fp}/reject` | Dashboard / Review / Waitlist reject cell |
 | Interviewing | `POST /board/jobs/{fp}/interview` | Applied dropdown |

--- a/src/findajob/actions.py
+++ b/src/findajob/actions.py
@@ -455,6 +455,58 @@ def un_withdraw_job(conn: sqlite3.Connection, job: Any, *, commit: bool = True) 
     return restored_stage
 
 
+def un_apply_job(conn: sqlite3.Connection, job: Any) -> None:
+    """Reverse a recent /apply (#699): move folder back from companies/_applied/
+    to companies/, delete the *.applied-YYYY-MM-DD.md snapshot siblings written
+    by snapshot_applied_md_files, flip stage to materials_drafted, clear
+    apply_flag, and write an audit_log row tagged 'web_un_apply'.
+
+    Caller (the /un-apply route) is responsible for the 30s time-window guard;
+    this helper is unconditional — if the row's stage is 'applied', it reverses.
+
+    Note on apply_flag: the spec clears it back to 0 even though /prep-completed
+    materials_drafted rows have apply_flag=1. The asymmetry is intentional — an
+    un-applied row is "draft I had decided to send, then changed my mind", not
+    "draft pending dispatch", so the flag-zero state is correct.
+    """
+    now = datetime.now(UTC).isoformat()
+
+    # Re-fetch prep_folder_path from the DB so callers can pass any row shape
+    # that has at least .id — matches handle_rejection's pattern.
+    jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
+    folder = jd["prep_folder_path"] if jd and jd["prep_folder_path"] else None
+    new_path = folder  # default: keep whatever path is on the row
+    if folder and os.path.isdir(folder):
+        # Move folder back from _applied/ to companies/
+        dest = os.path.join(BASE, "companies", os.path.basename(folder))
+        shutil.move(folder, dest)
+        new_path = dest
+        log_event("folder_moved_from_applied", job_id=job["id"], folder=os.path.basename(folder))
+
+        # Delete only files matching the exact snapshot regex (mirrors
+        # snapshot_applied_md_files's filter — not a glob, which would
+        # also match incidentally-named files).
+        dest_path = Path(dest)
+        for md in dest_path.glob("*.md"):
+            if _APPLIED_SNAPSHOT_RE.search(md.name):
+                md.unlink()
+                log_event("snapshot_removed_for_un_apply", job_id=job["id"], snapshot=md.name)
+
+    conn.execute(
+        "UPDATE jobs SET stage='materials_drafted', apply_flag=0, prep_folder_path=?, "
+        "stage_updated=?, updated_at=? WHERE id=?",
+        (new_path, now, now, job["id"]),
+    )
+    conn.commit()
+    write_audit(conn, job["id"], "stage", "applied", "materials_drafted", changed_by="web_un_apply")
+    log_event(
+        "job_un_applied",
+        job_id=job["id"],
+        company=job["company"],
+        title=job["title"],
+    )
+
+
 def reactivate_from_ingest(conn: sqlite3.Connection, job: Any, overwrite_fields: dict[str, str]) -> None:
     """Reactivate a waitlisted job via manual ingest.
 

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -29,6 +29,7 @@ from findajob.actions import (
     notify_waitlist_resurface,
     promote_to_scored,
     snapshot_applied_md_files,
+    un_apply_job,
     un_not_selected_job,
     un_reject_job,
     un_withdraw_job,
@@ -461,10 +462,17 @@ def regenerate_cell(
 @router.post("/board/jobs/{fingerprint}/apply", response_class=HTMLResponse)
 def apply(
     fingerprint: str,
-    request: Request,  # noqa: ARG001 — kept for handler signature parity
+    request: Request,
     db: sqlite3.Connection = Depends(get_db),  # noqa: B008
 ) -> HTMLResponse:
-    """Move job to the Applied tab. Returns empty body — HTMX removes the dashboard row."""
+    """Move job to the Applied tab. Response body is the undo toast partial
+    (#699 F3) carrying an out-of-band swap into #undo-toast — HTMX strips the
+    OOB element from the response before doing the primary swap into the row,
+    so the row is removed *and* the toast appears in the same request.
+
+    Idempotency: re-clicking on an already-applied row returns empty (no toast)
+    — the 30s window has either already passed or is being handled by an
+    earlier in-flight toast."""
     job = _fetch_job(db, fingerprint)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -473,6 +481,52 @@ def apply(
     changed_by = "outreach_button" if is_synthetic_job(job) else "user"
     _transition_stage(db, job, "applied", event_name="web_applied", changed_by=changed_by)
     _move_folder_to_applied(db, job)
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="board/_undo_toast.html",
+        context={"fingerprint": fingerprint},
+    )
+
+
+@router.post("/board/jobs/{fingerprint}/un-apply", response_class=HTMLResponse)
+def un_apply(
+    fingerprint: str,
+    request: Request,  # noqa: ARG001
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Reverse a recent /apply within the 30-second undo window (#699 F3).
+
+    Gates:
+      - 404 if fingerprint unknown
+      - 409 if stage != 'applied' (the dropdown surface is no longer applicable)
+      - 409 if no audit_log row '… → applied' within the last 30 seconds
+        (the undo window has expired)
+
+    On success, returns empty body — HTMX's outerHTML swap of the toast cell
+    with empty content removes it from the DOM. The row reappears on the
+    Dashboard at the next page load (not auto-inserted)."""
+    job = _fetch_job(db, fingerprint)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["stage"] != "applied":
+        raise HTTPException(status_code=409, detail="Job is not at stage='applied'")
+
+    # SQL-side window check — both /apply's write_audit and this gate use
+    # SQLite's datetime('now'), so test seeds and production writes are
+    # comparable without Python/DB clock drift.
+    recent = db.execute(
+        "SELECT 1 FROM audit_log "
+        "WHERE job_id=? AND field_changed='stage' AND new_value='applied' "
+        "  AND changed_at > datetime('now', '-30 seconds') "
+        "LIMIT 1",
+        (job["id"],),
+    ).fetchone()
+    if recent is None:
+        raise HTTPException(status_code=409, detail="Undo window expired")
+
+    un_apply_job(db, job)
     return HTMLResponse("")
 
 

--- a/src/findajob/web/templates/base.html
+++ b/src/findajob/web/templates/base.html
@@ -14,6 +14,9 @@
 </head>
 <body class="bg-slate-50 text-slate-900" hx-boost="true">
   <div id="htmx-error-toast" class="fixed top-4 right-4 z-50 hidden max-w-sm rounded bg-red-600 px-4 py-3 text-sm text-white shadow-lg"></div>
+  {# #699 F3: OOB target for the post-apply undo toast. Empty placeholder is
+     replaced by templates/board/_undo_toast.html on a /apply response. #}
+  <div id="undo-toast"></div>
   {% block nav %}{% include "_nav.html" %}{% endblock %}
   <main class="{% block main_classes %}max-w-6xl mx-auto px-4 py-6{% endblock %}">
     {% if _rendered_md is defined and _rendered_md %}<div class="prose prose-slate max-w-none">{{ _rendered_md | safe }}</div>{% endif %}

--- a/src/findajob/web/templates/board/_undo_toast.html
+++ b/src/findajob/web/templates/board/_undo_toast.html
@@ -1,0 +1,42 @@
+{#
+  Undo toast for the /apply action (#699 F3). Rendered as an HTMX
+  out-of-band swap from the /apply response — replaces the empty
+  <div id="undo-toast"> placeholder in base.html.
+
+  Inputs:
+    fingerprint — the job that was just applied
+
+  Behavior:
+    - Alpine x-data tracks a 30-second visibility window.
+    - x-init starts two timers: a 30s setTimeout that fades the toast,
+      and a 1s setInterval that drives the countdown display.
+    - The Undo button hx-posts to /un-apply targeting this whole
+      <div id="undo-toast">. On 200, the server returns empty and
+      the toast is replaced by nothing (HTMX outerHTML of empty).
+      On 409 (expired window), HTMX leaves the toast in place; the
+      htmx-error-toast plumbing in base.html surfaces the error.
+
+  The toast disappears on whichever happens first: 30s timer expiry,
+  successful Undo click, or operator dismiss.
+#}
+<div id="undo-toast"
+     hx-swap-oob="true"
+     x-data="{ visible: true, secondsLeft: 30 }"
+     x-init="setTimeout(() => visible = false, 30000); setInterval(() => secondsLeft = Math.max(0, secondsLeft - 1), 1000)"
+     x-show="visible"
+     x-transition.opacity.duration.300ms
+     class="fixed top-4 right-4 z-50 max-w-sm rounded bg-slate-900 px-4 py-3 text-sm text-white shadow-lg flex items-center gap-3">
+  <span>Applied. Folder moved and snapshot saved.</span>
+  <button type="button"
+          hx-post="/board/jobs/{{ fingerprint }}/un-apply"
+          hx-target="#undo-toast"
+          hx-swap="outerHTML"
+          @click="visible = false"
+          class="rounded bg-white/10 hover:bg-white/20 px-2 py-1 text-xs font-medium">
+    Undo (<span x-text="secondsLeft"></span>s)
+  </button>
+  <button type="button"
+          @click="visible = false"
+          aria-label="Dismiss"
+          class="text-white/70 hover:text-white text-base leading-none">✕</button>
+</div>

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -529,6 +529,115 @@ class TestUnWithdrawJob:
         assert count == 0
 
 
+# ── un_apply_job (#699) ─────────────────────────────────────────────────────
+
+
+class TestUnApplyJob:
+    """Reverse a recent /apply: move folder back from _applied/, delete the
+    *.applied-YYYY-MM-DD.md snapshot files, flip stage to materials_drafted,
+    clear apply_flag, write audit row with changed_by='web_un_apply'."""
+
+    def _seed_applied_with_folder(self, db, tmp_path):
+        """Set up the typical post-apply state: stage='applied', folder in
+        _applied/ with one real .md + one snapshot sibling."""
+        folder = tmp_path / "companies" / "_applied" / "Acme_UnApply_test"
+        folder.mkdir(parents=True)
+        # Real material
+        (folder / "resume.md").write_text("# Resume content")
+        # Snapshot sibling (what /apply's snapshot_applied_md_files would have written)
+        (folder / "resume.applied-2026-05-17.md").write_text("# Snapshot at apply time")
+        # Non-md file is untouched
+        (folder / "resume.pdf").write_bytes(b"%PDF")
+
+        job = insert_job(db, stage="applied", folder=str(folder), apply_flag=1)
+        return job, folder
+
+    def test_moves_folder_back_to_companies(self, db, tmp_path):
+        job, folder = self._seed_applied_with_folder(db, tmp_path)
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        actions.un_apply_job(db, job)
+
+        assert not folder.exists()
+        new_path = db.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()[0]
+        # Folder ends up at companies/{base}, not companies/_applied/{base}
+        assert os.path.basename(new_path) == "Acme_UnApply_test"
+        assert os.path.dirname(new_path).endswith("companies")
+        assert os.path.isdir(new_path)
+        # Real material survived the round-trip
+        assert (os.path.join(new_path, "resume.md")) in [os.path.join(new_path, f) for f in os.listdir(new_path)]
+        assert os.path.isfile(os.path.join(new_path, "resume.md"))
+
+    def test_deletes_only_snapshot_files_not_originals(self, db, tmp_path):
+        """Snapshot files match the _APPLIED_SNAPSHOT_RE regex
+        (.applied-YYYY-MM-DD.md); originals and incidentally-named files survive."""
+        job, folder = self._seed_applied_with_folder(db, tmp_path)
+        # Adversarial incidentally-named file that a glob *.applied-*.md
+        # would clobber but the regex correctly skips (no date suffix shape).
+        (folder / "notes.applied-rewrite.md").write_text("# Operator's edit notes")
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        actions.un_apply_job(db, job)
+
+        new_path = db.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()[0]
+        survivors = set(os.listdir(new_path))
+        assert "resume.md" in survivors
+        assert "resume.pdf" in survivors
+        # Incidentally-named (no YYYY-MM-DD shape) survives — regex precision pin
+        assert "notes.applied-rewrite.md" in survivors
+        # Snapshot deleted
+        assert "resume.applied-2026-05-17.md" not in survivors
+
+    def test_apply_flag_cleared(self, db, tmp_path):
+        """Spec pin: post-un-apply rows have apply_flag=0 even though
+        /prep-completed materials_drafted rows have apply_flag=1. Locks the
+        spec so a future reader doesn't 'fix' the asymmetry."""
+        job, _ = self._seed_applied_with_folder(db, tmp_path)
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        actions.un_apply_job(db, job)
+
+        flag = db.execute("SELECT apply_flag FROM jobs WHERE id=?", (job["id"],)).fetchone()[0]
+        assert flag == 0
+
+    def test_stage_flips_to_materials_drafted(self, db, tmp_path):
+        job, _ = self._seed_applied_with_folder(db, tmp_path)
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        actions.un_apply_job(db, job)
+
+        stage = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()[0]
+        assert stage == "materials_drafted"
+
+    def test_writes_audit_with_changed_by_web_un_apply(self, db, tmp_path):
+        job, _ = self._seed_applied_with_folder(db, tmp_path)
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        actions.un_apply_job(db, job)
+
+        audits = db.execute(
+            "SELECT field_changed, old_value, new_value, changed_by FROM audit_log WHERE job_id=? ORDER BY id",
+            (job["id"],),
+        ).fetchall()
+        un_apply_rows = [a for a in audits if a["changed_by"] == "web_un_apply"]
+        assert len(un_apply_rows) == 1
+        assert un_apply_rows[0]["field_changed"] == "stage"
+        assert un_apply_rows[0]["old_value"] == "applied"
+        assert un_apply_rows[0]["new_value"] == "materials_drafted"
+
+    def test_handles_missing_folder_path_gracefully(self, db):
+        """apply_flag was set, stage=applied, but prep_folder_path is NULL
+        (folder was never moved). The helper should still flip stage and
+        write audit — no crash."""
+        job = insert_job(db, stage="applied", folder=None, apply_flag=1)
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        actions.un_apply_job(db, job)
+
+        stage = db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()[0]
+        assert stage == "materials_drafted"
+
+
 # ── handle_waitlist ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -1068,7 +1068,10 @@ class TestApply:
         response = client.post("/board/jobs/fp_drafted/apply")
 
         assert response.status_code == 200
-        assert response.text == ""  # empty body = HTMX removes the row
+        # Body is the undo toast partial carrying hx-swap-oob="true" (#699).
+        # HTMX strips the OOB element from the body before the primary swap
+        # into closest tr, so the row is still removed despite non-empty body.
+        assert 'id="undo-toast"' in response.text
         assert _fetch_stage(client, "fp_drafted") == "applied"
         # Folder moved into _applied/
         conn = sqlite3.connect(client._db_path)
@@ -2496,3 +2499,109 @@ class TestReactivateAndPrep:
         assert _fetch_audit(client, "fp_waitlisted") == []
         prep_calls = [c for c in popen_calls if "prep_application.py" in c[1]]
         assert prep_calls == []
+# ── /un-apply route + /apply OOB toast (#699 F3) ──────────────────────────
+
+
+def _seed_applied_audit(client: TestClient, fingerprint: str, seconds_ago: int) -> None:
+    """Seed an audit_log row '… → applied' at a known offset from now.
+    SQL-side datetime arithmetic so the test clock and DB clock can't drift."""
+    conn = sqlite3.connect(client._db_path)
+    job_id = conn.execute("SELECT id FROM jobs WHERE fingerprint=?", (fingerprint,)).fetchone()[0]
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+        "VALUES (?, 'stage', 'materials_drafted', 'applied', datetime('now', ?), 'user')",
+        (job_id, f"-{seconds_ago} seconds"),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestUnApply:
+    def test_happy_path_within_window(self, client: TestClient):
+        """Audit row at -5s → un-apply succeeds and flips stage back to materials_drafted."""
+        _seed_applied_audit(client, "fp_applied", seconds_ago=5)
+
+        response = client.post("/board/jobs/fp_applied/un-apply")
+        assert response.status_code == 200
+        assert _fetch_stage(client, "fp_applied") == "materials_drafted"
+
+        # New audit row written by un_apply_job
+        audit = _fetch_audit(client, "fp_applied")
+        assert any(a == ("stage", "applied", "materials_drafted") for a in audit)
+
+    def test_409_on_expired_window(self, client: TestClient):
+        """Audit row at -60s exceeds the 30s undo window → 409, no state change."""
+        _seed_applied_audit(client, "fp_applied", seconds_ago=60)
+
+        response = client.post("/board/jobs/fp_applied/un-apply")
+        assert response.status_code == 409
+        # Stage unchanged
+        assert _fetch_stage(client, "fp_applied") == "applied"
+        # No new audit row from un-apply
+        audit = _fetch_audit(client, "fp_applied")
+        assert not any(a == ("stage", "applied", "materials_drafted") for a in audit)
+
+    def test_409_when_no_applied_audit_row_exists(self, client: TestClient):
+        """Defensive: stage='applied' was set in fixture but no audit row was
+        seeded. Without an audit row, the window guard can't verify recency —
+        treated as expired."""
+        # fp_applied is stage='applied' in fixture but has no audit_log row.
+        response = client.post("/board/jobs/fp_applied/un-apply")
+        assert response.status_code == 409
+        assert _fetch_stage(client, "fp_applied") == "applied"
+
+    def test_409_on_non_applied_stage(self, client: TestClient):
+        """Direct URL access from a non-applied stage returns 409."""
+        response = client.post("/board/jobs/fp_drafted/un-apply")
+        assert response.status_code == 409
+        assert _fetch_stage(client, "fp_drafted") == "materials_drafted"
+
+    def test_404_unknown_fingerprint(self, client: TestClient):
+        response = client.post("/board/jobs/fp_nonexistent/un-apply")
+        assert response.status_code == 404
+
+    def test_apply_flag_cleared_to_zero(self, client: TestClient):
+        """Pin spec: post-un-apply rows have apply_flag=0."""
+        _seed_applied_audit(client, "fp_applied", seconds_ago=5)
+        # Pre-condition: set apply_flag=1 so the assertion is meaningful
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET apply_flag=1 WHERE fingerprint='fp_applied'")
+        conn.commit()
+        conn.close()
+
+        client.post("/board/jobs/fp_applied/un-apply")
+
+        conn = sqlite3.connect(client._db_path)
+        flag = conn.execute("SELECT apply_flag FROM jobs WHERE fingerprint='fp_applied'").fetchone()[0]
+        conn.close()
+        assert flag == 0
+
+
+class TestApplyToastOOB:
+    def test_apply_response_includes_undo_toast_oob_swap(self, client: TestClient):
+        """POST /apply on a real (non-synthetic) materials_drafted row returns
+        an out-of-band swap targeting #undo-toast — so the toast appears even
+        though the row itself was removed by the empty primary swap."""
+        response = client.post("/board/jobs/fp_drafted/apply")
+        assert response.status_code == 200
+        text = response.text
+
+        # The OOB marker must be on the toast root, targeting the base
+        # template's <div id="undo-toast"></div> placeholder.
+        assert 'id="undo-toast"' in text
+        assert 'hx-swap-oob="true"' in text
+        # The toast's Undo button posts to /un-apply for this specific job
+        assert 'hx-post="/board/jobs/fp_drafted/un-apply"' in text
+
+    def test_apply_on_synthetic_job_still_returns_toast(self, client: TestClient):
+        """Synthetic [SPEC] jobs use the same /apply route; the toast is
+        identical (un-apply behavior is identical per spec)."""
+        conn = sqlite3.connect(client._db_path)
+        conn.execute("UPDATE jobs SET title='[SPEC] Test Speculative', synthetic=1 WHERE fingerprint='fp_drafted'")
+        conn.commit()
+        conn.close()
+
+        response = client.post("/board/jobs/fp_drafted/apply")
+        assert response.status_code == 200
+        assert 'id="undo-toast"' in response.text
+        assert 'hx-post="/board/jobs/fp_drafted/un-apply"' in response.text


### PR DESCRIPTION
## Summary

- Closes board-transition-audit gaps **G3** (no un-apply affordance) and **G4** (apply is one-click with no confirm despite side effects). Adopts the audit's Tier-2 policy: undo toast, not confirm modal.
- Last remaining Wave-3 item in milestone "Board Transition Coherence" (#24); with this merged, milestone #24 reaches full F-series coverage.

## Changes

- `src/findajob/actions.py` — new `un_apply_job(conn, job)` helper. Moves folder back from `_applied/`, deletes only files matching the precise `_APPLIED_SNAPSHOT_RE` (mirrors `snapshot_applied_md_files`'s filter), flips stage to `materials_drafted`, clears `apply_flag` to 0, writes audit row with `changed_by='web_un_apply'`.
- `src/findajob/web/routes/board_actions.py`:
  - New `POST /board/jobs/{fp}/un-apply` route. Gate order: 404 → 409 on non-applied → 409 on expired window. Window guard is SQL-side `datetime('now', '-30 seconds')` so test seeds and production writes share the SQLite clock (no Python/DB drift).
  - `POST /apply` now returns the `_undo_toast.html` partial. HTMX strips the `hx-swap-oob` element from the body before the primary swap into the row, so the row is removed *and* the toast appears in #undo-toast in one request.
- `src/findajob/web/templates/board/_undo_toast.html` — new Alpine-driven partial. 30s countdown via `setInterval`, fade via `x-transition.opacity`, Undo button hx-posts to `/un-apply`.
- `src/findajob/web/templates/base.html` — `<div id="undo-toast"></div>` placeholder added alongside existing `htmx-error-toast`.
- `tests/test_actions.py` — `TestUnApplyJob` class with 6 tests (folder round-trip, snapshot regex precision vs glob, apply_flag pin to 0, stage flip, audit row contents, missing-folder graceful handling).
- `tests/test_board_actions.py` — `TestUnApply` (6 tests) + `TestApplyToastOOB` (2 tests including synthetic [SPEC] job parity).
- `CLAUDE.md` — Board Routes table updated with `/un-apply` row and `/apply` toast note.

## Spec deviations

None. Every acceptance-criteria bullet from #699 is addressed.

## Test plan

- [x] `uv run pytest tests/test_actions.py::TestUnApplyJob` — 6 passed.
- [x] `uv run pytest tests/test_board_actions.py::TestUnApply tests/test_board_actions.py::TestApplyToastOOB tests/test_board_actions.py::TestApply` — 12 passed.
- [x] `uv run pytest tests/` — full suite **2653 passed**, 1 skipped.
- [x] `uv run ruff check src/ tests/` clean.
- [x] `uv run ruff format --check src/ tests/` clean.
- [x] `uv run mypy src/findajob/actions.py src/findajob/web/routes/board_actions.py` clean.
- [x] Advisor pre-write catches addressed: regex-based snapshot filter (test `test_deletes_only_snapshot_files_not_originals` includes an adversarial `notes.applied-rewrite.md` that the regex correctly skips); SQL-side window guard (no Python `timedelta`); single OOB ID `undo-toast` named in both `base.html` and `_undo_toast.html`; spec-pinning test `test_apply_flag_cleared_to_zero`.
- [ ] **Browser smoke not run.** Unit tests verify rendered HTML (toast presence, hx-post URLs, OOB attribute) but not Alpine countdown actually decrementing, HTMX OOB swap actually landing in `#undo-toast`, or visual fade. This is the first usage of `hx-swap-oob` + Alpine `setInterval` together in the dashboard surface — recommend a quick browser smoke on `findajob-clean` post-merge before tester wave rolls.

## After this lands

Milestone #24 (Board Transition Coherence) is feature-complete: F1 #697 ✅, F2 #698 ✅, F4 #700 (PR #710), F6 #701 ✅, F7 #696 ✅, F8 #702 (PR #711), F3 #699 (this PR). Merge order is independent — three open PRs touch disjoint surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)