### PR TITLE
refactor(actions): #709 — defer filesystem ops past DB commit for atomicity

### DIFF
--- a/src/findajob/actions.py
+++ b/src/findajob/actions.py
@@ -6,12 +6,26 @@ or drop marker files live here. Invoked from `scripts/watchdog.py` and from
 the web POST handlers in `findajob.web.routes.board_actions`.
 
 Every function takes an open `sqlite3.Connection` as its first argument and,
-by default, commits itself. The ``un_*`` helpers and ``handle_not_selected``
-accept a kwarg-only ``commit=False`` so callers can compose multiple writes
-into one transaction (used by ``reattribute_from_archive`` for atomic
-source-and-target updates). Functions return a `bool` indicating whether a
-folder was moved (or, for `reset_prep_to_scored`, whether the reset actually
-happened).
+by default, commits itself. Helpers that touch the filesystem (folder moves,
+marker file creation/deletion) accept a kwarg-only ``deferred_fs`` list so
+callers can compose multiple writes into one atomic transaction:
+
+- When ``deferred_fs is None`` (default, single-call), the helper runs its
+  DB writes, calls ``conn.commit()``, and then executes its filesystem ops
+  inline. Failure to commit leaves the filesystem untouched; failure of an
+  fs op leaves the DB authoritative (cosmetic disk artifact at worst).
+- When ``deferred_fs`` is a list, the helper appends its filesystem ops as
+  zero-arg closures to that list and does NOT commit. The caller owns the
+  transaction: call ``conn.commit()`` first, then execute each closure.
+  Used by ``reattribute_from_archive`` for atomic source-and-target updates.
+
+This replaces the older ``commit=False`` kwarg from #707. The two concerns
+(transaction ownership + fs deferral) collapsed into one kwarg because every
+caller that wanted ``commit=False`` also needed fs deferral to be meaningful
+in a rollback (#709).
+
+Functions retain their existing return values (`bool` for folder-moved,
+`str` for restored-stage, `None` elsewhere).
 """
 
 import glob
@@ -21,12 +35,15 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from findajob.audit import log_event, write_audit
 from findajob.paths import BASE
+
+FsOp = Callable[[], None]
 
 _APPLIED_SNAPSHOT_RE = re.compile(r"\.applied-\d{4}-\d{2}-\d{2}\.md$")
 
@@ -69,10 +86,28 @@ def snapshot_applied_md_files(
     return created
 
 
-def handle_rejection(conn: sqlite3.Connection, job: Any, reason: str) -> bool:
+def handle_rejection(
+    conn: sqlite3.Connection,
+    job: Any,
+    reason: str,
+    *,
+    deferred_fs: list[FsOp] | None = None,
+) -> bool:
     """Store rejection in DB, write to feedback_log, and move company folder to _rejected.
-    Drops a marker file named {reason}_{date}.txt inside the moved folder.
-    Returns True if a folder was moved."""
+
+    Drops a marker file named ``REJECTED_{reason}_{date}.txt`` inside the moved
+    folder. Returns True if a folder will be (or was) moved.
+
+    Args:
+        deferred_fs: When ``None`` (default), the helper commits the DB writes
+            and then executes filesystem ops inline. When a list is passed,
+            the helper appends fs ops to it as closures and does NOT commit;
+            the caller must commit and then execute each closure. See module
+            docstring.
+    """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
     old_stage = job["stage"]
     conn.execute(
@@ -90,35 +125,52 @@ def handle_rejection(conn: sqlite3.Connection, job: Any, reason: str) -> bool:
             (job["id"], job["title"], job["company"], job["relevance_score"], reason, jd_excerpt),
         )
 
-    # Move company folder to _rejected if it exists
+    # Stage folder move + marker write as deferred fs ops; DB row gets the
+    # post-move path eagerly so it commits atomically with the stage change.
     folder_moved = False
     folder = jd["prep_folder_path"] if jd else None
     if folder and os.path.isdir(folder):
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         # Derive companies_root from the folder being moved rather than the
-        # process-global `BASE`. The folder lives at `<companies_root>/<name>/`
-        # by convention, so `Path(folder).parent` recovers companies_root.
-        # `BASE`-relative paths broke fixture isolation under the full test
-        # suite — the move target landed at the operator's literal cwd, not
-        # `tmp_path` (#716). The other BASE-relative call sites in this file
-        # (handle_waitlist, handle_reactivate, un_reject, un_apply,
-        # un_withdraw_job) carry the same anti-pattern but aren't exercised
-        # by failing tests today — fix them when a test surfaces.
+        # process-global `BASE`. See #716 for the BASE-relative isolation bug.
         rejected_dir = str(Path(folder).parent / "_rejected")
-        os.makedirs(rejected_dir, exist_ok=True)
-        dest = os.path.join(rejected_dir, os.path.basename(folder))
-        shutil.move(folder, dest)
-        # Drop a marker file: filesystem-safe reason + date
+        folder_name = os.path.basename(folder)
+        dest = os.path.join(rejected_dir, folder_name)
         safe_reason = re.sub(r"[^\w\s-]", "", reason).strip().replace(" ", "_")[:60]
         date_str = datetime.now().strftime("%Y-%m-%d")
-        open(os.path.join(dest, f"REJECTED_{safe_reason}_{date_str}.txt"), "w").close()
+        marker_path = os.path.join(dest, f"REJECTED_{safe_reason}_{date_str}.txt")
+        src_folder: str = folder
+        job_id: str = job["id"]
+
+        def _move_and_mark(
+            src: str = src_folder,
+            d: str = dest,
+            rd: str = rejected_dir,
+            mp: str = marker_path,
+            jid: str = job_id,
+            fname: str = folder_name,
+            r: str = reason,
+        ) -> None:
+            os.makedirs(rd, exist_ok=True)
+            shutil.move(src, d)
+            open(mp, "w").close()
+            log_event("folder_moved_to_rejected", job_id=jid, folder=fname, reason=r)
+
+        fs_ops.append(_move_and_mark)
         conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
-        log_event("folder_moved_to_rejected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
         folder_moved = True
 
-    conn.commit()
-    write_audit(conn, job["id"], "stage", old_stage, "rejected")
-    write_audit(conn, job["id"], "reject_reason", "", reason)
+    if own_transaction:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", old_stage, "rejected", commit=own_transaction)
+    write_audit(conn, job["id"], "reject_reason", "", reason, commit=own_transaction)
     log_event("job_rejected", job_id=job["id"], company=job["company"], title=job["title"], reason=reason)
+
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
     return folder_moved
 
 
@@ -128,7 +180,7 @@ def handle_not_selected(
     reason: str,
     *,
     changed_by: str | None = None,
-    commit: bool = True,
+    deferred_fs: list[FsOp] | None = None,
 ) -> bool:
     """Company rejected the application. Sets stage=not_selected, drops a marker file.
 
@@ -142,12 +194,13 @@ def handle_not_selected(
             ``'gmail_rejection_detector'`` from the rejections-review confirm
             endpoint per spec §4.5.2 so the audit trail distinguishes
             operator-confirmed Gmail-detected rejections from manual flips.
-        commit: When False, skip the internal ``conn.commit()`` and propagate
-            ``commit=False`` to the inner ``write_audit`` calls so the caller
-            can compose this with another helper inside a single transaction
-            (used by ``reattribute_from_archive`` for atomic source-and-target
-            updates). Default True preserves existing single-call behavior.
+        deferred_fs: When ``None`` (default), commits and runs the marker
+            write inline. When a list, appends the marker write as a closure
+            and does NOT commit. See module docstring.
     """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
     old_stage = job["stage"]
     conn.execute(
@@ -155,27 +208,59 @@ def handle_not_selected(
         ("not_selected", reason, now, job["id"]),
     )
 
-    # Drop marker file in existing folder (stays in _applied/)
+    # Stage marker write as a deferred fs op (folder stays in _applied/).
     jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
     folder = jd["prep_folder_path"] if jd else None
     if folder and os.path.isdir(folder):
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         safe_reason = re.sub(r"[^\w\s-]", "", reason).strip().replace(" ", "_")[:60]
         date_str = datetime.now().strftime("%Y-%m-%d")
-        open(os.path.join(folder, f"NOT_SELECTED_{safe_reason}_{date_str}.txt"), "w").close()
-        log_event("marker_added_not_selected", job_id=job["id"], folder=os.path.basename(folder), reason=reason)
+        marker_path = os.path.join(folder, f"NOT_SELECTED_{safe_reason}_{date_str}.txt")
+        folder_name = os.path.basename(folder)
+        job_id: str = job["id"]
 
-    if commit:
+        def _write_marker(
+            mp: str = marker_path,
+            jid: str = job_id,
+            fname: str = folder_name,
+            r: str = reason,
+        ) -> None:
+            open(mp, "w").close()
+            log_event("marker_added_not_selected", job_id=jid, folder=fname, reason=r)
+
+        fs_ops.append(_write_marker)
+
+    if own_transaction:
         conn.commit()
-    write_audit(conn, job["id"], "stage", old_stage, "not_selected", changed_by=changed_by, commit=commit)
-    write_audit(conn, job["id"], "reject_reason", "", reason, changed_by=changed_by, commit=commit)
+    write_audit(conn, job["id"], "stage", old_stage, "not_selected", changed_by=changed_by, commit=own_transaction)
+    write_audit(conn, job["id"], "reject_reason", "", reason, changed_by=changed_by, commit=own_transaction)
     log_event("job_not_selected", job_id=job["id"], company=job["company"], title=job["title"], reason=reason)
+
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
     return False
 
 
-def handle_waitlist(conn: sqlite3.Connection, job: Any) -> bool:
+def handle_waitlist(
+    conn: sqlite3.Connection,
+    job: Any,
+    *,
+    deferred_fs: list[FsOp] | None = None,
+) -> bool:
     """Move job to waitlisted stage and folder to _waitlisted/.
-    Returns True if a folder was moved, False otherwise.
-    Does NOT write to feedback_log — waitlisting is not rejection."""
+
+    Returns True if a folder will be (or was) moved, False otherwise. Does
+    NOT write to feedback_log — waitlisting is not rejection.
+
+    Args:
+        deferred_fs: See module docstring.
+    """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
     old_stage = job["stage"]
     conn.execute("UPDATE jobs SET stage=?, updated_at=? WHERE id=?", ("waitlisted", now, job["id"]))
@@ -184,32 +269,71 @@ def handle_waitlist(conn: sqlite3.Connection, job: Any) -> bool:
     jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
     folder = jd["prep_folder_path"] if jd else None
     if folder and os.path.isdir(folder):
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         waitlisted_dir = os.path.join(BASE, "companies", "_waitlisted")
-        os.makedirs(waitlisted_dir, exist_ok=True)
         dest = os.path.join(waitlisted_dir, os.path.basename(folder))
-        shutil.move(folder, dest)
+        src_folder: str = folder
+        folder_name = os.path.basename(folder)
+        job_id: str = job["id"]
+
+        def _move_to_waitlisted(
+            src: str = src_folder,
+            d: str = dest,
+            wd: str = waitlisted_dir,
+            jid: str = job_id,
+            fname: str = folder_name,
+        ) -> None:
+            os.makedirs(wd, exist_ok=True)
+            shutil.move(src, d)
+            log_event("folder_moved_to_waitlisted", job_id=jid, folder=fname)
+
+        fs_ops.append(_move_to_waitlisted)
         conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
-        log_event("folder_moved_to_waitlisted", job_id=job["id"], folder=os.path.basename(folder))
         folder_moved = True
 
-    conn.commit()
-    write_audit(conn, job["id"], "stage", old_stage, "waitlisted")
+    if own_transaction:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", old_stage, "waitlisted", commit=own_transaction)
     log_event("job_waitlisted", job_id=job["id"], company=job["company"], title=job["title"])
+
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
     return folder_moved
 
 
-def handle_reactivate(conn: sqlite3.Connection, job: Any) -> bool:
+def handle_reactivate(
+    conn: sqlite3.Connection,
+    job: Any,
+    *,
+    deferred_fs: list[FsOp] | None = None,
+) -> bool:
     """Restore a waitlisted job to scored or materials_drafted.
-    Returns True if a folder was moved back."""
+
+    Returns True if a folder will be (or was) moved back.
+
+    Args:
+        deferred_fs: See module docstring.
+    """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
     jd = conn.execute("SELECT prep_folder_path FROM jobs WHERE id=?", (job["id"],)).fetchone()
     folder = jd["prep_folder_path"] if jd else None
     folder_moved = False
 
     if folder and os.path.isdir(folder):
-        # Move folder back from _waitlisted/ to companies/
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         dest = os.path.join(BASE, "companies", os.path.basename(folder))
-        shutil.move(folder, dest)
+        src_folder: str = folder
+
+        def _move_from_waitlisted(src: str = src_folder, d: str = dest) -> None:
+            shutil.move(src, d)
+
+        fs_ops.append(_move_from_waitlisted)
         conn.execute(
             "UPDATE jobs SET stage=?, prep_folder_path=?, updated_at=? WHERE id=?",
             ("materials_drafted", dest, now, job["id"]),
@@ -220,9 +344,16 @@ def handle_reactivate(conn: sqlite3.Connection, job: Any) -> bool:
         conn.execute("UPDATE jobs SET stage=?, updated_at=? WHERE id=?", ("scored", now, job["id"]))
         new_stage = "scored"
 
-    conn.commit()
-    write_audit(conn, job["id"], "stage", "waitlisted", new_stage)
+    if own_transaction:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", "waitlisted", new_stage, commit=own_transaction)
     log_event("job_reactivated", job_id=job["id"], company=job["company"], title=job["title"], stage=new_stage)
+
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
     return folder_moved
 
 
@@ -390,7 +521,7 @@ def un_reject_job(
     job: Any,
     overwrite_fields: dict[str, str],
     *,
-    commit: bool = True,
+    deferred_fs: list[FsOp] | None = None,
 ) -> None:
     """Reverse a user rejection: restore to scored, delete feedback_log rows.
 
@@ -399,11 +530,11 @@ def un_reject_job(
     Deletes feedback_log rows so the scorer's feedback loop stays clean.
 
     Args:
-        commit: When False, skip the internal ``conn.commit()`` and propagate
-            ``commit=False`` to the inner ``write_audit`` calls so the caller
-            can compose this with another helper inside a single transaction.
-            Default True preserves existing single-call behavior.
+        deferred_fs: See module docstring.
     """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
 
     set_parts = ["stage='scored'", "reject_reason=''", "relevance_score=8", "updated_at=?"]
@@ -416,19 +547,43 @@ def un_reject_job(
 
     folder = job["prep_folder_path"] if job["prep_folder_path"] else None
     if folder and os.path.isdir(folder):
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         dest = os.path.join(BASE, "companies", os.path.basename(folder))
-        shutil.move(folder, dest)
-        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
-        log_event("folder_moved_from_rejected", job_id=job["id"], folder=os.path.basename(folder))
+        src_folder: str = folder
+        folder_name = os.path.basename(folder)
+        job_id: str = job["id"]
 
-    if commit:
+        def _move_from_rejected(
+            src: str = src_folder,
+            d: str = dest,
+            jid: str = job_id,
+            fname: str = folder_name,
+        ) -> None:
+            shutil.move(src, d)
+            log_event("folder_moved_from_rejected", job_id=jid, folder=fname)
+
+        fs_ops.append(_move_from_rejected)
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
+
+    if own_transaction:
         conn.commit()
-    write_audit(conn, job["id"], "stage", "rejected", "scored", commit=commit)
-    write_audit(conn, job["id"], "reject_reason", job["reject_reason"] or "", "", commit=commit)
+    write_audit(conn, job["id"], "stage", "rejected", "scored", commit=own_transaction)
+    write_audit(conn, job["id"], "reject_reason", job["reject_reason"] or "", "", commit=own_transaction)
     log_event("job_un_rejected", job_id=job["id"], company=job["company"], title=job["title"])
 
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
 
-def un_not_selected_job(conn: sqlite3.Connection, job: Any, *, commit: bool = True) -> str:
+
+def un_not_selected_job(
+    conn: sqlite3.Connection,
+    job: Any,
+    *,
+    deferred_fs: list[FsOp] | None = None,
+) -> str:
     """Reverse a company-not-selected stage: restore the prior stage from
     audit_log, clear the reject_reason, delete all NOT_SELECTED_*.txt marker
     files from the job's folder.
@@ -443,12 +598,11 @@ def un_not_selected_job(conn: sqlite3.Connection, job: Any, *, commit: bool = Tr
     keeps the folder in companies/_applied/).
 
     Args:
-        commit: When False, skip the internal ``conn.commit()`` and propagate
-            ``commit=False`` to the inner ``write_audit`` calls so the caller
-            can compose this with another helper inside a single transaction
-            (used by ``reattribute_from_archive`` for atomic source-and-target
-            updates). Default True preserves existing single-call behavior.
+        deferred_fs: See module docstring.
     """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
 
     prior = conn.execute(
@@ -466,19 +620,37 @@ def un_not_selected_job(conn: sqlite3.Connection, job: Any, *, commit: bool = Tr
 
     folder = job["prep_folder_path"] if job["prep_folder_path"] else None
     if folder and os.path.isdir(folder):
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
+        # Snapshot the marker list at planning time so a deferred caller
+        # gets the same set of markers it would have deleted today. Each
+        # closure binds its own ``mp`` via default-arg trick — without it,
+        # lazy capture would bind every closure to the final iteration's
+        # ``marker_path``.
+        folder_name = os.path.basename(folder)
+        job_id: str = job["id"]
         for marker_path in glob.glob(os.path.join(folder, "NOT_SELECTED_*.txt")):
-            os.remove(marker_path)
-            log_event(
-                "marker_removed_not_selected",
-                job_id=job["id"],
-                folder=os.path.basename(folder),
-                marker=os.path.basename(marker_path),
-            )
 
-    if commit:
+            def _remove_marker(
+                mp: str = marker_path,
+                jid: str = job_id,
+                fname: str = folder_name,
+            ) -> None:
+                os.remove(mp)
+                log_event(
+                    "marker_removed_not_selected",
+                    job_id=jid,
+                    folder=fname,
+                    marker=os.path.basename(mp),
+                )
+
+            fs_ops.append(_remove_marker)
+
+    if own_transaction:
         conn.commit()
-    write_audit(conn, job["id"], "stage", "not_selected", restored_stage, changed_by="user", commit=commit)
-    write_audit(conn, job["id"], "reject_reason", job["reject_reason"] or "", "", changed_by="user", commit=commit)
+    write_audit(conn, job["id"], "stage", "not_selected", restored_stage, changed_by="user", commit=own_transaction)
+    write_audit(
+        conn, job["id"], "reject_reason", job["reject_reason"] or "", "", changed_by="user", commit=own_transaction
+    )
     log_event(
         "job_un_not_selected",
         job_id=job["id"],
@@ -486,10 +658,21 @@ def un_not_selected_job(conn: sqlite3.Connection, job: Any, *, commit: bool = Tr
         title=job["title"],
         restored_stage=restored_stage,
     )
+
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
     return restored_stage
 
 
-def un_withdraw_job(conn: sqlite3.Connection, job: Any, *, commit: bool = True) -> str:
+def un_withdraw_job(
+    conn: sqlite3.Connection,
+    job: Any,
+    *,
+    deferred_fs: list[FsOp] | None = None,
+) -> str:
     """Reverse a withdraw: restore the prior stage from audit_log
     (typically applied/interview/offer).
 
@@ -501,14 +684,15 @@ def un_withdraw_job(conn: sqlite3.Connection, job: Any, *, commit: bool = True) 
     Unlike un_not_selected_job, there is no marker file to delete (withdraw
     never wrote one) and no folder to touch (withdraw doesn't move folders).
     Unlike un_reject_job, no feedback_log row exists (withdraw doesn't
-    write to feedback_log). Pure stage restoration.
+    write to feedback_log). Pure stage restoration — ``deferred_fs`` exists
+    only for caller-composition uniformity; the list stays empty.
 
     Args:
-        commit: When False, skip the internal ``conn.commit()`` and propagate
-            ``commit=False`` to the inner ``write_audit`` call so the caller
-            can compose this with another helper inside a single transaction.
-            Default True preserves existing single-call behavior.
+        deferred_fs: See module docstring. Always appends zero closures for
+            this helper (no fs ops); accepted for API parity.
     """
+    own_transaction = deferred_fs is None
+
     now = datetime.now(UTC).isoformat()
 
     prior = conn.execute(
@@ -523,9 +707,9 @@ def un_withdraw_job(conn: sqlite3.Connection, job: Any, *, commit: bool = True) 
         "UPDATE jobs SET stage=?, updated_at=? WHERE id=?",
         (restored_stage, now, job["id"]),
     )
-    if commit:
+    if own_transaction:
         conn.commit()
-    write_audit(conn, job["id"], "stage", "withdrawn", restored_stage, changed_by="user", commit=commit)
+    write_audit(conn, job["id"], "stage", "withdrawn", restored_stage, changed_by="user", commit=own_transaction)
     log_event(
         "job_un_withdrawn", job_id=job["id"], company=job["company"], title=job["title"], restored_stage=restored_stage
     )
@@ -554,6 +738,7 @@ def un_apply_job(conn: sqlite3.Connection, job: Any) -> None:
     folder = jd["prep_folder_path"] if jd and jd["prep_folder_path"] else None
     new_path = folder  # default: keep whatever path is on the row
     if folder and os.path.isdir(folder):
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         # Move folder back from _applied/ to companies/
         dest = os.path.join(BASE, "companies", os.path.basename(folder))
         shutil.move(folder, dest)
@@ -601,6 +786,7 @@ def reactivate_from_ingest(conn: sqlite3.Connection, job: Any, overwrite_fields:
 
     folder = job["prep_folder_path"] if job["prep_folder_path"] else None
     if folder and os.path.isdir(folder):
+        assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         dest = os.path.join(BASE, "companies", os.path.basename(folder))
         shutil.move(folder, dest)
         conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -15,6 +15,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+from collections.abc import Callable
 from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
@@ -1313,13 +1314,15 @@ def reattribute_from_archive(
 ) -> HTMLResponse:
     """Reattribute the rejection from the current not_selected row to a
     different job. Calls un_not_selected_job on current row (restores prior
-    stage, deletes marker files), then handle_not_selected on target with
-    changed_by='archive_reattribute'.
+    stage, queues marker-file deletions), then handle_not_selected on target
+    with changed_by='archive_reattribute' (queues marker-file write).
 
-    Both helpers run with ``commit=False`` and a single trailing
-    ``db.commit()`` so source-restore + target-mark land atomically — if
-    either raises mid-call, neither is persisted and the operator sees the
-    error rather than a half-applied reattribution.
+    Both helpers share a ``deferred_fs`` list so source-restore + target-mark
+    land atomically: DB writes accumulate, a single trailing ``db.commit()``
+    persists them, then the queued filesystem ops execute in order. If
+    either helper raises mid-call, neither DB writes nor filesystem changes
+    have happened — the operator sees the error rather than a half-applied
+    reattribution (#709, supersedes the ``commit=False`` shape from #707).
 
     Atomic: 404 on unknown source or target; 409 if source stage !=
     'not_selected' or if target_fingerprint missing/blank.
@@ -1346,12 +1349,16 @@ def reattribute_from_archive(
 
     final_reason = (reason or "").strip() or "Reattributed"
 
+    deferred_fs: list[Callable[[], None]] = []
     try:
-        un_not_selected_job(db, source, commit=False)
-        handle_not_selected(db, target, final_reason, changed_by="archive_reattribute", commit=False)
+        un_not_selected_job(db, source, deferred_fs=deferred_fs)
+        handle_not_selected(db, target, final_reason, changed_by="archive_reattribute", deferred_fs=deferred_fs)
         db.commit()
     except Exception:
         db.rollback()
         raise
+
+    for fs_op in deferred_fs:
+        fs_op()
 
     return HTMLResponse("")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -10,10 +10,12 @@ import json
 import os
 import sqlite3
 import uuid
+from pathlib import Path
 
 import pytest
 
 from findajob import actions, audit
+from findajob.paths import BASE
 
 SCHEMA = """
 CREATE TABLE jobs (
@@ -942,20 +944,27 @@ def test_handle_rejection_skips_feedback_log_for_synthetic(tmp_path, monkeypatch
     assert real_after["stage"] == "rejected"
 
 
-# ── commit=False atomic-composition kwarg (#707) ────────────────────────────
+# ── deferred_fs atomic-composition kwarg (#709, supersedes #707 commit=False) ──
 
 
-class TestActionsCommitFalse:
-    """Every helper that grew a ``commit=True`` kwarg in #707 must, when
-    called with ``commit=False``, leave its UPDATEs and audit INSERTs inside
-    an open transaction so the caller can compose multiple helpers and commit
-    (or rollback) atomically. The contract is verified by issuing
-    ``conn.rollback()`` after the call and asserting every write disappeared.
+class TestActionsDeferredFs:
+    """Every helper that touches DB+filesystem must, when called with
+    ``deferred_fs=[]``, leave its UPDATEs, audit INSERTs, AND filesystem
+    mutations pending: the DB writes stay in the open transaction, and the
+    fs ops are appended as closures to the passed list (not executed). The
+    contract is verified by issuing ``conn.rollback()`` WITHOUT executing
+    the closures and asserting every DB and disk side effect disappeared.
+
+    This is the regression net for #709: previously fs ops ran inline before
+    the commit decision, so a rollback reverted the DB while leaving the
+    filesystem half-applied.
     """
 
-    def test_un_reject_job_commit_false_is_rollback_safe(self, db, tmp_path):
-        folder = tmp_path / "companies" / "_rejected" / "Acme_Ops_commit_false"
+    def test_un_reject_job_deferred_fs_is_rollback_safe(self, db, tmp_path):
+        folder = tmp_path / "companies" / "_rejected" / "Acme_Ops_deferred"
         folder.mkdir(parents=True)
+        marker = folder / "REJECTED_Wrong_Level_2026-05-18.txt"
+        marker.touch()
         job = insert_job(db, stage="rejected", folder=str(folder), score=2)
         db.execute("UPDATE jobs SET reject_reason='Wrong Level' WHERE id=?", (job["id"],))
         db.execute(
@@ -965,14 +974,20 @@ class TestActionsCommitFalse:
         )
         db.commit()
         job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        expected_dest = Path(BASE) / "companies" / folder.name
 
-        actions.un_reject_job(db, job, overwrite_fields={}, commit=False)
+        deferred: list = []
+        actions.un_reject_job(db, job, overwrite_fields={}, deferred_fs=deferred)
         # Pre-rollback: caller sees the staged change
         assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "scored"
+        # Pre-rollback: fs op queued but NOT executed — folder still at _rejected/
+        assert folder.exists(), "deferred_fs must not execute fs ops"
+        assert not expected_dest.exists()
+        assert len(deferred) == 1
 
         db.rollback()
 
-        # Post-rollback: every write reversed — UPDATE, feedback_log DELETE, audit INSERTs
+        # Post-rollback: every DB write reversed
         row = db.execute("SELECT stage, reject_reason FROM jobs WHERE id=?", (job["id"],)).fetchone()
         assert row["stage"] == "rejected"
         assert row["reject_reason"] == "Wrong Level"
@@ -980,9 +995,22 @@ class TestActionsCommitFalse:
         assert fb_count == 1, "DELETE on feedback_log must roll back too"
         audits = db.execute("SELECT * FROM audit_log WHERE job_id=?", (job["id"],)).fetchall()
         assert len(audits) == 0
+        # Post-rollback: filesystem state still pre-call (folder + marker untouched)
+        assert folder.exists()
+        assert marker.exists()
+        assert not expected_dest.exists()
 
-    def test_un_not_selected_job_commit_false_is_rollback_safe(self, db):
-        job = insert_job(db, stage="not_selected")
+    def test_un_not_selected_job_deferred_fs_is_rollback_safe(self, db, tmp_path):
+        # Fixture surgery (#709): the previous version of this test seeded
+        # the job without a folder, so there was no fs side effect to assert
+        # against. Now seed a folder + marker so the rollback assertion can
+        # verify the marker survives an un-not-selected rollback.
+        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_deferred"
+        folder.mkdir(parents=True)
+        marker = folder / "NOT_SELECTED_Company_passed_2026-05-18.txt"
+        marker.touch()
+
+        job = insert_job(db, stage="not_selected", folder=str(folder))
         db.execute(
             "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
             "VALUES (?, 'stage', 'applied', 'not_selected', datetime('now'), 'user')",
@@ -993,8 +1021,12 @@ class TestActionsCommitFalse:
         job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
         seed_audit_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
 
-        actions.un_not_selected_job(db, job, commit=False)
+        deferred: list = []
+        actions.un_not_selected_job(db, job, deferred_fs=deferred)
         assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "applied"
+        # Pre-rollback: marker delete queued but NOT executed
+        assert marker.exists(), "deferred_fs must not execute fs ops"
+        assert len(deferred) == 1
 
         db.rollback()
 
@@ -1004,8 +1036,60 @@ class TestActionsCommitFalse:
         # Only the seed audit row survives — no new audit rows from the rolled-back call
         post_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
         assert post_count == seed_audit_count
+        # Post-rollback: marker still on disk — the deferred delete never ran
+        assert marker.exists()
 
-    def test_un_withdraw_job_commit_false_is_rollback_safe(self, db):
+    def test_un_not_selected_job_multiple_markers_each_closure_binds_its_own_path(self, db, tmp_path):
+        """Regression net for closure lazy-capture in the marker-glob loop.
+
+        With naive ``lambda: os.remove(marker_path)`` the closure binds to the
+        loop variable, not the per-iteration value — every closure ends up
+        targeting the LAST marker path, so executing the deferred list deletes
+        that one file N times and leaves the others on disk. The default-arg
+        trick ``def _remove_marker(mp=marker_path)`` defeats this by eager-
+        binding ``mp`` at closure definition time.
+
+        Seeding two markers and asserting both queued closures resolve to
+        distinct paths catches a regression that a single-marker test cannot.
+        """
+        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_multi"
+        folder.mkdir(parents=True)
+        marker_a = folder / "NOT_SELECTED_Wrong_Level_2026-05-18.txt"
+        marker_b = folder / "NOT_SELECTED_Company_passed_2026-05-19.txt"
+        marker_a.touch()
+        marker_b.touch()
+
+        job = insert_job(db, stage="not_selected", folder=str(folder))
+        db.execute(
+            "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
+            "VALUES (?, 'stage', 'applied', 'not_selected', datetime('now'), 'user')",
+            (job["id"],),
+        )
+        db.commit()
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        deferred: list = []
+        actions.un_not_selected_job(db, job, deferred_fs=deferred)
+        assert len(deferred) == 2, "one closure per marker"
+        # Pre-execute: both markers still on disk (deferred_fs blocks fs ops)
+        assert marker_a.exists()
+        assert marker_b.exists()
+
+        # Execute the deferred ops. Both markers must be deleted — if lazy
+        # capture were broken, both closures would target the same path,
+        # one os.remove() call would raise FileNotFoundError on the second
+        # invocation, AND only one marker would actually disappear.
+        db.commit()
+        for op in deferred:
+            op()
+
+        assert not marker_a.exists()
+        assert not marker_b.exists()
+
+    def test_un_withdraw_job_deferred_fs_is_rollback_safe(self, db):
+        # un_withdraw_job has no fs ops; the kwarg exists for caller-composition
+        # uniformity. Verify the helper still returns the restored stage and
+        # leaves the DB writes pending.
         job = insert_job(db, stage="withdrawn")
         db.execute(
             "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
@@ -1016,8 +1100,10 @@ class TestActionsCommitFalse:
         job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
         seed_audit_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
 
-        actions.un_withdraw_job(db, job, commit=False)
+        deferred: list = []
+        actions.un_withdraw_job(db, job, deferred_fs=deferred)
         assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "applied"
+        assert deferred == [], "un_withdraw_job has no fs ops"
 
         db.rollback()
 
@@ -1025,13 +1111,17 @@ class TestActionsCommitFalse:
         post_count = db.execute("SELECT COUNT(*) FROM audit_log WHERE job_id=?", (job["id"],)).fetchone()[0]
         assert post_count == seed_audit_count
 
-    def test_handle_not_selected_commit_false_is_rollback_safe(self, db, tmp_path):
-        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_commit_false"
+    def test_handle_not_selected_deferred_fs_is_rollback_safe(self, db, tmp_path):
+        folder = tmp_path / "companies" / "_applied" / "Acme_Ops_deferred"
         folder.mkdir(parents=True)
         job = insert_job(db, stage="applied", folder=str(folder))
 
-        actions.handle_not_selected(db, job, "Too Senior", commit=False)
+        deferred: list = []
+        actions.handle_not_selected(db, job, "Too Senior", deferred_fs=deferred)
         assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "not_selected"
+        # Pre-rollback: marker write queued but NOT executed
+        assert list(folder.glob("NOT_SELECTED_*.txt")) == [], "deferred_fs must not execute fs ops"
+        assert len(deferred) == 1
 
         db.rollback()
 
@@ -1040,3 +1130,5 @@ class TestActionsCommitFalse:
         assert row["reject_reason"] == ""
         audits = db.execute("SELECT * FROM audit_log WHERE job_id=?", (job["id"],)).fetchall()
         assert len(audits) == 0
+        # Post-rollback: no marker file on disk (the deferred write never ran)
+        assert list(folder.glob("NOT_SELECTED_*.txt")) == []

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -2189,17 +2189,29 @@ class TestReattributeFromArchive:
         assert response.status_code == 409
 
     def test_handle_not_selected_failure_rolls_back_source_restore(self, client: TestClient, monkeypatch):
-        """#707 — both helpers run with commit=False inside a single
+        """#707 + #709 — both helpers run with deferred_fs inside a single
         transaction; if handle_not_selected raises mid-call, db.rollback() in
-        the route's except branch undoes the source un-not-selected too. The
-        operator sees the error and can retry, rather than discovering a
-        half-applied reattribution with source restored and target unchanged.
+        the route's except branch undoes the source un-not-selected, AND the
+        queued filesystem ops (marker delete on source, marker write on
+        target) never execute. The operator sees the error and can retry,
+        rather than discovering a half-applied reattribution with the source
+        marker file already deleted but the DB un-restored.
         """
         from findajob.web.routes import board_actions
 
+        # Seed source folder + NOT_SELECTED_*.txt marker so the rollback can
+        # be verified to leave the filesystem untouched (#709).
+        src_folder = client._tmp_path / "companies" / "_applied" / "Acme_Ops_rollback"
+        src_folder.mkdir(parents=True)
+        src_marker = src_folder / "NOT_SELECTED_Company_passed_2026-05-18.txt"
+        src_marker.touch()
+
         conn = sqlite3.connect(client._db_path)
         src_id = _insert_job(conn, fingerprint="fp_src_rollback", stage="not_selected")
-        conn.execute("UPDATE jobs SET reject_reason='Company passed' WHERE id=?", (src_id,))
+        conn.execute(
+            "UPDATE jobs SET reject_reason='Company passed', prep_folder_path=? WHERE id=?",
+            (str(src_folder), src_id),
+        )
         conn.execute(
             "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at, changed_by) "
             "VALUES (?, 'stage', 'applied', 'not_selected', datetime('now'), 'user')",
@@ -2247,6 +2259,13 @@ class TestReattributeFromArchive:
         ).fetchall()
         assert tgt_audits == []
         conn.close()
+
+        # Filesystem unchanged (#709): the source's marker file survived
+        # the failed reattribution — un_not_selected_job staged the delete
+        # via deferred_fs, the route's except branch caught the failure
+        # before db.commit(), so the deferred closures never ran.
+        assert src_marker.exists()
+        assert src_folder.exists()
 
 
 # ── /board/jobs/search handler ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #709. The 7 action helpers in `findajob.actions` (`handle_rejection`, `handle_not_selected`, `handle_waitlist`, `handle_reactivate`, `un_reject_job`, `un_not_selected_job`, `un_withdraw_job`) previously ran filesystem mutations (folder moves into `_rejected/`/`_waitlisted/`, `NOT_SELECTED_*.txt` marker create/delete) **before** their commit decision. `conn.rollback()` reverted DB writes but left filesystem mutations on disk — the failure surface that #707's `commit=False` kwarg made composable was still missing fs atomicity.

Replaces the older `commit=False` kwarg with a unified `deferred_fs: list[Callable] | None` kwarg. When `None` (default), the helper commits and runs fs ops inline; when a list, fs ops are appended as zero-arg closures and execution is deferred to the caller after their `conn.commit()`.

`reattribute_from_archive` (the original failure-mode site) now drives one `db.commit()` across both helpers followed by a single `for op in deferred: op()` loop — a failure before commit leaves both the DB and the filesystem fully un-mutated.

## Failure-mode direction flips (strictly better than today)

The issue body's Smart-tier check called the new window "even worse than today." It isn't — the direction matters:

- **Today (fs-then-DB):** fs op succeeds, DB fails → folder is in `_rejected/` but `stage='scored'`. Dashboard re-surfaces it. User re-acts. **Correctness broken.**
- **New (DB-then-fs):** DB succeeds, fs op fails → `stage='rejected'` but folder still in `companies/`. DB is authoritative; markers are forensic-only. **Cosmetic disk artifact at worst.**

Don't relitigate this window in a future PR — DB-then-fs is the strictly better failure mode for both fs-op classes in findajob (folder moves where DB carries the authoritative stage, marker files that are forensic-only).

## Closure capture

`un_not_selected_job`'s marker delete is inside a `for marker_path in glob.glob(...)` loop. Naïve `lambda: os.remove(marker_path)` would lazy-bind every closure to the **last** iteration's path. The default-arg trick (`def _remove_marker(mp: str = marker_path)`) eager-binds per iteration. A new 2-marker regression test (`test_un_not_selected_job_multiple_markers_each_closure_binds_its_own_path`) asserts both closures resolve to distinct paths — a single-marker test cannot catch this regression.

## Out of scope

`un_apply_job` and `reactivate_from_ingest` have the same fs-then-DB shape but are not in AC#2's seven. Will file a follow-up issue.

## Test plan

- [x] `uv run pytest tests/test_actions.py tests/test_actions_resurface.py tests/test_board_actions.py` (256 passed)
- [x] `uv run pytest` full suite (2806 passed, 1 skipped)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run mypy src/findajob/actions.py src/findajob/web/routes/board_actions.py`
- [x] New rollback tests on each `commit=False`→`deferred_fs` test grow filesystem-state assertions (folder/marker absent before execution, present after rollback when fs ops never ran)
- [x] `test_handle_not_selected_failure_rolls_back_source_restore` grows source-marker assertion: marker survives the failed reattribute because deferred fs never executes
- [x] 2-marker glob-loop regression test
- [ ] Browser smoke (not run — pure refactor, no UI surface; HTTP-layer tests in `test_board_actions.py` cover the route behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)