### PR TITLE
fix(loose-ends): #751 — tune phase-2 audit (URL + parser + exclusion + itinerary)

### DIFF
--- a/config/loose_ends_walkthrough_exclusions.yaml
+++ b/config/loose_ends_walkthrough_exclusions.yaml
@@ -26,3 +26,18 @@ exclusions:
     route: /board/rejected
     rubric: empty_state_no_guidance
     rationale: NUX correctly has zero rejected jobs; emptiness is intentional.
+
+  # Wrong-rubric-for-the-concern: flow_without_exit correctly returns false
+  # because nav affordances (sidebar, stage dropdown) exist. The genuine
+  # loose-end here is "no action confirmation after the stage transition"
+  # — a different rubric category tracked in #779 (action_without_confirmation).
+  # When #779 lands, remove these and route the affected walkthroughs to the
+  # new rubric instead.
+  - persona: established_user
+    route: /board/applied
+    rubric: flow_without_exit
+    rationale: >
+      Rubric correctly returns is_loose_end=false; nav affordances are present.
+      Operator-intuition concern (no transition feedback / confirmation toast
+      after stage change) belongs to the action_without_confirmation rubric
+      category tracked in #779.

--- a/config/loose_ends_walkthroughs.yaml
+++ b/config/loose_ends_walkthroughs.yaml
@@ -95,7 +95,13 @@ walkthroughs:
     persona: established_user
     target_category: 3
     steps:
-      - goto: /board/dashboard?col=__nonexistent__&col_min=99
+      # Use a recognized column (relevance_score) with an impossible threshold
+      # so the filter actually applies and produces empty-state UX. The prior
+      # ?col=__nonexistent__&col_min=99 URL was silently dropped by the
+      # findajob.web.filters parser (cols_clean filters out unknown column
+      # names), leaving the dashboard populated and defeating the empty-state
+      # rubric check. See #751 AC1.
+      - goto: /board/dashboard?relevance_score_min=99
       - evaluate_dom:
           category: 3
           rubric: empty_state_no_guidance
@@ -108,3 +114,32 @@ walkthroughs:
       - evaluate_dom:
           category: 3
           rubric: empty_state_no_guidance
+
+  # AC3 expansion — surfaces missing from the original 5 (#751)
+  - name: not_selected_default_view
+    persona: established_user
+    target_category: 3
+    steps:
+      - goto: /board/not-selected
+      - evaluate_dom:
+          category: 3
+          rubric: empty_state_no_guidance
+
+  - name: archive_default_view
+    persona: established_user
+    target_category: 3
+    steps:
+      - goto: /board/archive
+      - evaluate_dom:
+          category: 3
+          rubric: empty_state_no_guidance
+
+  - name: materials_index_browse
+    persona: established_user
+    target_category: 2
+    steps:
+      - goto: /materials/
+      - evaluate_dom:
+          category: 2
+          rubric: flow_without_exit
+          context_hint: "User opened the materials index to find a prep folder"

