### PR TITLE
feat(web/archive): #281 — Reject affordance + default-exclude rejected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ responds in the same request — no poll cycle, no mirror table.
 
 The rejections-review row is keyed by `rejection_suggestions.id` rather than `jobs.fingerprint` — the suggestion is the source row, the job_id is found via `matched_job_id` (or operator-supplied on reattribute). Confirm/reattribute call `handle_not_selected(..., changed_by='gmail_rejection_detector')` so the audit trail tags the transition.
 
-**REJECT_REASON dropdown**: 11 options (includes "Low Fit Score"). Behavior depends on STATUS:
+**REJECT_REASON dropdown**: vocabulary is per-stack configurable via `config/reject_reasons.yaml`; defaults to a field-agnostic list in `findajob.config_loader._DEFAULT_REJECT_REASONS`, hot-reloaded per request. A "title-signal" subset (declared in the same YAML, defaults in `_DEFAULT_TITLE_SIGNAL_REASONS`) feeds `analyze_feedback._prefilter_candidates` so the scorer learns from rejections where the title alone was a tell. Behavior depends on STATUS:
 - If STATUS = `Not Selected`: company rejection → `stage=not_selected`, NO `feedback_log`, folder stays in `_applied/` with `NOT_SELECTED_` marker file
 - Otherwise: user rejection → `stage=rejected`, writes `feedback_log`, moves folder to `_rejected/`
 

