### PR TITLE
refactor(actions): #726 — un_apply_job + reactivate_from_ingest gain deferred_fs

### DIFF
--- a/src/findajob/actions.py
+++ b/src/findajob/actions.py
@@ -716,7 +716,12 @@ def un_withdraw_job(
     return restored_stage
 
 
-def un_apply_job(conn: sqlite3.Connection, job: Any) -> None:
+def un_apply_job(
+    conn: sqlite3.Connection,
+    job: Any,
+    *,
+    deferred_fs: list[FsOp] | None = None,
+) -> None:
     """Reverse a recent /apply (#699): move folder back from companies/_applied/
     to companies/, delete the *.applied-YYYY-MM-DD.md snapshot siblings written
     by snapshot_applied_md_files, flip stage to materials_drafted, clear
@@ -729,7 +734,17 @@ def un_apply_job(conn: sqlite3.Connection, job: Any) -> None:
     materials_drafted rows have apply_flag=1. The asymmetry is intentional — an
     un-applied row is "draft I had decided to send, then changed my mind", not
     "draft pending dispatch", so the flag-zero state is correct.
+
+    Args:
+        deferred_fs: See module docstring. The single closure performs the
+            folder move AND the snapshot deletes in one pass; the snapshot
+            glob iterates at execution time (at the post-move destination),
+            so there's no closure-capture trap from collecting per-file
+            closures inside a loop (#709 pattern).
     """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
 
     # Re-fetch prep_folder_path from the DB so callers can pass any row shape
@@ -739,28 +754,42 @@ def un_apply_job(conn: sqlite3.Connection, job: Any) -> None:
     new_path = folder  # default: keep whatever path is on the row
     if folder and os.path.isdir(folder):
         assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
-        # Move folder back from _applied/ to companies/
         dest = os.path.join(BASE, "companies", os.path.basename(folder))
-        shutil.move(folder, dest)
         new_path = dest
-        log_event("folder_moved_from_applied", job_id=job["id"], folder=os.path.basename(folder))
+        src_folder: str = folder
+        dest_folder: str = dest
+        folder_name = os.path.basename(folder)
+        job_id: str = job["id"]
 
-        # Delete only files matching the exact snapshot regex (mirrors
-        # snapshot_applied_md_files's filter — not a glob, which would
-        # also match incidentally-named files).
-        dest_path = Path(dest)
-        for md in dest_path.glob("*.md"):
-            if _APPLIED_SNAPSHOT_RE.search(md.name):
-                md.unlink()
-                log_event("snapshot_removed_for_un_apply", job_id=job["id"], snapshot=md.name)
+        def _move_and_clean_snapshots(
+            src: str = src_folder,
+            d: str = dest_folder,
+            jid: str = job_id,
+            fname: str = folder_name,
+        ) -> None:
+            # Single closure: glob iteration happens at execution time on the
+            # post-move folder, so collapsing the per-file deletes inside the
+            # loop into one closure body sidesteps the lazy-capture trap that
+            # bit un_not_selected_job in #709.
+            shutil.move(src, d)
+            log_event("folder_moved_from_applied", job_id=jid, folder=fname)
+            for md in Path(d).glob("*.md"):
+                if _APPLIED_SNAPSHOT_RE.search(md.name):
+                    md.unlink()
+                    log_event("snapshot_removed_for_un_apply", job_id=jid, snapshot=md.name)
+
+        fs_ops.append(_move_and_clean_snapshots)
 
     conn.execute(
         "UPDATE jobs SET stage='materials_drafted', apply_flag=0, prep_folder_path=?, "
         "stage_updated=?, updated_at=? WHERE id=?",
         (new_path, now, now, job["id"]),
     )
-    conn.commit()
-    write_audit(conn, job["id"], "stage", "applied", "materials_drafted", changed_by="web_un_apply")
+    if own_transaction:
+        conn.commit()
+    write_audit(
+        conn, job["id"], "stage", "applied", "materials_drafted", changed_by="web_un_apply", commit=own_transaction
+    )
     log_event(
         "job_un_applied",
         job_id=job["id"],
@@ -768,13 +797,31 @@ def un_apply_job(conn: sqlite3.Connection, job: Any) -> None:
         title=job["title"],
     )
 
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
 
-def reactivate_from_ingest(conn: sqlite3.Connection, job: Any, overwrite_fields: dict[str, str]) -> None:
+
+def reactivate_from_ingest(
+    conn: sqlite3.Connection,
+    job: Any,
+    overwrite_fields: dict[str, str],
+    *,
+    deferred_fs: list[FsOp] | None = None,
+) -> None:
     """Reactivate a waitlisted job via manual ingest.
 
     Sets stage=scored, relevance_score=8, overwrites non-blank submitted
     fields, moves prep folder from _waitlisted/ back to companies/.
+
+    Args:
+        deferred_fs: See module docstring.
     """
+    own_transaction = deferred_fs is None
+    fs_ops: list[FsOp] = []
+
     now = datetime.now(UTC).isoformat()
 
     set_parts = ["stage='scored'", "relevance_score=8", "updated_at=?"]
@@ -788,13 +835,32 @@ def reactivate_from_ingest(conn: sqlite3.Connection, job: Any, overwrite_fields:
     if folder and os.path.isdir(folder):
         assert isinstance(folder, str)  # mypy narrowing — prep_folder_path is TEXT
         dest = os.path.join(BASE, "companies", os.path.basename(folder))
-        shutil.move(folder, dest)
-        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
-        log_event("folder_moved_from_waitlisted", job_id=job["id"], folder=os.path.basename(folder))
+        src_folder: str = folder
+        folder_name = os.path.basename(folder)
+        job_id: str = job["id"]
 
-    conn.commit()
-    write_audit(conn, job["id"], "stage", "waitlisted", "scored")
+        def _move_from_waitlisted(
+            src: str = src_folder,
+            d: str = dest,
+            jid: str = job_id,
+            fname: str = folder_name,
+        ) -> None:
+            shutil.move(src, d)
+            log_event("folder_moved_from_waitlisted", job_id=jid, folder=fname)
+
+        fs_ops.append(_move_from_waitlisted)
+        conn.execute("UPDATE jobs SET prep_folder_path=? WHERE id=?", (dest, job["id"]))
+
+    if own_transaction:
+        conn.commit()
+    write_audit(conn, job["id"], "stage", "waitlisted", "scored", commit=own_transaction)
     log_event("job_reactivated_via_ingest", job_id=job["id"], company=job["company"], title=job["title"])
+
+    if deferred_fs is None:
+        for op in fs_ops:
+            op()
+    else:
+        deferred_fs.extend(fs_ops)
 
 
 def refresh_active_job(conn: sqlite3.Connection, job: Any, overwrite_fields: dict[str, str]) -> None:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1132,3 +1132,131 @@ class TestActionsDeferredFs:
         assert len(audits) == 0
         # Post-rollback: no marker file on disk (the deferred write never ran)
         assert list(folder.glob("NOT_SELECTED_*.txt")) == []
+
+    def test_un_apply_job_deferred_fs_is_rollback_safe(self, db, tmp_path):
+        """#726 — un_apply_job participates in the deferred_fs contract.
+
+        Seed an applied row with a folder in `_applied/` containing a
+        snapshot `.applied-YYYY-MM-DD.md` file. Verify that ``deferred_fs=[]``
+        leaves both the folder and the snapshot on disk pre-execution, that
+        rollback restores DB state, and that the deferred closures haven't
+        run (so the snapshot is still on disk).
+        """
+        applied_dir = tmp_path / "companies" / "_applied"
+        applied_dir.mkdir(parents=True, exist_ok=True)
+        folder = applied_dir / "Acme_Ops_un_apply_deferred"
+        folder.mkdir()
+        snapshot = folder / "resume.applied-2026-05-18.md"
+        snapshot.write_text("snapshot content")
+
+        job = insert_job(db, stage="applied", folder=str(folder))
+        db.commit()
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        deferred: list = []
+        actions.un_apply_job(db, job, deferred_fs=deferred)
+        # Pre-rollback: DB shows new state
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "materials_drafted"
+        # Pre-rollback: fs op queued but NOT executed — folder + snapshot still in place
+        assert folder.exists(), "deferred_fs must not execute fs ops"
+        assert snapshot.exists()
+        assert len(deferred) == 1
+
+        db.rollback()
+
+        # Post-rollback: every DB write reversed
+        row = db.execute("SELECT stage, apply_flag FROM jobs WHERE id=?", (job["id"],)).fetchone()
+        assert row["stage"] == "applied"
+        audits = db.execute("SELECT * FROM audit_log WHERE job_id=?", (job["id"],)).fetchall()
+        assert len(audits) == 0
+        # Post-rollback: filesystem state still pre-call
+        assert folder.exists()
+        assert snapshot.exists()
+
+    def test_un_apply_job_multiple_snapshots_single_closure_no_capture_trap(self, db, tmp_path):
+        """#726 — un_apply_job collapses per-snapshot deletes into ONE closure
+        whose body iterates `glob("*.md")` at execution time (#709 lessons
+        learned). Verify that with 2+ snapshots, executing the deferred list
+        deletes ALL matching snapshots — a lazy-capture regression would
+        only delete the last one because the iteration variable would bind
+        to the final value.
+
+        Distinct from `un_not_selected_job`'s 2-marker test in that
+        un_apply_job intentionally uses single-closure-with-internal-loop
+        rather than N-closures-each-binding-one-path. Both patterns are
+        valid; this test locks in the chosen one.
+        """
+        applied_dir = tmp_path / "companies" / "_applied"
+        applied_dir.mkdir(parents=True, exist_ok=True)
+        folder = applied_dir / "Acme_Ops_multi_snap"
+        folder.mkdir()
+        snap_a = folder / "resume.applied-2026-05-18.md"
+        snap_b = folder / "cover.applied-2026-05-18.md"
+        snap_a.write_text("resume")
+        snap_b.write_text("cover")
+        # Non-snapshot .md should survive
+        unrelated = folder / "briefing.md"
+        unrelated.write_text("briefing — not a snapshot, must survive")
+
+        # Monkeypatch BASE so the deferred move targets tmp_path/companies/ —
+        # without this, dest is `<repo>/companies/` and the test pollutes the
+        # real repo. (Existing un_apply tests use this same pattern.)
+        import findajob.actions as actions_mod
+
+        original_base = actions_mod.BASE
+        actions_mod.BASE = str(tmp_path)
+        try:
+            job = insert_job(db, stage="applied", folder=str(folder))
+            db.commit()
+            job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+            deferred: list = []
+            actions.un_apply_job(db, job, deferred_fs=deferred)
+            assert len(deferred) == 1, "single closure body, not per-snapshot"
+
+            db.commit()
+            for op in deferred:
+                op()
+        finally:
+            actions_mod.BASE = original_base
+
+        moved_folder = tmp_path / "companies" / folder.name
+        assert moved_folder.exists()
+        # Both snapshots deleted at the destination
+        assert not (moved_folder / snap_a.name).exists()
+        assert not (moved_folder / snap_b.name).exists()
+        # Non-snapshot .md survived
+        assert (moved_folder / unrelated.name).exists()
+
+    def test_reactivate_from_ingest_deferred_fs_is_rollback_safe(self, db, tmp_path):
+        """#726 — reactivate_from_ingest participates in the deferred_fs contract.
+
+        Seed a waitlisted row with a folder in `_waitlisted/`. Verify
+        ``deferred_fs=[]`` keeps the folder at `_waitlisted/`, then rollback
+        restores `stage='waitlisted'` and the folder remains in place.
+        """
+        wl_dir = tmp_path / "companies" / "_waitlisted"
+        wl_dir.mkdir(parents=True, exist_ok=True)
+        folder = wl_dir / "Acme_Ops_reactivate_deferred"
+        folder.mkdir()
+
+        job = insert_job(db, stage="waitlisted", folder=str(folder))
+        db.commit()
+        job = db.execute("SELECT * FROM jobs WHERE id=?", (job["id"],)).fetchone()
+
+        deferred: list = []
+        actions.reactivate_from_ingest(db, job, overwrite_fields={}, deferred_fs=deferred)
+        # Pre-rollback: DB shows new state
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "scored"
+        # Pre-rollback: fs op queued but NOT executed — folder still at _waitlisted/
+        assert folder.exists(), "deferred_fs must not execute fs ops"
+        assert len(deferred) == 1
+
+        db.rollback()
+
+        # Post-rollback: DB writes reversed
+        assert db.execute("SELECT stage FROM jobs WHERE id=?", (job["id"],)).fetchone()["stage"] == "waitlisted"
+        audits = db.execute("SELECT * FROM audit_log WHERE job_id=?", (job["id"],)).fetchall()
+        assert len(audits) == 0
+        # Post-rollback: folder still at _waitlisted/
+        assert folder.exists()


### PR DESCRIPTION
## Summary

Closes #726. Out-of-AC siblings from #709 — `un_apply_job` and `reactivate_from_ingest` carried the same fs-then-DB ordering that #709 standardized via `deferred_fs: list[Callable] | None = None`. Not bug-triggering today (no composing callers) but eliminating the inconsistency while #709's pattern is still fresh.

## Notes

- `un_apply_job` collapses its folder-move + per-snapshot deletes into **one closure** whose body iterates `glob("*.md")` at execution time. This is intentionally *different* from #709's `un_not_selected_job` (N closures, each binding one `marker_path`). Both shapes are valid; the per-snapshot delete here happens at the POST-move destination, so the glob has to run after the move runs — single closure body sidesteps the lazy-capture trap entirely.
- `reactivate_from_ingest` is the simplest application of the pattern: one `shutil.move`, no marker work. Template for future minimal-fs helpers.

## Test plan

- [x] `uv run pytest tests/test_actions.py::TestActionsDeferredFs` — 8/8 (was 5/5; added 3)
- [x] `uv run pytest tests/test_actions.py tests/test_actions_resurface.py tests/test_board_actions.py` — 260 passed
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run mypy src/findajob/actions.py`
- [x] 2-snapshot regression test (`test_un_apply_job_multiple_snapshots_single_closure_no_capture_trap`) locks in the single-closure shape — would catch a future regression that splits the snapshot deletes back into per-file closures with lazy capture
- [ ] Browser smoke (not run — pure refactor, no UI surface; HTTP-layer tests in `test_board_actions.py` cover the route behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)