### PR TITLE
feat(audit): #8 — in-process rotation for logs/pipeline.jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **#8 feat(audit): in-process rotation for `logs/pipeline.jsonl`.** The file caps at 5 MB; on threshold cross, the current file is gzipped to `pipeline.jsonl.1.gz`, older `.gz` backups shift up (`.1.gz` → `.2.gz`, …), and the ring keeps the 6 most recent. Any backup older than 90 days is also swept at the end of every rotation regardless of slot. Total disk footprint per stack is now bounded at a few MB instead of growing unbounded (operator's stack was at 4.99 MB after 36 days pre-#8 across 8 cohort stacks). Implemented inline in `src/findajob/audit.py` rather than via `logging.handlers.RotatingFileHandler` — three of the four needed features (gzip on rotation, 90-day mtime sweep, monkeypatch-friendly `LOG_PATH` resolution for tests) require custom hooks anyway, and stdlib's per-process open file handle would have introduced a multi-process race the existing open-append-close pattern avoids. The hot path stays open-append-close (POSIX `O_APPEND` writes ≤ PIPE_BUF are atomic, so no lock is needed there); the rare rotation block is serialized across the supercronic+uvicorn processes with a non-blocking `fcntl.flock` on a sidecar `<path>.rotate.lock` file. If another process is mid-rotation, the would-be caller skips silently and the next call retries. Reader compat: `findajob.admin.jsonl_tail` already reads only the trailing 1 MB so the admin dashboard is unaffected; `findajob.staging.green._read_events` extended to also read `pipeline.jsonl.1.gz` so the 26h `pipeline_complete` predicate survives a rotation that lands between green-check runs. Docs in `docs/operations/README.md` replace the prior manual-`logrotate` workaround. No `migration-required` — purely additive runtime behavior, no schema/config/compose change.
+
 ## [0.27.3] — 2026-05-20
 
 ### Migration required

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -171,19 +171,15 @@ The materials sub-view (`/materials/`) renders prep-folder contents grouped by s
 
 ## Log Rotation
 
-`logs/pipeline.jsonl` grows without bound. Rotation #8 is open; until that lands, rotate manually or set up `logrotate` on the host targeting the bind-mounted log directory.
+`logs/pipeline.jsonl` rotates in-process at 5 MB. The rotator lives in `findajob.audit` (the same module that writes the file) so the behavior is identical inside and outside Docker without per-host `logrotate` setup.
 
-Run `logrotate` on the host against the bind-mounted directory:
+On rotation, the current file is gzipped to `pipeline.jsonl.1.gz`; older backups shift up (`.1.gz` → `.2.gz`, `.2.gz` → `.3.gz`, …). The ring keeps the 6 most recent backups, so disk usage per stack is bounded at roughly 5 MB current file + 6 × ≪5 MB gzipped backups (a few MB total in practice). At the end of every rotation, any backup older than 90 days is also swept regardless of slot — on low-activity stacks where rotation happens only every few months, this prevents indefinitely-stale gzipped history from accumulating.
 
-```
-/opt/stacks/findajob-{handle}/state/logs/*.jsonl {
-    weekly
-    rotate 4
-    compress
-    missingok
-    notifempty
-}
-```
+Two readers know about rotation:
+- The admin dashboard (`findajob.admin.jsonl_tail`) reads only the trailing 1 MB of the *current* file; rotated history is intentionally not surfaced there.
+- The staging green-check (`findajob.staging.green`) reads the current file plus `pipeline.jsonl.1.gz` so the 26h `pipeline_complete` predicate survives a rotation that lands between green-check runs.
+
+If you specifically need a long-running off-host log history, ship `pipeline.jsonl` to syslog / Loki / Datadog from the host — the in-container rotation is intentionally short-window operational visibility, not durable archival. The durable transition trail lives in the `audit_log` SQLite table, not in `pipeline.jsonl`.
 
 ---
 

--- a/src/findajob/audit.py
+++ b/src/findajob/audit.py
@@ -6,30 +6,122 @@ operational role: persisting a record of what the pipeline did.
 - :func:`log_event` appends one JSON-line to ``logs/pipeline.jsonl``.
   Used everywhere — fetchers, scoring, prep, web routes — for any
   observable event worth surfacing to the operator's tail / health-check
-  pipeline.
+  pipeline. Size-bounded via a custom inline rotator (see below) — the
+  file caps at 5 MB, rotates to gzipped ``pipeline.jsonl.N.gz`` siblings
+  keeping the most recent 6, with anything older than 90 days swept.
 - :func:`write_audit` inserts one row into ``audit_log`` for every
   ``jobs.*`` field transition. Used by ``findajob.actions`` (every web
   POST handler) and the watchdog. Provides the durable trail that the
   ``/audit/`` page renders.
 
