### PR TITLE
docs: cut v0.27.0 — CHANGELOG move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.27.0] — 2026-05-17
+
 ### Migration required
 - **#277 New `view_prefs` table (migration 0005).** `src/findajob/migrations/0005_view_prefs.sql` creates the per-tab persistence table that drives the new Columns dropdown + filter-state persistence on every board tab. Schema: `tab TEXT PRIMARY KEY CHECK (tab IN (…seven tab ids…))`, `query_string TEXT NOT NULL`, `updated_at TEXT NOT NULL DEFAULT (datetime('now'))`. Bumps `_meta.schema_version` to 5. Idempotent — fresh installs and existing stacks both pick it up on the next `apply_pending` (which `scripts/init_db.py` runs at every container start). No operator action required beyond `docker compose pull && docker compose up -d`. Test fixtures that hand-roll a minimal schema rather than running migrations need `tests.conftest.ensure_view_prefs_table(conn)` after their CREATE statements — added to all 11 board-route tests this PR.
 
@@ -1172,7 +1174,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/brockamer/findajob/releases/tag/v0.27.0
 [0.26.0]: https://github.com/brockamer/findajob/releases/tag/v0.26.0
 [0.25.1]: https://github.com/brockamer/findajob/releases/tag/v0.25.1
 [0.25.0]: https://github.com/brockamer/findajob/releases/tag/v0.25.0


### PR DESCRIPTION
## Summary

Cut v0.27.0. Moves [Unreleased] entries into the named version block. PRs in range (v0.26.0..HEAD):

- **#277** — per-tab Columns dropdown + persisted view prefs (migration 0005, `migration-required`)
- **#691** — briefing-first gate, Sessions 1+2+3 (migration: jobs.stage + background_tasks.kind CHECK constraints, idempotent rebuild)
- **#281** — Archive Reject affordance + default-exclude rejected
- **#696/#697/#698/#699/#700/#701/#702** — board UX surge (notes universal, Rejected/Not-Selected tabs, undo toast, regenerate confirm, archive parity, reactivate-and-prep)
- **#676/#689** — onboarding env-var detection + RapidAPI smoke
- Docs cleanups: #651, #668, #674, #684, #687, #694

## Pre-tag gates (all green)

- [x] **Fresh-install smoke** (`scripts/test_container_integration.sh`): 75 jobs scored, pipeline_complete event written, cost_log populated, /healthz 200, /docs slugs reachable, rclone absent.
- [x] **findajob-staging green-check**: 4/4 predicates green (pipeline_complete in last 26h, zero ERROR events in last pipeline, verify_auth=0, clicker sentinel=0).
- [x] **findajob-clean structural pre-flight**: on `:latest`, schema_version=5, view_prefs table present, verify_auth=0 (deployed in the run that brought brock/staging/clean/fly up to current main).

## Tag mechanics

After merge, `:latest` rebuilds off the CHANGELOG commit. Then `git tag v0.27.0 && git push origin v0.27.0` triggers:
- `build-image.yml` pushes `:v0.27.0` (immutable), `:v0.27` (moving), `:latest`
- `create-release.yml` generates the GitHub Release with "Action required before upgrade" surfaced from #277/#691's `migration-required` labels

## Cohort plan

Operator + dev stacks already on `:latest` (no-op on tag): findajob-brock, -staging, -clean, fly.
Tester stacks bump `:v0.26` → `:v0.27` in a single pass per `feedback_deploy_both_stacks` / `feedback_stack_pin_discipline`: alice, papa, dave, judy, tango.

🤖 Generated with [Claude Code](https://claude.com/claude-code)