--- a/scripts/walk_loose_ends.py
+++ b/scripts/walk_loose_ends.py
@@ -65,6 +65,26 @@ def _filter_walkthroughs(walkthroughs: list[Walkthrough], persona: str) -> list[
     return [w for w in walkthroughs if w.persona == persona]
 
 
+def _resolve_creds(secrets: dict[str, str], persona: str) -> tuple[str, str]:
+    """Pick basic-auth creds per persona, with FINDAJOB_TEST_* as legacy fallback.
+
+    Per-persona keys reflect the per-stack split (clean for nux, staging for
+    established); FINDAJOB_TEST_* predates the #565 findajob-test → findajob-clean
+    rename and is kept as a fallback so older ~/.secrets layouts keep working.
+    """
+    primary_user_key = {
+        "nux_user": "FINDAJOB_CLEAN_USER",
+        "established_user": "FINDAJOB_STAGING_USER",
+    }.get(persona, "FINDAJOB_TEST_USER")
+    primary_pass_key = {
+        "nux_user": "FINDAJOB_CLEAN_PASS",
+        "established_user": "FINDAJOB_STAGING_PASS",
+    }.get(persona, "FINDAJOB_TEST_PASS")
+    user = secrets.get(primary_user_key) or secrets.get("FINDAJOB_TEST_USER", "")
+    password = secrets.get(primary_pass_key) or secrets.get("FINDAJOB_TEST_PASS", "")
+    return user, password
+
+
 def _run_with_playwright(
     *,
     walkthroughs: list[Walkthrough],
@@ -72,6 +92,7 @@ def _run_with_playwright(
     secrets: dict[str, str],
     exclusions: dict[str, str],
     findings_jsonl: Path,
+    persona: str,
 ) -> tuple[float, int]:
     """Launch Playwright, run each walkthrough, write findings. Returns (cost, count)."""
     try:
@@ -85,8 +106,7 @@ def _run_with_playwright(
 
     total_cost = 0.0
     total_findings = 0
-    user = secrets.get("FINDAJOB_TEST_USER", "")
-    password = secrets.get("FINDAJOB_TEST_PASS", "")
+    user, password = _resolve_creds(secrets, persona)
     with sync_playwright() as pw:
         launch_kwargs: dict = {"headless": True}
         channel = secrets.get("PLAYWRIGHT_BROWSER_CHANNEL", "")
@@ -193,6 +213,7 @@ def main() -> int:
                     secrets=secrets,
                     exclusions=exclusions,
                     findings_jsonl=findings_jsonl,
+                    persona="nux_user",
                 )
                 total_cost += cost
                 total_findings += count
@@ -213,6 +234,7 @@ def main() -> int:
                     secrets=secrets,
                     exclusions=exclusions,
                     findings_jsonl=findings_jsonl,
+                    persona="established_user",
                 )
                 total_cost += cost
                 total_findings += count

--- a/src/findajob/loose_ends/walkthrough.py
+++ b/src/findajob/loose_ends/walkthrough.py
@@ -130,12 +130,16 @@ class _HintParser(HTMLParser):
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attr_dict = {k: (v or "") for k, v in attrs}
-        if tag in ("table", "ul", "ol", "div"):
+        if tag in ("table", "tbody", "ul", "ol", "div"):
             # Collection container if it has an id or a data-collection attribute.
+            # tbody included because findajob's board templates carry the id on
+            # <tbody id="rows"> rather than the parent <table> (#751 baseline
+            # discovered the rubric received empty collection_container_ids for
+            # every board tab because of this).
             collection_id = attr_dict.get("data-collection") or attr_dict.get("id")
             classes = attr_dict.get("class", "").split()
             if collection_id and (
-                tag in ("table", "ul", "ol") or "collection" in classes or "data-collection" in attr_dict
+                tag in ("table", "tbody", "ul", "ol") or "collection" in classes or "data-collection" in attr_dict
             ):
                 self.collection_container_ids.append(collection_id)
         if tag == "button":

--- a/tests/loose_ends/test_walkthrough.py
+++ b/tests/loose_ends/test_walkthrough.py
@@ -244,6 +244,19 @@ def test_extract_hints_finds_collection_containers():
     assert set(hints["collection_container_ids"]) >= {"applied-jobs", "dashboard-list", "rejected"}
 
 
+def test_extract_hints_recognizes_tbody_id_as_collection():
+    # findajob's board templates put the id on <tbody>, not the parent <table>.
+    # Without this, the rubric receives an empty collection_container_ids list
+    # for every board tab and can't evaluate empty-state loose ends.
+    dom = """
+    <html><body>
+        <table class="min-w-full"><tbody id="rows"></tbody></table>
+    </body></html>
+    """
+    hints = extract_hints(dom=dom, current_url="/board/dashboard")
+    assert "rows" in hints["collection_container_ids"]
+
+
 def test_extract_hints_finds_form_targets():
     dom = """
     <html><body>


### PR DESCRIPTION
Closes #751.

## Summary

Four parts to close the AC:

- **AC1**: `dashboard_all_filters_applied` URL changed from `?col=__nonexistent__&col_min=99` (silently dropped by `findajob.web.filters` parser) to `?relevance_score_min=99` — recognized column with impossible threshold, produces actual empty state on the dashboard.
- **AC2**: Added one exclusion entry for `(established_user, /board/applied, flow_without_exit)`. The rubric correctly returns `is_loose_end=false` (nav affordances are present); the operator's intuition concern is `action_without_confirmation`, a different rubric category tracked in #779.
- **AC3**: Expanded the established_user itinerary from 5 → 8 walkthroughs (`not_selected_default_view`, `archive_default_view`, `materials_index_browse`) — surfaces missing from the original 5.
- **AC4**: `rejected_view_with_data` flagged `is_loose_end=true` with operator agreement — `/board/rejected` empty state lacks "no rejections yet" guidance copy.

## Adjacent fixes the audit surfaced

- `_HintParser` now recognizes `<tbody id="...">` as a collection container. Without this, the rubric received empty `collection_container_ids` for every board tab (findajob's board templates carry the id on `<tbody id="rows">`, not the parent `<table>`) and couldn't evaluate empty-state loose ends.
- `walk_loose_ends.py` picks basic-auth credentials per persona via `_resolve_creds` (`FINDAJOB_CLEAN_*` / `FINDAJOB_STAGING_*` / legacy `FINDAJOB_TEST_*` fallback).

## Follow-ups filed (discovered scope, out of #751)

- #777 staging needs a persistent waitlisted fixture row
- #778 harness DOM truncation may hide rubric findings on large pages
- #779 new rubric category `action_without_confirmation` (blocked by #778)

## Test plan

- [x] `pytest tests/loose_ends/` — 50 passed (new test added for tbody-id collection-container recognition)
- [x] `ruff check` + `ruff format --check` clean
- [x] Baseline audit run against `findajob-staging` produced the four expected outcomes (2 excluded, 1 fixture-broken @ #777, 1 truncation-hidden @ #778, 1 ✓ flagged + 3 new-surface walkthroughs); roll-up at `docs/personal/audit-reports/2026-05-21-walkthrough-run-v4/`
- [x] Pre-commit PII hook ran on the diff (52 patterns × 94 lines) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)