### PR TITLE
feat(web): #196 /stats/throughput — per-ISO-week stacked-bar dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **#196 feat(web): /stats/throughput — per-ISO-week stacked-bar dashboard for applied/interview/offer transitions.** Flips the Throughput tab live in `templates/stats/_tabs.html`, ships the route + Jinja template + 8 unit tests. All-time view (no rolling window) — operator reads multi-month rhythm at a glance. Source is `audit_log` rows where `field_changed='stage'` AND `new_value IN ('applied','interview','offer')` so the dashboard measures *event throughput*, not currently-applied job count: a job that re-cycles applied→rejected→reactivated→applied contributes two applied ticks. Week label format `%Y-W##` from SQLite's `strftime('%Y-W%W', changed_at)`; `%W` is Monday-based and close-enough to ISO 8601 for at-a-glance cadence (strict ISO `%V` is not exposed by SQLite). Series colors `#059669/#10b981/#22c55e` match the late-funnel slice of `/stats/funnel`'s ramp so "applied = dark green" reads consistently across `/stats/*`. Empty-state guard renders informative copy ("No stage transitions to applied/interview/offer recorded yet") rather than an empty chart or 500. Negative-assertion test pins out-of-scope rows (`field_changed='user_notes'`, `new_value='scored'/'rejected'/'manual_review'`) excluded from the payload — protects against WHERE-clause regressions. Data-table row order is descending by week so recent activity reads at the top. **No `migration-required`** — purely additive route + template + tab flip + new tests; no schema, config, cron, mount, or compose changes.
+
 ## [0.27.5] — 2026-05-21
 
 ### Added

--- a/src/findajob/web/routes/stats.py
+++ b/src/findajob/web/routes/stats.py
@@ -66,6 +66,15 @@ _SCORING_WINDOW_DAYS = 30
 _REJECTIONS_TOP_COMPANIES = 5
 _REJECTION_STAGES: tuple[str, ...] = ("rejected", "not_selected")
 
+# /stats/throughput renders an all-time per-ISO-week count of stage transitions
+# into applied, interview, offer. Stacked-bar series — applied bottom, interview
+# middle, offer top — so a single bar reads as the per-week activity stack.
+# Source is audit_log, not jobs.stage, because we want event counts: a job that
+# moved applied → interview → offer contributes one tick to each series, and
+# moved → applied → rejected → reactivated → applied contributes two applied
+# ticks. The jobs table only carries the current stage.
+_THROUGHPUT_STAGES: tuple[str, ...] = ("applied", "interview", "offer")
+
 # Score columns charted on /stats/scoring. Tuple shape:
 #   (column_name, label, range_kind, slug)
 # range_kind drives bucketing in _bucketize_scores(): "int_1_10" → 10 integer