--- a/src/findajob/config_loader.py
+++ b/src/findajob/config_loader.py
@@ -31,6 +31,7 @@ _SPEND_CEILING_PATH = Path(BASE) / "config" / "spend_ceiling.txt"
 # `reasons:` is empty. Operator stacks override via the file (interview-emitted
 # in a follow-up to #429); fresh installs and tester stacks see this default.
 _DEFAULT_REJECT_REASONS: tuple[str, ...] = (
+    "Not relevant",
     "Skills Mismatch",
     "Geography",
     "Compensation",

--- a/src/findajob/web/routes/board.py
+++ b/src/findajob/web/routes/board.py
@@ -573,10 +573,13 @@ def _archive_query(parsed: ParsedFilters, offset: int, page_size: int = _ARCHIVE
     clauses, filter_params = build_filter_clauses(specs, parsed)
     sort = parsed.sort or _ARCHIVE_DEFAULT_SORT
     order = "DESC" if parsed.desc else "ASC"
-    # Strip leading " AND " and prefix with " WHERE " — Archive has no base WHERE.
-    where_sql = ""
-    if clauses:
-        where_sql = " WHERE " + clauses[len(" AND ") :]
+    # Strip leading " AND " — Archive has no base WHERE.
+    where_body = clauses[len(" AND ") :] if clauses else ""
+    # #281: Default-exclude rejected rows so the score-5/6 triage workflow doesn't
+    # re-show already-rejected rows. Reachable via ?stage=rejected or /board/rejected.
+    if "stage" not in parsed.enum:
+        where_body = f"{where_body} AND stage != 'rejected'" if where_body else "stage != 'rejected'"
+    where_sql = f" WHERE {where_body}" if where_body else ""
     sql = (
         "SELECT fingerprint, title, company, stage, relevance_score, fit_score, "
         "probability_score, location, remote_status, source, url, user_notes, created_at, stage_updated "

--- a/src/findajob/web/templates/board/_archive_actions_cell.html
+++ b/src/findajob/web/templates/board/_archive_actions_cell.html
@@ -41,7 +41,7 @@
                 htmx.ajax('POST','/board/jobs/{{ row.fingerprint }}/reject',{target:tr,swap:'outerHTML',values:{reason:this.value}});
                 this.value='';
               }">
-        <option value="">▾</option>
+        <option value="">Other…</option>
         {% for reason in reject_reason_options() if reason != 'Not relevant' %}
         <option value="{{ reason }}">{{ reason }}</option>
         {% endfor %}

--- a/src/findajob/web/templates/board/_archive_actions_cell.html
+++ b/src/findajob/web/templates/board/_archive_actions_cell.html
@@ -1,7 +1,9 @@
 {#
   Archive-tab actions cell — 4 stage cases:
 
-  - scored: Promote (POST /promote) — bumps relevance_score=7, surfaces row on Dashboard
+  - scored: Promote (POST /promote, bumps relevance_score=7) + hybrid Reject
+    affordance (single-click ✕ posts /reject with reason="Not relevant"; adjacent
+    ▾ dropdown posts /reject with operator-selected alternate reason). #281.
   - rejected: Un-reject with confirm modal (GET /un-reject/confirm) — destructive
     (deletes feedback_log row). Reuses #697's generic _confirm_modal.html partial.
   - withdrawn: Un-withdraw (POST /un-withdraw) — pure stage restore, no warning
@@ -16,11 +18,35 @@
 #}
 <td class="px-3 py-1 align-top text-sm whitespace-nowrap">
   {% if row.stage == 'scored' %}
-    <button type="button"
-            class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
-            hx-post="/board/jobs/{{ row.fingerprint }}/promote"
-            hx-target="closest tr"
-            hx-swap="outerHTML">Promote</button>
+    <div class="flex gap-1 items-center">
+      <button type="button"
+              class="rounded bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-500"
+              hx-post="/board/jobs/{{ row.fingerprint }}/promote"
+              hx-target="closest tr"
+              hx-swap="outerHTML">Promote</button>
+      <button type="button"
+              title="Reject as 'Not relevant'"
+              aria-label="Reject as Not relevant"
+              class="rounded bg-slate-100 hover:bg-rose-100 hover:text-rose-700 px-2 py-1 text-xs text-slate-700"
+              hx-post="/board/jobs/{{ row.fingerprint }}/reject"
+              hx-vals='{"reason":"Not relevant"}'
+              hx-target="closest tr"
+              hx-swap="outerHTML">✕</button>
+      <select
+              class="block rounded border-slate-300 bg-white px-1 py-1 text-xs text-slate-600"
+              aria-label="Reject with alternate reason"
+              title="Reject with alternate reason"
+              onchange="if(this.value){
+                const tr=this.closest('tr');
+                htmx.ajax('POST','/board/jobs/{{ row.fingerprint }}/reject',{target:tr,swap:'outerHTML',values:{reason:this.value}});
+                this.value='';
+              }">
+        <option value="">▾</option>
+        {% for reason in reject_reason_options() if reason != 'Not relevant' %}
+        <option value="{{ reason }}">{{ reason }}</option>
+        {% endfor %}
+      </select>
+    </div>
   {% elif row.stage == 'rejected' %}
     <button type="button"
             class="rounded bg-slate-100 hover:bg-slate-200 px-2 py-0.5 text-xs text-slate-700"

--- a/tests/test_web_board_archive.py
+++ b/tests/test_web_board_archive.py
@@ -144,3 +144,86 @@ def test_archive_shows_relevance_score_column(scored_client: TestClient) -> None
     assert r.status_code == 200
     # The sort link for relevance_score proves the column is in the header.
     assert "sort=relevance_score" in r.text
+
+
+@pytest.fixture
+def reject_mix_client(tmp_path: Path) -> TestClient:
+    """Fixture with mixed scored + rejected rows for #281 default-exclude tests."""
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "relevance_score INTEGER, fit_score REAL, probability_score REAL, location TEXT, "
+        "remote_status TEXT, source TEXT, url TEXT, created_at TEXT, stage_updated TEXT, "
+        "user_notes TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) "
+        "VALUES ('id-s','fp-s','Scored Job','CoS','scored',6,'2026-04-24')"
+    )
+    conn.execute(
+        "INSERT INTO jobs (id, fingerprint, title, company, stage, relevance_score, created_at) "
+        "VALUES ('id-r','fp-r','Rejected Job','CoR','rejected',5,'2026-04-24')"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+def test_archive_default_excludes_rejected_rows(reject_mix_client: TestClient) -> None:
+    """#281: Archive default view excludes stage='rejected' so the score-5/6 triage
+    workflow doesn't re-show already-rejected rows."""
+    r = reject_mix_client.get("/board/archive")
+    assert r.status_code == 200
+    assert "Scored Job" in r.text
+    assert "Rejected Job" not in r.text
+
+
+def test_archive_explicit_stage_rejected_surfaces_rejected_rows(reject_mix_client: TestClient) -> None:
+    """#281: ?stage=rejected explicitly overrides the default exclusion."""
+    r = reject_mix_client.get("/board/archive?stage=rejected")
+    assert r.status_code == 200
+    assert "Rejected Job" in r.text
+    assert "Scored Job" not in r.text
+
+
+def test_archive_explicit_stage_scored_still_excludes_rejected(reject_mix_client: TestClient) -> None:
+    """#281: ?stage=scored is the operator's filter — should hide rejected rows naturally,
+    not because of the default-exclude (this verifies the default doesn't double-apply)."""
+    r = reject_mix_client.get("/board/archive?stage=scored")
+    assert r.status_code == 200
+    assert "Scored Job" in r.text
+    assert "Rejected Job" not in r.text
+
+
+def test_archive_rows_htmx_default_excludes_rejected(reject_mix_client: TestClient) -> None:
+    """#281: HTMX partial /board/archive/rows shares the same default-exclude behavior."""
+    r = reject_mix_client.get("/board/archive/rows?offset=0")
+    assert r.status_code == 200
+    assert "Scored Job" in r.text
+    assert "Rejected Job" not in r.text
+
+
+def test_archive_scored_row_renders_hybrid_reject_affordance(scored_client: TestClient) -> None:
+    """#281: scored-stage rows render both the ✕ single-click button (default reason)
+    and the ▾ alternate-reason dropdown alongside Promote."""
+    r = scored_client.get("/board/archive?relevance_score_min=6")
+    assert r.status_code == 200
+    # Single-click ✕ posts to /reject with the Not-relevant default reason
+    assert "/board/jobs/fp-6a/reject" in r.text
+    assert '"reason":"Not relevant"' in r.text
+    # ▾ dropdown lists other reasons; "Not relevant" is excluded (it's the ✕ path)
+    assert '<option value="Not relevant">' not in r.text
+    # At least one alternate reason from the default list shows up in the dropdown
+    assert '<option value="Skills Mismatch">' in r.text
+
+
+def test_archive_non_scored_row_does_not_render_reject_affordance(scored_client: TestClient) -> None:
+    """#281: the new reject affordance is on the scored branch only — applied rows
+    keep their existing non-scored cell behavior (dash, in this fixture)."""
+    r = scored_client.get("/board/archive?relevance_score_min=6")
+    assert r.status_code == 200
+    assert "/board/jobs/fp-9/reject" not in r.text


### PR DESCRIPTION
## Summary

- Hybrid Reject affordance on Archive `scored`-stage rows: single-click ✕ (default reason `"Not relevant"`) + adjacent ▾ dropdown for alternates. Both paths reuse `POST /board/jobs/{fp}/reject`.
- Default `_archive_query` excludes `stage='rejected'` when no explicit `stage=` URL param is set. Rejected rows still reachable via `?stage=rejected` or the `/board/rejected` tab (#697).
- `"Not relevant"` added to `_DEFAULT_REJECT_REASONS` (image-baked default; ships to all stacks). Excluded from `_DEFAULT_TITLE_SIGNAL_REASONS`.
- CLAUDE.md `REJECT_REASON dropdown` description swapped from stale `"11 options"` enumeration to a source-of-truth pointer at `findajob.config_loader` (per the docs-normative-not-narrative principle).

## Reshape note

Original issue was filed 2026-04-25 against a codebase where Archive had no actions cell and the Rejected tab didn't exist. Reshape applied on 2026-05-17 against current state — `_archive_actions_cell.html` (post-#701, 2026-05-17) and `/board/rejected` (post-#697, 2026-05-17). Issue body was rewritten to reflect the current scope; original framing preserved in `## Context > Reshape note`.

## Test plan

- [x] `tests/test_web_board_archive.py` — 15 tests pass (9 pre-existing + 6 new):
  - `test_archive_default_excludes_rejected_rows`
  - `test_archive_explicit_stage_rejected_surfaces_rejected_rows`
  - `test_archive_explicit_stage_scored_still_excludes_rejected`
  - `test_archive_rows_htmx_default_excludes_rejected`
  - `test_archive_scored_row_renders_hybrid_reject_affordance` (verifies HTMX target, `hx-vals` payload, dropdown contents, exclusion of "Not relevant" from dropdown)
  - `test_archive_non_scored_row_does_not_render_reject_affordance`
- [x] Full suite: 2732 pass, 1 skipped. The 2 failures in `tests/test_materials_briefing_gate.py::TestRejectFromMaterials` are the pre-existing #716 isolation bug (confirmed identical failure on `origin/main` baseline with my changes stashed).
- [x] `ruff check`, `ruff format --check`, `mypy` — all clean on touched files.
- [ ] **Browser verification — not done locally.** Disclosure per feedback_disclose_verify_gaps: integration tests cover the rendered HTML (HTMX attrs, `hx-vals` payload, dropdown options); the dropdown JS is a verbatim copy of `_reject_cell.html`'s `onchange` pattern (proven on Dashboard/Review/Waitlist); the `hx-vals` shape matches `_reattribute_modal.html`. Visual regression risk: low. Recommend verifying on findajob-clean or findajob-brock post-merge: filter `/board/archive?relevance_score_min=5&relevance_score_max=6` to surface score-5/6 scored rows, click ✕ on one (default-reject as "Not relevant"), pick an alternate reason from ▾ on another, confirm both rows transition to `rejected` and drop off the view, then re-open `/board/archive` (no `?stage=` param) and verify they don't reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)