### PR TITLE
fix(loose-ends): #735 — phase-2 --output-dir now controls report location

### DIFF
--- a/scripts/walk_loose_ends.py
+++ b/scripts/walk_loose_ends.py
@@ -218,11 +218,10 @@ def main() -> int:
                 total_findings += count
 
     # Roll-up
-    report_dir = repo_root / "docs" / "personal" / "audit-reports"
     report_path, prose_cost = write_report(
         findings_jsonl=findings_jsonl,
         exclusions=exclusions,
-        output_dir=report_dir,
+        output_dir=args.output_dir,
     )
     total_cost += prose_cost
 


### PR DESCRIPTION
## Summary

- `scripts/walk_loose_ends.py` was passing a hardcoded `docs/personal/audit-reports/` to `write_report()` while `findings.jsonl` honored the CLI's `--output-dir`. Same-day re-runs against different `--output-dir`s would isolate findings but clobber each other's reports.
- Routes `args.output_dir` through to `write_report()`; drops the dead `report_dir` alias.

## Test plan

- [x] `uv run ruff check scripts/walk_loose_ends.py` — clean
- [x] `uv run ruff format --check scripts/walk_loose_ends.py` — already formatted
- [x] `uv run pytest tests/loose_ends/` — 49/49 pass
- [x] Code inspection — both `findings_jsonl = args.output_dir / "findings.jsonl"` (line 170) and `output_dir=args.output_dir` (line 222) now reference the same CLI argument
- [ ] **Skipped: live `--report-only` run.** Per issue body's Model & execution guidance (Standard-tier: none — single-line behavior fix), no new test or live verification run. The verification step in the body costs LLM credit (`write_report` calls `openrouter.complete`) and adds no signal beyond code inspection for a one-line argument plumb-through.
- [x] `## Acceptance criteria` mapping:
  - `--output-dir` controls both findings.jsonl and report location consistently — ✓ (both reference `args.output_dir`)
  - Shim's docstring example matches what actually runs — ✓ (line 15 shows `--output-dir docs/personal/audit-reports/2026-05-19-walkthrough-run/`; after the fix both outputs land in that dir, matching the example's intent)
  - Re-runs on the same day don't clobber prior reports — ✓ (different `--output-dir`s now yield distinct report locations)

Closes #735

🤖 Generated with [Claude Code](https://claude.com/claude-code)