### PR TITLE
fix(onboarding): #740 hotfix — hx-boost='false' on streaming form

### DIFF
--- a/src/findajob/web/templates/onboarding/interview.html
+++ b/src/findajob/web/templates/onboarding/interview.html
@@ -69,7 +69,14 @@
   <div id="stream-progress" class="flex flex-wrap items-center gap-2"
        aria-live="polite" role="status"></div>
 
+  {# hx-boost="false" opts this form out of body-level hx-boost="true" (see
+     base.html). Without it, HTMX intercepts the submit BEFORE our JS handler
+     in onboarding-stream.js runs, fires an XHR GET to the form's default
+     action (current URL + form data as query params), and silently
+     reload-renders the chat page without ever hitting /turn-stream. The
+     Finalize form below uses the same opt-out for the same reason. #}
   <form data-stream-endpoint="/onboarding/interview/turn-stream"
+        hx-boost="false"
         class="space-y-2">
     <input type="hidden" name="session_id" value="{{ session_id }}">
     <textarea name="message" rows="4" required

--- a/tests/test_web_onboarding_interview_render.py
+++ b/tests/test_web_onboarding_interview_render.py
@@ -190,6 +190,26 @@ def test_interview_page_includes_streaming_form_pointing_at_turn_stream(
     # Negative containment: the streaming endpoint URL must NOT appear as
     # the non-streaming /turn (catches a lazy substring match).
     assert "/onboarding/interview/turn-stream" in body
+    # base.html sets hx-boost="true" on <body>, which boosts all descendant
+    # forms by default. Without an explicit opt-out, HTMX intercepts the
+    # submit BEFORE onboarding-stream.js's handler runs and fires an XHR GET
+    # to the form's default action — the streaming endpoint is never hit and
+    # the chat page silently reload-renders. Caught in browser verification
+    # against findajob-clean after #740 merged; one-line regression guard.
+    assert 'hx-boost="false"' in body
+    # Pair with structural containment: the opt-out must be on the streaming
+    # form specifically. Look at the rendered slice containing the form tag.
+    streaming_form_idx = body.find('data-stream-endpoint="/onboarding/interview/turn-stream"')
+    # The opt-out attribute must live on the same <form ...> opening tag —
+    # search backward for the form open and forward for the tag close, and
+    # assert the hx-boost="false" landed inside that range.
+    form_open = body.rfind("<form", 0, streaming_form_idx)
+    form_close = body.find(">", streaming_form_idx)
+    streaming_form_tag = body[form_open : form_close + 1]
+    assert 'hx-boost="false"' in streaming_form_tag, (
+        "hx-boost='false' must be on the streaming form's opening tag, not a sibling element. "
+        f"Tag was: {streaming_form_tag!r}"
+    )
 
 
 def test_interview_page_hides_finalize_block_when_not_ready(client_with_key: TestClient, base_root: Path) -> None:


### PR DESCRIPTION
## Summary

One-line hotfix to make #740's streaming UX actually work in the browser.

The streaming form added in #740 inherits `hx-boost="true"` from `base.html`'s `<body>` tag. HTMX intercepts the submit BEFORE `onboarding-stream.js`'s handler runs, fires an XHR GET to the form's default action (current URL + form data as query params), and silently reload-renders the chat page without ever hitting `/turn-stream`. Result: the streaming UX is dead-on-arrival in production despite all unit tests passing.

## How it was caught

Browser walkthrough on findajob-clean immediately after #740 merged. The first send-turn click produced a `GET /onboarding/interview/{sid}?session_id={sid}` in the network tab — the native form submit, not the SSE POST. The JS handler never ran because HTMX intercepted first.

TestClient-based unit tests can't catch this — they don't load HTMX or fire DOM events. The original render test asserted the `data-stream-endpoint` attribute was set but not that the form actually submitted to it.

## Fix

Add `hx-boost="false"` to the streaming form, mirroring the Finalize form right below it which already has the same opt-out for the same reason.

## Regression guard

Extends the existing render test:
- Asserts `hx-boost="false"` is present in the rendered page
- AND asserts it lives on the streaming form's opening tag specifically (structural check via `body.rfind("<form", 0, streaming_form_idx)` to find the form open, then containment check inside the tag range — catches the case where `hx-boost="false"` is on a sibling element).

## Test plan

- [x] `uv run pytest tests/test_web_onboarding_interview_render.py::test_interview_page_includes_streaming_form_pointing_at_turn_stream` — passes with the new assertions
- [ ] Re-deploy findajob-clean (post-build-push), walk the interview, verify the SSE flow actually fires this time

## Migration

None. Single template attribute addition + one extended test assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)