@@ -498,5 +507,73 @@ def rejections(
             "top_n": _REJECTIONS_TOP_COMPANIES,
             "global_chart_data_json": json.dumps(global_chart_data),
             "company_chart_data_json": json.dumps(company_chart_data),
+        },
+    )
+
+
+@router.get("/stats/throughput", response_class=HTMLResponse)
+def throughput(
+    request: Request,
+    db: sqlite3.Connection = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Per-ISO-week stage-transition throughput — applied, interview, offer.
+
+    All-time view, no window — operator wants to read multi-month rhythm. ISO
+    week label format `YYYY-W##` from SQLite's `strftime('%Y-W%W', ...)`. The
+    `%W` token is Monday-based and close-enough to ISO 8601 for at-a-glance
+    weekly cadence; strict ISO week-numbering (`%V`) is not used because
+    SQLite doesn't expose it and the dashboard reads the same either way.
+
+    Source is audit_log (event counts), not jobs.stage (current state) — see
+    the `_THROUGHPUT_STAGES` comment above for the design rationale.
+    """
+    placeholders = ",".join("?" * len(_THROUGHPUT_STAGES))
+    rows = db.execute(
+        f"""
+        SELECT strftime('%Y-W%W', changed_at) AS week,
+               new_value AS stage,
+               COUNT(*) AS n
+        FROM audit_log
+        WHERE field_changed = 'stage'
+          AND new_value IN ({placeholders})
+          AND changed_at IS NOT NULL
+        GROUP BY week, stage
+        ORDER BY week ASC, stage
+        """,
+        _THROUGHPUT_STAGES,
+    ).fetchall()
+
+    weekly: dict[str, dict[str, int]] = {}
+    for row in rows:
+        week = row["week"] if isinstance(row, sqlite3.Row) else row[0]
+        stage = row["stage"] if isinstance(row, sqlite3.Row) else row[1]
+        n = row["n"] if isinstance(row, sqlite3.Row) else row[2]
+        if not week or stage not in _THROUGHPUT_STAGES:
+            continue
+        weekly.setdefault(week, dict.fromkeys(_THROUGHPUT_STAGES, 0))[stage] = n
+
+    weeks_sorted = sorted(weekly)
+    totals = {stage: sum(weekly[w][stage] for w in weekly) for stage in _THROUGHPUT_STAGES}
+    grand_total = sum(totals.values())
+
+    chart_data = {
+        "labels": weeks_sorted,
+        "datasets": [
+            {"label": stage, "data": [weekly[w][stage] for w in weeks_sorted]} for stage in _THROUGHPUT_STAGES
+        ],
+    }
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request=request,
+        name="stats/throughput.html",
+        context={
+            "tab": "throughput",
+            "stages": _THROUGHPUT_STAGES,
+            "weeks": weeks_sorted,
+            "weekly": weekly,
+            "totals": totals,
+            "grand_total": grand_total,
+            "chart_data_json": json.dumps(chart_data),
         },
     )

--- a/src/findajob/web/templates/stats/_tabs.html
+++ b/src/findajob/web/templates/stats/_tabs.html
@@ -5,7 +5,7 @@
   ("/stats/feedback", "Feedback", true),
   ("/stats/scoring", "Scoring", true),
   ("/stats/rejections", "Rejections", true),
-  ("/stats/throughput", "Throughput", false),
+  ("/stats/throughput", "Throughput", true),
   ("/stats/effectiveness", "Effectiveness", false),
 ] %}
 <nav class="mb-4 border-b border-slate-200" aria-label="Stats views">

--- a/src/findajob/web/templates/stats/throughput.html
+++ b/src/findajob/web/templates/stats/throughput.html
@@ -1,0 +1,118 @@
+{% extends "base.html" %}
+{% block title %}Throughput — findajob stats{% endblock %}
+{% block main_classes %}w-full px-4 py-6{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Application throughput — all time</h1>
+{% include "stats/_tabs.html" %}
+
+<p class="mb-4 text-sm text-slate-600">
+  Per-ISO-week count of transitions <em>into</em> <code>applied</code>,
+  <code>interview</code>, and <code>offer</code>. A job that moves
+  <code>scored → applied → interview → offer</code> contributes one tick to
+  each series, so each bar reads as a week's activity stack rather than as a
+  snapshot of where jobs currently sit. Companion to
+  <a href="/stats/funnel" class="text-blue-700 underline">/stats/funnel</a>,
+  which slices a 30-day window by day and includes the full stage set.
+  Total: <span class="font-semibold">{{ grand_total }}</span> transition{{ '' if grand_total == 1 else 's' }}.
+</p>
+
+<section class="mb-6">
+  <h2 class="text-lg font-semibold mb-2">All-time totals</h2>
+  <div class="grid grid-cols-3 gap-2 max-w-md">
+    {% for stage in stages %}
+      <div class="bg-white rounded border border-slate-200 px-3 py-2">
+        <div class="text-xs uppercase text-slate-500 tracking-wide">{{ stage }}</div>
+        <div class="text-xl font-semibold">{{ totals[stage] }}</div>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="mb-8">
+  <h2 class="text-lg font-semibold mb-2">Weekly transitions</h2>
+  {% if grand_total == 0 %}
+    <p class="text-sm text-slate-500">
+      No stage transitions to <code>applied</code>, <code>interview</code>, or
+      <code>offer</code> recorded yet. This chart populates as you mark jobs
+      Applied from the board.
+    </p>
+  {% else %}
+    <div class="bg-white rounded border border-slate-200 p-3">
+      <canvas id="throughput-chart" role="img" aria-label="Per-week stage-transition counts, stacked by stage" height="110"></canvas>
+      <noscript>
+        <p class="text-sm text-slate-600">Chart requires JavaScript. The table below has the same data.</p>
+      </noscript>
+    </div>
+  {% endif %}
+</section>
+
+{% if grand_total > 0 %}
+<section>
+  <h2 class="text-lg font-semibold mb-2">Data table</h2>
+  <div class="overflow-x-auto">
+    <table class="min-w-full bg-white shadow-sm rounded-sm text-sm">
+      <thead class="bg-slate-100 text-left text-xs uppercase tracking-wide text-slate-600">
+        <tr>
+          <th class="px-3 py-2">Week</th>
+          {% for stage in stages %}
+            <th class="px-3 py-2 text-right">{{ stage }}</th>
+          {% endfor %}
+          <th class="px-3 py-2 text-right">total</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for week in weeks | reverse %}
+          <tr class="{% if loop.index0 % 2 %}bg-slate-50{% endif %}">
+            <td class="px-3 py-1 font-mono">{{ week }}</td>
+            {% for stage in stages %}
+              <td class="px-3 py-1 text-right {% if weekly[week][stage] == 0 %}text-slate-300{% endif %}">{{ weekly[week][stage] }}</td>
+            {% endfor %}
+            {% set row_total = weekly[week].values() | sum %}
+            <td class="px-3 py-1 text-right font-semibold">{{ row_total }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script id="throughput-data" type="application/json">{{ chart_data_json | safe }}</script>
+<script>
+  (function () {
+    const el = document.getElementById('throughput-chart');
+    if (!el) return;
+    const c = JSON.parse(document.getElementById('throughput-data').textContent);
+    // Matches the late-funnel slice of /stats/funnel's blue-to-green ramp —
+    // applied/interview/offer read as the same colors on both pages, so the
+    // operator's eye carries "applied = dark green" across views.
+    const colors = {
+      applied: '#059669',
+      interview: '#10b981',
+      offer: '#22c55e',
+    };
+    const datasets = c.datasets.map((ds) => ({
+      label: ds.label,
+      data: ds.data,
+      backgroundColor: colors[ds.label] || '#64748b',
+      borderWidth: 0,
+    }));
+    new Chart(el, {
+      type: 'bar',
+      data: { labels: c.labels, datasets: datasets },
+      options: {
+        responsive: true,
+        scales: {
+          x: { stacked: true, ticks: { maxRotation: 60, minRotation: 0, autoSkip: false } },
+          y: { stacked: true, beginAtZero: true, ticks: { precision: 0 } },
+        },
+        plugins: {
+          legend: { position: 'bottom', labels: { boxWidth: 16 } },
+          tooltip: { mode: 'index', intersect: false },
+        },
+      },
+    });
+  })();
+</script>
+{% endif %}
+{% endblock %}

--- a/tests/test_web_stats_tabs.py
+++ b/tests/test_web_stats_tabs.py
@@ -1,8 +1,8 @@
 """Stats sub-tab bar — full taxonomy visible from day one; deferred tabs disabled.
 
-14e (#63, #193, #194, #195). Funnel, Feedback, Scoring, and Rejections are
-active links; Throughput and Effectiveness render as disabled
-<span aria-disabled="true"> placeholders until #196/#197 ship.
+14e (#63, #193, #194, #195, #196). Funnel, Feedback, Scoring, Rejections, and
+Throughput are active links; Effectiveness renders as a disabled
+<span aria-disabled="true"> placeholder until #197 ships.
 """
 
 import sqlite3
@@ -14,8 +14,8 @@ from fastapi.testclient import TestClient
 from findajob.onboarding import mark_complete
 from findajob.web.app import create_app
 
-ENABLED = {"/stats/funnel", "/stats/feedback", "/stats/scoring", "/stats/rejections"}
-DISABLED_LABELS = ("Throughput", "Effectiveness")
+ENABLED = {"/stats/funnel", "/stats/feedback", "/stats/scoring", "/stats/rejections", "/stats/throughput"}
+DISABLED_LABELS = ("Effectiveness",)
 
 
 @pytest.fixture
@@ -99,6 +99,20 @@ def test_rejections_tab_active_marker(client: TestClient) -> None:
     r = client.get("/stats/rejections")
     assert r.status_code == 200
     idx = r.text.index('href="/stats/rejections"')
+    snippet = r.text[idx : idx + 400]
+    assert 'aria-current="page"' in snippet
+
+
+def test_throughput_tab_has_href(client: TestClient) -> None:
+    r = client.get("/stats/funnel")
+    assert r.status_code == 200
+    assert 'href="/stats/throughput"' in r.text
+
+
+def test_throughput_tab_active_marker(client: TestClient) -> None:
+    r = client.get("/stats/throughput")
+    assert r.status_code == 200
+    idx = r.text.index('href="/stats/throughput"')
     snippet = r.text[idx : idx + 400]
     assert 'aria-current="page"' in snippet
 

--- a/tests/test_web_stats_throughput.py
+++ b/tests/test_web_stats_throughput.py
@@ -1,0 +1,257 @@
+"""Stats throughput route — /stats/throughput SQL correctness + render (#196).
+
+All-time per-ISO-week count of stage transitions into applied/interview/offer,
+sourced from `audit_log` rows where `field_changed='stage'` and `new_value` is
+one of the three throughput stages. Stacked-bar with one tick per audit event,
+so re-applies (e.g., reactivated rows) count separately — the page measures
+event throughput, not currently-applied job count.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+
+
+def _seed_event(
+    conn: sqlite3.Connection,
+    *,
+    job_id: str,
+    field_changed: str,
+    new_value: str,
+    changed_at: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, old_value, new_value, changed_at) VALUES (?, ?, NULL, ?, ?)",
+        (job_id, field_changed, new_value, changed_at),
+    )
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs ("
+        "  id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, company TEXT, stage TEXT, "
+        "  reject_reason TEXT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE feedback_log ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, job_id TEXT NOT NULL, title TEXT NOT NULL, "
+        "company TEXT NOT NULL, relevance_score INTEGER, reject_reason TEXT NOT NULL, "
+        "jd_excerpt TEXT DEFAULT '', created_at TEXT DEFAULT (datetime('now')))"
+    )
+
+    # Week 2026-W18 (Mon 2026-05-04 .. Sun 2026-05-10): 3 applied, 1 interview
+    _seed_event(conn, job_id="j1", field_changed="stage", new_value="applied", changed_at="2026-05-04 10:00:00")
+    _seed_event(conn, job_id="j2", field_changed="stage", new_value="applied", changed_at="2026-05-05 12:00:00")
+    _seed_event(conn, job_id="j3", field_changed="stage", new_value="applied", changed_at="2026-05-10 18:00:00")
+    _seed_event(conn, job_id="j4", field_changed="stage", new_value="interview", changed_at="2026-05-07 09:30:00")
+
+    # Week 2026-W19 (Mon 2026-05-11 .. Sun 2026-05-17): 1 applied, 2 interview, 1 offer
+    _seed_event(conn, job_id="j5", field_changed="stage", new_value="applied", changed_at="2026-05-12 11:00:00")
+    _seed_event(conn, job_id="j6", field_changed="stage", new_value="interview", changed_at="2026-05-13 14:00:00")
+    _seed_event(conn, job_id="j7", field_changed="stage", new_value="interview", changed_at="2026-05-15 10:00:00")
+    _seed_event(conn, job_id="j8", field_changed="stage", new_value="offer", changed_at="2026-05-16 16:00:00")
+
+    # Out-of-scope rows that MUST NOT leak into the payload — negative assertions
+    # below check these don't appear (per feedback_negative_test_assertions).
+    # 1) field_changed != 'stage' but new_value matches a throughput stage
+    _seed_event(conn, job_id="j9", field_changed="user_notes", new_value="applied", changed_at="2026-05-05 10:00:00")
+    # 2) field_changed = 'stage' but new_value is a non-throughput stage
+    _seed_event(conn, job_id="j10", field_changed="stage", new_value="scored", changed_at="2026-05-05 10:00:00")
+    _seed_event(conn, job_id="j11", field_changed="stage", new_value="rejected", changed_at="2026-05-05 10:00:00")
+    _seed_event(conn, job_id="j12", field_changed="stage", new_value="manual_review", changed_at="2026-05-05 10:00:00")
+
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+def test_throughput_renders_200(client: TestClient) -> None:
+    r = client.get("/stats/throughput")
+    assert r.status_code == 200
+
+
+def test_throughput_totals_match_seed(client: TestClient) -> None:
+    r = client.get("/stats/throughput")
+    body = r.text
+    # Totals come from the seed: 4 applied (3 in W18 + 1 in W19), 3 interview
+    # (1 in W18 + 2 in W19), 1 offer.
+    # Assert each total card renders with its expected value adjacent to its
+    # stage label — substring containment is sufficient given the template
+    # shape (`<div>...applied</div><div>...4</div>`), but we also assert grand
+    # total is right.
+    assert 'Total: <span class="font-semibold">8</span> transition' in body
+    # Per-stage totals appear in the totals grid cards.
+    for stage, expected in (("applied", 4), ("interview", 3), ("offer", 1)):
+        assert stage in body
+        # The grid card layout: <div>label</div><div>value</div>. Look for the
+        # label and the value text both — coarse-grained but catches drops.
+        assert f">{expected}<" in body, f"expected total {expected} for {stage}"
+
+
+def test_throughput_table_has_both_weeks(client: TestClient) -> None:
+    r = client.get("/stats/throughput")
+    body = r.text
+    # W18 starts Monday 2026-05-04 → SQLite strftime('%Y-W%W', ...) → "2026-W18"
+    # W19 starts Monday 2026-05-11 → "2026-W19"
+    assert "2026-W18" in body
+    assert "2026-W19" in body
+
+
+def test_throughput_table_is_sorted_descending(client: TestClient) -> None:
+    """Data table renders newest-week-first (operator reads recent activity at the top)."""
+    r = client.get("/stats/throughput")
+    body = r.text
+    w18_idx = body.index("2026-W18")
+    w19_idx = body.index("2026-W19")
+    assert w19_idx < w18_idx, "expected W19 (newer) to appear before W18 (older) in the table"
+
+
+def test_throughput_chart_payload_shape(client: TestClient) -> None:
+    """The embedded JSON payload is what Chart.js consumes — assert its structure
+    directly instead of inferring from rendered HTML."""
+    r = client.get("/stats/throughput")
+    body = r.text
+    # Extract the embedded data block.
+    needle = '<script id="throughput-data" type="application/json">'
+    start = body.index(needle) + len(needle)
+    end = body.index("</script>", start)
+    payload = json.loads(body[start:end])
+
+    assert payload["labels"] == ["2026-W18", "2026-W19"]
+    series = {ds["label"]: ds["data"] for ds in payload["datasets"]}
+    assert series == {
+        "applied": [3, 1],
+        "interview": [1, 2],
+        "offer": [0, 1],
+    }
+
+
+def test_throughput_excludes_out_of_scope_rows(client: TestClient) -> None:
+    """Negative assertions — the seed includes deliberately-poisoning rows that
+    MUST NOT leak into the dashboard. If the WHERE clause loses its
+    `field_changed='stage'` filter or its stage-set restriction, this catches
+    it (per feedback_negative_test_assertions).
+    """
+    r = client.get("/stats/throughput")
+    body = r.text
+    needle = '<script id="throughput-data" type="application/json">'
+    start = body.index(needle) + len(needle)
+    end = body.index("</script>", start)
+    payload = json.loads(body[start:end])
+
+    # No third week should appear (we only seeded W18 and W19; out-of-scope rows
+    # sit inside those weeks but in different field_changed / new_value combos).
+    assert len(payload["labels"]) == 2
+
+    # Per-stage totals stay at the in-scope counts. If field_changed='user_notes'
+    # leaked, applied would be 5 not 4. If new_value='scored' or 'rejected'
+    # leaked, a non-throughput dataset would appear in the payload.
+    series = {ds["label"]: ds["data"] for ds in payload["datasets"]}
+    assert set(series) == {"applied", "interview", "offer"}, "only throughput stages should appear as series"
+    assert sum(series["applied"]) == 4, "applied total leaked an out-of-scope row"
+    # Defensive negative-asserts against the specific poison values.
+    assert "scored" not in series
+    assert "rejected" not in series
+    assert "manual_review" not in series
+
+
+def test_throughput_empty_state(tmp_path: Path) -> None:
+    """No audit_log rows → page renders 200 with empty-state copy, no 500."""
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, "
+        "company TEXT, stage TEXT, reject_reason TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE feedback_log ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, job_id TEXT NOT NULL, title TEXT NOT NULL, "
+        "company TEXT NOT NULL, relevance_score INTEGER, reject_reason TEXT NOT NULL, "
+        "jd_excerpt TEXT DEFAULT '', created_at TEXT DEFAULT (datetime('now')))"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    client = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = client.get("/stats/throughput")
+    assert r.status_code == 200
+    body = r.text
+    assert "No stage transitions" in body
+    # Total is 0 — the singular form should render ("0 transitions" via the
+    # template's '' if grand_total == 1 else 's' guard).
+    assert 'Total: <span class="font-semibold">0</span> transitions' in body
+    # Chart payload should still be present and well-formed even when empty,
+    # but no <canvas> element renders (empty-state branch).
+    assert 'id="throughput-chart"' not in body
+
+
+def test_throughput_ignores_null_changed_at(tmp_path: Path) -> None:
+    """audit_log allows changed_at default of datetime('now'), but pre-existing
+    rows or malformed inserts could carry NULL. The route filters them out so
+    strftime doesn't emit NULL labels."""
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE jobs (id TEXT PRIMARY KEY, fingerprint TEXT, title TEXT, "
+        "company TEXT, stage TEXT, reject_reason TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE audit_log (id INTEGER PRIMARY KEY, job_id TEXT, field_changed TEXT, "
+        "old_value TEXT, new_value TEXT, changed_at TEXT, changed_by TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE feedback_log ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, job_id TEXT NOT NULL, title TEXT NOT NULL, "
+        "company TEXT NOT NULL, relevance_score INTEGER, reject_reason TEXT NOT NULL, "
+        "jd_excerpt TEXT DEFAULT '', created_at TEXT DEFAULT (datetime('now')))"
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, new_value, changed_at) VALUES ('jX', 'stage', 'applied', NULL)"
+    )
+    conn.execute(
+        "INSERT INTO audit_log (job_id, field_changed, new_value, changed_at) "
+        "VALUES ('jY', 'stage', 'applied', '2026-05-04 10:00:00')"
+    )
+    conn.commit()
+    conn.close()
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    client = TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+    r = client.get("/stats/throughput")
+    assert r.status_code == 200
+    body = r.text
+    needle = '<script id="throughput-data" type="application/json">'
+    start = body.index(needle) + len(needle)
+    end = body.index("</script>", start)
+    payload = json.loads(body[start:end])
+
+    # Exactly one week (the non-NULL row), with applied=1.
+    assert payload["labels"] == ["2026-W18"]
+    series = {ds["label"]: ds["data"] for ds in payload["datasets"]}
+    assert series["applied"] == [1]


### PR DESCRIPTION
## Summary

- Adds `GET /stats/throughput` — all-time per-ISO-week stacked-bar of stage transitions into `applied`, `interview`, `offer`. Sources from `audit_log` so it measures *event throughput*, not currently-applied job count.
- Flips the `Throughput` tab from disabled to active in `templates/stats/_tabs.html`. The other 14e dashboards (`/funnel`, `/feedback`, `/scoring`, `/rejections`) have all shipped; this leaves only `/effectiveness` (#197) disabled.
- Series colors match the late-funnel slice of `/stats/funnel`'s blue-to-green ramp (`#059669/#10b981/#22c55e`) so `applied = dark green` reads consistently across `/stats/*`. Convention is documented in the template's JS comment for the next stats page to pick up.

Closes #196.

### Why the design choices look the way they do

- **`field_changed='stage'` filter** — defensive against any future audit row that happens to set `new_value='applied'` on a non-stage field. Mirrors the pattern in `/stats/funnel` and `findajob/actions.py`.
- **`changed_at IS NOT NULL` guard** — `audit_log.changed_at` defaults to `datetime('now')` but historic / migrated rows could carry NULL; without the guard, `strftime` emits a NULL week label that would render as a blank x-axis tick. Test `test_throughput_ignores_null_changed_at` pins this.
- **`%W` not `%V`** — SQLite doesn't expose ISO 8601's `%V`. `%W` (Monday-based, 00–53) is close enough for at-a-glance weekly cadence and is what the AC specified.
- **Empty-state branch** — renders informative copy ("No stage transitions to applied/interview/offer recorded yet") rather than an empty `<canvas>` or 500. Same shape as `/stats/rejections`'s zero-row guard.

## Test plan

- [x] `pytest tests/test_web_stats_throughput.py tests/test_web_stats_tabs.py` — 20 passed
- [x] Full stats suite `pytest -k stats` — 52 passed, no regressions in funnel / feedback / scoring / rejections
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `mypy src/findajob/web/routes/stats.py` — no issues
- [x] **Local uvicorn smoke** — seeded scratch DB with 15 in-scope transitions across 3 ISO weeks + 3 poison rows (`field_changed='user_notes'` with stage value, `field_changed='stage'` with non-throughput value), `GET /stats/throughput` returns 200 with correct payload:
  - Labels `["2026-W18", "2026-W19", "2026-W20"]`
  - applied `[5, 3, 2]`, interview `[1, 2, 1]`, offer `[0, 1, 0]`, grand total = 15
  - Poison rows excluded (applied total = 10, would be 11 if `user_notes` leaked)
  - Tab carries `aria-current="page"` (active link, not disabled span)
  - Data table sorted W20 → W19 → W18 (descending by week)
- [x] **Negative assertions** — `test_throughput_excludes_out_of_scope_rows` pins WHERE-clause correctness so a future loosening can't silently drift (per `feedback_negative_test_assertions`)
- [ ] **Visual Chart.js render verification** — skipped. Playwright was stopped at the operator's request earlier in the session; `findajob-clean` is held by a parallel session. The Chart.js block copies the working pattern from `/stats/rejections` (already shipped in #776), so the visual-rendering risk surface is limited to color consistency, which is locked to the documented `/stats/funnel` palette.

## Files

- `src/findajob/web/routes/stats.py` — new `/stats/throughput` handler + `_THROUGHPUT_STAGES` constant
- `src/findajob/web/templates/stats/throughput.html` — new template (stacked bar + data table + empty state)
- `src/findajob/web/templates/stats/_tabs.html` — `Throughput` tab flipped from `false` to `true`
- `tests/test_web_stats_throughput.py` — 8 new tests
- `tests/test_web_stats_tabs.py` — Throughput moved from disabled-tabs assertion into the enabled-set
- `CHANGELOG.md` — `[Unreleased] ### Added` entry

**No `migration-required`** — purely additive route + template + tab flip + tests; no schema, config, cron, mount, or compose changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)