### PR TITLE
release: v0.27.3 — schema cleanup + Fly install honesty docs + Indeed allowlist retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.27.3] — 2026-05-20
+
 ### Migration required
 
 - **#498 `jobs.score_status` CHECK constraint tightened — `needs_info` dropped.** Pre-#498 the constraint permitted `'scored'`, `'manual_review'`, and `'needs_info'`; the third value was dead — never written by any code path, absent from `config/scoring_schema.json`, and verified zero rows across every active cohort stack at filing time. New `findajob.db.migrate._tighten_score_status_check_if_needed()` runs on every `apply_pending` and rebuilds the `jobs` table via the rename-create-copy-drop pattern when the live CHECK still includes `'needs_info'`. Pre-rebuild row-count guard: if any row carries `score_status='needs_info'`, the helper raises `RuntimeError` with a specific recovery message rather than letting `_rebuild_table_with_indexes` surface a buried CHECK violation; the legacy row is left untouched and the stack stops taking writes until cleaned (`UPDATE jobs SET score_status='scored' WHERE …` or operator-chosen value). Helper runs FIRST in `apply_pending`'s post-migration step (before `_add_briefing_ready_stage_if_needed` and `_add_prep_phase_b_kind_if_needed`) so its specific message wins over the generic one a sibling rebuild would surface. Idempotent — short-circuits when `'needs_info'` is no longer in the live schema. Fresh installs pick up the tightened constraint directly from the edited `0001_initial.sql:60`; existing stacks at `_meta.schema_version=1` absorb it on their next entrypoint run with no schema_version bump and no operator action.
@@ -1234,7 +1236,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.27.2...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.27.3...HEAD
+[0.27.3]: https://github.com/brockamer/findajob/releases/tag/v0.27.3
 [0.27.2]: https://github.com/brockamer/findajob/releases/tag/v0.27.2
 [0.27.1]: https://github.com/brockamer/findajob/releases/tag/v0.27.1
 [0.27.0]: https://github.com/brockamer/findajob/releases/tag/v0.27.0

--- a/ops/fly.toml.example
+++ b/ops/fly.toml.example
@@ -21,7 +21,7 @@ primary_region = "iad"
 # when rolling to a new release and re-run ops/fly-deploy.sh (or just
 # `fly deploy --config ops/fly.toml`).
 [build]
-  image = "ghcr.io/brockamer/findajob:v0.27.2"
+  image = "ghcr.io/brockamer/findajob:v0.27.3"
 
 # Non-secret env. Mirrors compose.yaml.example's environment block, with
 # one critical difference: JSP_BASE points at /app/state, not /app. Fly


### PR DESCRIPTION
## Summary

Cuts patch release v0.27.3. Contents since v0.27.2:

- **chore(schema): #498** — drop dead `needs_info` from `jobs.score_status` CHECK constraint (migration-required, idempotent zero-action). PR #757.
- **refactor: retire `indeed_title_allow` per-stack post-filter** (#746, #417 reversed). Direct commit.
- **docs(672 / 673)** — README §Quick start fork to Fly-first / Docker-self-host paths; `install-fly.md` Step 1 + 4 + §7 honesty edits; fly.toml.example bump (last release's pin was 2 minors stale); dry-run doc link repairs.

Plus `ops/fly.toml.example` image pin bumped v0.27.2 → v0.27.3 (release-process checklist requirement).

## Pre-release gates

- [x] **Pre-tag fresh-install smoke check** — `FINDAJOB_TEST_IMAGE=findajob:local scripts/test_container_integration.sh` on docker.lan: 63 jobs scored, all four assertions green (pipeline_complete with scored > 0, jobs table rows in scored/manual_review, cost_log rows, materials viewer + /docs/ routes).
- [x] **Staging green-check** — `python -m findajob.staging.green` exit 0, 4/4 predicates.
- [x] **:latest cohort verification** — operator + clean + staging all on the post-#498 image, `verify_auth` exit 0 on each.
- [x] **migration-required label sweep** — #757 carries the label; no other in-range PRs trigger.
- [x] **CHANGELOG cross-reference links** — `[Unreleased]` updated to compare/v0.27.3...HEAD; `[0.27.3]` link added.

## Test plan

- [ ] Wait for CI green on this PR
- [ ] Merge → wait for `:latest` rebuild off the CHANGELOG commit
- [ ] `git tag v0.27.3 && git push origin v0.27.3` → triggers `build-image.yml` (publishes :v0.27.3, advances :v0.27, advances :latest) and `create-release.yml` (Release page with Migration required section)
- [ ] Post-tag verification: Release page renders, both workflows succeeded, image pullable
- [ ] Cohort deploy to 5 tester stacks (alice/papa/dave/judy/tango), verify_auth each

🤖 Generated with [Claude Code](https://claude.com/claude-code)