-Extracted from ``utils.py`` in M4.E2.I2 (#550). No logic changes.
+Rotation design (#8) — custom inline rather than
+``logging.handlers.RotatingFileHandler``. Three of the four features we
+need (gzip on rotation, 90-day mtime sweep, test-monkeypatch-compatible
+``LOG_PATH`` resolution) require custom hooks anyway, and stdlib's
+per-process open file handle would introduce a multi-process race the
+existing open-append-close pattern avoids. The hot path stays
+open-append-close so POSIX ``O_APPEND`` atomicity guarantees no lock is
+needed there; the rare rotation block is serialized across processes
+with a non-blocking ``fcntl.flock`` on a sidecar lock file.
+
+Extracted from ``utils.py`` in M4.E2.I2 (#550). #8 added rotation in 2026-05.
 """
 
 from __future__ import annotations
 
+import fcntl
+import gzip
 import json
 import os
+import shutil
 import sqlite3
+import time
 from datetime import UTC, datetime
+from pathlib import Path
 
 from findajob.paths import BASE
 
 LOG_PATH: str = f"{BASE}/logs/pipeline.jsonl"
 
+_MAX_BYTES = 5 * 1024 * 1024
+_BACKUP_COUNT = 6
+_RETENTION_SECONDS = 90 * 24 * 60 * 60
+
+
+def _rotate(path: str) -> None:
+    """Shift existing ``.N.gz`` backups up, gzip the current file to
+    ``.1.gz``, then sweep any backup older than 90 days.
+
+    Caller must hold the rotation flock. Safe to re-enter — if another
+    process rotated between the caller's size check and lock
+    acquisition, ``_maybe_rotate`` re-checks size under the lock and
+    short-circuits before calling this.
+    """
+    for i in range(_BACKUP_COUNT, 0, -1):
+        src = f"{path}.{i}.gz"
+        if i == _BACKUP_COUNT:
+            if os.path.exists(src):
+                os.remove(src)
+            continue
+        dst = f"{path}.{i + 1}.gz"
+        if os.path.exists(src):
+            os.replace(src, dst)
+    staging = f"{path}.1"
+    try:
+        os.replace(path, staging)
+    except FileNotFoundError:
+        return
+    target = f"{path}.1.gz"
+    with open(staging, "rb") as f_in, gzip.open(target, "wb") as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    os.remove(staging)
+    cutoff = time.time() - _RETENTION_SECONDS
+    log_dir = Path(path).parent
+    base_name = Path(path).name
+    for entry in log_dir.glob(f"{base_name}.*.gz"):
+        try:
+            if entry.stat().st_mtime < cutoff:
+                entry.unlink()
+        except OSError:
+            continue
+
+
+def _maybe_rotate(path: str) -> None:
+    """Size-check ``path`` and rotate under a non-blocking flock.
+
+    Returns immediately if size is under threshold, the file is missing,
+    or another process is already rotating. The flock is sidecar
+    (``<path>.rotate.lock``) so the hot append path never contends.
+    """
+    try:
+        if os.path.getsize(path) < _MAX_BYTES:
+            return
+    except OSError:
+        return
+    lock_path = f"{path}.rotate.lock"
+    try:
+        lock_fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT, 0o644)
+    except OSError:
+        return
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return
+        try:
+            if os.path.getsize(path) < _MAX_BYTES:
+                return
+        except OSError:
+            return
+        _rotate(path)
+    finally:
+        os.close(lock_fd)
+
 
 def log_event(event_type: str, **kwargs: object) -> None:
     entry = {"ts": datetime.now(UTC).isoformat(), "event": event_type, **kwargs}
     os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+    _maybe_rotate(LOG_PATH)
     with open(LOG_PATH, "a") as f:
         f.write(json.dumps(entry) + "\n")
 

--- a/src/findajob/staging/green.py
+++ b/src/findajob/staging/green.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import gzip
 import json
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 from findajob.audit import LOG_PATH as _AUDIT_LOG_PATH
@@ -34,11 +36,9 @@ DEFAULT_SENTINEL = Path(BASE) / "data" / ".staging_clicker_last_status"
 DEFAULT_TRIAGE_MAX_AGE_HOURS = 26
 
 
-def _read_events(log: Path) -> list[dict]:
-    if not log.exists():
-        return []
+def _parse_events(lines: Iterable[str]) -> list[dict]:
     out: list[dict] = []
-    for raw in log.read_text().splitlines():
+    for raw in lines:
         raw = raw.strip()
         if not raw:
             continue
@@ -46,6 +46,27 @@ def _read_events(log: Path) -> list[dict]:
             out.append(json.loads(raw))
         except json.JSONDecodeError:
             continue
+    return out
+
+
+def _read_events(log: Path) -> list[dict]:
+    # Include the most recent rotated backup. `pipeline.jsonl` is
+    # bounded by audit.py's rotator (#8 — 5 MB cap, .1.gz holds the
+    # previous segment); reading only the current file would silently
+    # drop the last triage cycle on a stack that rotated since.
+    out: list[dict] = []
+    rotated = Path(str(log) + ".1.gz")
+    if rotated.exists():
+        try:
+            with gzip.open(rotated, "rt") as f:
+                out.extend(_parse_events(f))
+        except OSError:
+            pass
+    if log.exists():
+        try:
+            out.extend(_parse_events(log.read_text().splitlines()))
+        except OSError:
+            pass
     return out
 
 

--- a/tests/test_admin_stacks_route.py
+++ b/tests/test_admin_stacks_route.py
@@ -186,8 +186,10 @@ def test_render_under_2s(operator_app, tmp_path: Path) -> None:
     of running the test against trivial fixtures (the previous 500-event ~30KB
     files exercised the happy path without proving the bound matters).
 
-    Operator's stack pipeline.jsonl was ~10MB on 2026-04-30; long-running
-    tester stacks will land in the same range.
+    Sizes this large no longer occur in production after #8 (rotation at 5 MB);
+    the test deliberately seeds past the rotation threshold to verify the
+    dashboard render stays bounded even in the brief window between a file
+    crossing 5 MB and the next log_event call that triggers rotation.
     """
     import json
     import time

--- a/tests/test_audit_rotation.py
+++ b/tests/test_audit_rotation.py
@@ -1,0 +1,180 @@
+"""Size-based rotation for logs/pipeline.jsonl (#8).
+
+The hot path (`log_event`) opens the file per call, so we can drive
+rotation by hammering small writes against a monkeypatched
+`_MAX_BYTES`. Each event serializes to ~80 B; the tiny threshold below
+triggers a rotation every ~4 events so a short batch covers
+ring-fill + eviction in one test.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from findajob import audit
+
+
+@pytest.fixture(autouse=True)
+def _isolated_log_path(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(audit, "LOG_PATH", str(tmp_path / "logs" / "pipeline.jsonl"))
+    return tmp_path / "logs" / "pipeline.jsonl"
+
+
+@pytest.fixture()
+def _tiny_threshold(monkeypatch):
+    monkeypatch.setattr(audit, "_MAX_BYTES", 256)
+
+
+def _write_n(n: int, **extra) -> None:
+    for i in range(n):
+        audit.log_event("tick", i=i, **extra)
+
+
+def _read_jsonl(p: Path) -> list[dict]:
+    return [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+
+
+def _read_gz_jsonl(p: Path) -> list[dict]:
+    with gzip.open(p, "rt") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _collect_all_events(log_path: Path) -> list[dict]:
+    """Aggregate events across rotated backups + current, oldest-first."""
+    events: list[dict] = []
+    for i in range(audit._BACKUP_COUNT, 0, -1):
+        gz = Path(str(log_path) + f".{i}.gz")
+        if gz.exists():
+            events.extend(_read_gz_jsonl(gz))
+    if log_path.exists():
+        events.extend(_read_jsonl(log_path))
+    return events
+
+
+class TestUnderThreshold:
+    def test_no_rotation_below_threshold(self, _isolated_log_path: Path) -> None:
+        audit.log_event("hello", who="world")
+        assert _isolated_log_path.exists()
+        events = _read_jsonl(_isolated_log_path)
+        assert len(events) == 1
+        assert events[0]["event"] == "hello"
+        assert not list(_isolated_log_path.parent.glob("*.gz"))
+
+    def test_monkeypatched_log_path_redirects_writes(self, tmp_path: Path, monkeypatch) -> None:
+        """Regression-guard: existing tests monkeypatch findajob.audit.LOG_PATH
+        to redirect log_event during fixtures. log_event must read LOG_PATH
+        fresh each call rather than caching it from import time."""
+        custom = tmp_path / "elsewhere" / "events.jsonl"
+        monkeypatch.setattr(audit, "LOG_PATH", str(custom))
+        audit.log_event("redirected")
+        assert custom.exists()
+        assert _read_jsonl(custom)[0]["event"] == "redirected"
+
+
+class TestRotation:
+    def test_rotation_preserves_all_events_until_eviction(self, _isolated_log_path: Path, _tiny_threshold) -> None:
+        _write_n(20)
+        # At least one rotation must have happened.
+        assert Path(str(_isolated_log_path) + ".1.gz").exists()
+        events = _collect_all_events(_isolated_log_path)
+        # 20 events ≈ 5 rotations × ~4 events per slot. The ring has
+        # capacity for 6 backups so nothing should have been evicted yet.
+        assert len(events) == 20
+        assert [e["i"] for e in events] == list(range(20))
+
+    def test_older_backups_hold_older_events(self, _isolated_log_path: Path, _tiny_threshold) -> None:
+        _write_n(20)
+        gz1 = Path(str(_isolated_log_path) + ".1.gz")
+        gz2 = Path(str(_isolated_log_path) + ".2.gz")
+        assert gz1.exists() and gz2.exists()
+        # Higher-numbered slot = older events; lower-numbered = newer.
+        older = _read_gz_jsonl(gz2)
+        newer = _read_gz_jsonl(gz1)
+        assert max(e["i"] for e in older) < min(e["i"] for e in newer), (
+            f"slot order violated: gz2={[e['i'] for e in older]} vs gz1={[e['i'] for e in newer]}"
+        )
+
+    def test_ring_caps_at_six_and_evicts_oldest(self, _isolated_log_path: Path, _tiny_threshold) -> None:
+        # 50 events ≈ 12 rotations → ring saturates and the oldest get evicted.
+        _write_n(50)
+        for i in range(1, 7):
+            assert Path(str(_isolated_log_path) + f".{i}.gz").exists(), f"missing .{i}.gz"
+        assert not Path(str(_isolated_log_path) + ".7.gz").exists()
+        events = _collect_all_events(_isolated_log_path)
+        # Some early events must have been evicted; the survivors are
+        # contiguous from the end.
+        assert len(events) < 50
+        indices = [e["i"] for e in events]
+        assert max(indices) == 49
+        assert indices == sorted(indices)
+        # Earliest surviving index is consistent with a 6-backup ring +
+        # current file; the precise number depends on serialized byte
+        # count per event, but it must be > 0.
+        assert min(indices) > 0
+
+
+class TestRetentionSweep:
+    def test_90_day_sweep_deletes_aged_backups(self, _isolated_log_path: Path, _tiny_threshold) -> None:
+        """Pre-create a stale backup in a slot that survives one rotation's
+        shift; verify the sweep at the end of _rotate removes it even
+        though the ring rule would have kept it."""
+        _isolated_log_path.parent.mkdir(parents=True, exist_ok=True)
+        stale_src = Path(str(_isolated_log_path) + ".3.gz")
+        with gzip.open(stale_src, "wt") as f:
+            f.write('{"event": "ancient"}\n')
+        ancient = time.time() - (100 * 24 * 60 * 60)
+        os.utime(stale_src, (ancient, ancient))
+        # Trigger one rotation; .3.gz → .4.gz (mtime preserved by rename).
+        # Then sweep removes any .gz older than 90 days.
+        _write_n(5)
+        assert not Path(str(_isolated_log_path) + ".4.gz").exists(), "90-day sweep should have removed the aged backup"
+        # The fresh .1.gz from this rotation must remain.
+        new_gz1 = Path(str(_isolated_log_path) + ".1.gz")
+        assert new_gz1.exists()
+        cutoff = time.time() - audit._RETENTION_SECONDS
+        for gz in _isolated_log_path.parent.glob("*.gz"):
+            assert gz.stat().st_mtime >= cutoff, f"{gz} survived sweep with stale mtime"
+
+
+class TestReaderCompat:
+    def test_jsonl_tail_yields_only_current_file(self, _isolated_log_path: Path, _tiny_threshold) -> None:
+        from findajob.admin.jsonl_tail import tail_events
+
+        _write_n(20)
+        assert Path(str(_isolated_log_path) + ".1.gz").exists()
+        # tail_events reads the live file only — by design (#355). Rotated
+        # events are not surfaced. Verify it still yields a valid set of
+        # events without exception.
+        events = list(tail_events(_isolated_log_path))
+        assert len(events) > 0
+        for e in events:
+            assert "i" in e
+            assert e["i"] >= 0
+
+    def test_staging_green_spans_rotation(self, _isolated_log_path: Path, _tiny_threshold) -> None:
+        """staging.green._read_events must include the most recent rotated
+        backup so the 26h pipeline_complete predicate survives a rotation
+        that lands between green-check runs."""
+        from findajob.staging import green
+
+        _write_n(20)
+        assert Path(str(_isolated_log_path) + ".1.gz").exists()
+        current_only_count = len(_read_jsonl(_isolated_log_path))
+        events = green._read_events(_isolated_log_path)
+        # Spans .1.gz + current → strictly more events than reading
+        # current alone. (Earlier slots .2.gz+ are intentionally excluded
+        # — green-check only needs the last triage cycle.)
+        assert len(events) > current_only_count
+        # Order invariant: .1.gz events appear before current events.
+        # Pick the maximum index in each batch and verify the rotated
+        # slice's max is lower than the current slice's min.
+        rotated_count = len(events) - current_only_count
+        rotated_indices = [e["i"] for e in events[:rotated_count]]
+        current_indices = [e["i"] for e in events[rotated_count:]]
+        assert max(rotated_indices) < min(current_indices)


### PR DESCRIPTION
## Summary

- Caps `logs/pipeline.jsonl` at 5 MB. On threshold cross: current file → `pipeline.jsonl.1.gz`, older backups shift up, ring keeps 6 most recent, anything older than 90 days swept regardless of slot.
- Rotation is inline in `src/findajob/audit.py` — hot path stays open-append-close, rare rotation block serialized across processes with `fcntl.flock(LOCK_EX | LOCK_NB)` on a sidecar lock file.
- `findajob.staging.green._read_events` extended to also read `pipeline.jsonl.1.gz` so the 26h `pipeline_complete` predicate survives a rotation between green-check runs.

Closes #8.

## Deviations from the issue's acceptance criteria, called out explicitly

1. **Custom inline rotation, not `logging.handlers.RotatingFileHandler`.** The AC names the stdlib class. Three of the four needed features (gzip on rotation, 90-day mtime sweep, monkeypatch-friendly `LOG_PATH` resolution for tests) require custom hooks anyway, and stdlib's per-process open file handle would introduce a multi-process race the current open-append-close pattern avoids. The CHANGELOG entry walks through the analysis. Happy to switch to stdlib if you'd rather — design call.

2. **`src/findajob/staging/green.py` touched, not just `audit.py`.** The issue says "implementation lives entirely in `src/findajob/audit.py` plus a small docs touch." Pre-implementation audit found that `green._read_events` did `Path(log).read_text()` on the full file — adding rotation without updating this reader would silently drop events on a stack that rotated between green-check runs. Fix extends `_read_events` to span `pipeline.jsonl.1.gz` + current (~30 lines). The change is narrow and necessary; flagging it because the PR scope is wider than the issue advertised.

## Test plan

- [x] `tests/test_audit_rotation.py` — 8 new tests covering: under-threshold no-rotation, `LOG_PATH` monkeypatch redirects writes (regression-guard for existing fixture pattern), `.1.gz` is created, second rotation promotes `.1.gz` → `.2.gz`, 6-file ring caps + evicts oldest, 90-day mtime sweep removes aged backups (pre-created in a slot that survives the shift to isolate sweep behavior from ring eviction), `jsonl_tail` reads only current file (by design — `#355`), `staging.green._read_events` spans rotation.
- [x] `tests/test_admin_stacks_route.py:189` stale comment updated — the test still seeds past the 5 MB threshold to verify dashboard render stays bounded in the brief window between size-cross and the next `log_event` that triggers rotation.
- [x] `uv run pytest -q` — 2897 passed, 2 skipped, 130 warnings, no failures (4m21s).
- [x] `uv run ruff check . && uv run ruff format --check .` — clean.
- [x] `uv run mypy src/findajob/` — Success: no issues found in 153 source files.
- [ ] Multi-process rotation race not exercised in tests. `LOCK_NB` semantics are stdlib-guaranteed and rotation events are rare (~5-week cadence per stack on operator's growth rate), so a synthetic concurrent test would be flaky theater. Disclosed per [`feedback_disclose_verify_gaps`](https://github.com/brockamer/findajob/blob/main/.claude/) rather than claimed silent success.
- [ ] Not yet validated in production — recommend a dry-run on `findajob-clean` after merge (the `:latest` stack), since `findajob-clean`'s pipeline.jsonl is only 2.8 KB so it won't rotate organically; for a smoke, write a one-off script that calls `audit._maybe_rotate` with a small `_MAX_BYTES` override and inspect the resulting `.gz`.

## Notes

- No `migration-required` label per the issue — no schema, config, compose, or cron change.
- Docs update in `docs/operations/README.md` replaces the prior manual-`logrotate` workaround block, per the same-PR docs rule.
- Coordination: this PR was developed in a separate `git worktree` (`~/Code/findajob-8/`) so it doesn't conflict with a parallel session working `#752` on the main checkout. File domain has zero overlap with `#752` (board route + dashboard template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)