### PR TITLE
docs(install-fly,README): defensive command blocks for non-engineers (#783)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,19 +148,28 @@ Full runbook (15 minutes of reading + executing): [`docs/getting-started/install
 In short:
 
 ```bash
-# Install flyctl
-brew install flyctl                                    # macOS
-curl -L https://fly.io/install.sh | sh                 # Linux
+# 1. (macOS only) Install Homebrew if you don't have it — see https://brew.sh
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# Clone the repo (you'll only edit one config line)
+# 2. Install flyctl
+brew install flyctl                              # macOS
+curl -L https://fly.io/install.sh | sh           # Linux
+
+# 3. Clone the repo (creates a "findajob" folder in your current directory)
 git clone https://github.com/brockamer/findajob.git
 cd findajob
 
-# Sign in and deploy
+# 4. Sign in to Fly (opens a browser; signs you up if you don't have an account yet)
 fly auth login
+
+# 5. Pick your app name (becomes part of your URL)
 cp ops/fly.toml.example ops/fly.toml
-$EDITOR ops/fly.toml                                   # change `app = "findajob-<your-handle>"`
-bash ops/fly-deploy.sh                                 # prompts for API keys, creates app + volume, deploys
+open -e ops/fly.toml                             # macOS — opens in TextEdit
+nano ops/fly.toml                                # Linux — terminal editor
+# Change the line: app = "findajob-<your-handle>"
+
+# 6. Deploy (creates the app + 8GB volume, prompts for API keys, runs `fly deploy`)
+bash ops/fly-deploy.sh
 ```
 
 The script provisions the Fly app + 8 GB volume, stages your API keys as Fly secrets, runs `fly deploy`, and verifies the basic-auth gate post-deploy. On success it prints your URL: `https://findajob-<your-handle>.fly.dev/`.

--- a/docs/getting-started/install-fly.md
+++ b/docs/getting-started/install-fly.md
@@ -48,6 +48,8 @@ curl -L https://fly.io/install.sh | sh
 iwr https://fly.io/install.ps1 -useb | iex
 ```
 
+If you don't have Homebrew yet: see <https://brew.sh> — the install takes 5 minutes and asks for your Mac login password.
+
 The Fly installer page (<https://fly.io/docs/flyctl/install/>) has alternative installers and PATH-troubleshooting tips if any of the above don't work. After installing:
 
 ```
@@ -67,6 +69,8 @@ git clone https://github.com/brockamer/findajob.git
 cd findajob
 ```
 
+If you don't have git: on macOS, run `git --version` and accept the Command Line Tools install prompt. On Linux, `sudo apt install git` (Debian/Ubuntu) or `sudo dnf install git` (Fedora/RHEL).
+
 You won't edit pipeline code — only the `ops/fly.toml` config to set your app name.
 
 ## 3. Configure your app name
@@ -75,7 +79,8 @@ Copy the example fly.toml and pick a handle. The handle is the leftmost label of
 
 ```
 cp ops/fly.toml.example ops/fly.toml
-$EDITOR ops/fly.toml
+open -e ops/fly.toml      # macOS — opens in TextEdit
+nano ops/fly.toml         # Linux — terminal editor
 ```
 
 Change one line:
@@ -216,7 +221,8 @@ If a deploy goes bad:
 
 ```
 fly releases --app findajob-<your-handle>      # find your prior version
-$EDITOR ops/fly.toml                            # set image to that prior tag
+open -e ops/fly.toml                            # macOS — set image to that prior tag in TextEdit
+nano ops/fly.toml                               # Linux — set image to that prior tag in nano
 fly deploy --config ops/fly.toml
 fly ssh console --app findajob-<your-handle> --command "python -m findajob.web.verify_auth"
 ```


### PR DESCRIPTION
## Summary

The README §Quick start sells Fly as "recommended for most people" but the §Deploy — Fly.io command block immediately under it assumes Homebrew is installed, `git` is on PATH, and `$EDITOR` is set. The same dev-tooling assumptions appear in `install-fly.md`. Surfaced during the #672 unaffiliated-tester persona walkthrough (M3 README findings + M5 install-fly.md findings).

This PR fixes both surfaces in one consistent voice — the pattern is the same on both, just expressed in two different forms (inline parenthetical comments in README, footnotes in install-fly.md).

## Changes — README §Deploy — Fly.io

- Reformatted as 6 numbered steps with plain-language parentheticals per command
- **Step 1 (macOS only):** inline Homebrew install command + `brew.sh` link as fallback
- **Step 4:** `fly auth login` annotated to clarify it includes signup
- **Step 5:** `$EDITOR ops/fly.toml` → explicit `open -e` (macOS, TextEdit) and `nano` (Linux). Default-shell zsh with no `$EDITOR` set no longer produces `zsh: permission denied: ops/fly.toml`

## Changes — install-fly.md

- **§1 Install flyctl:** Homebrew-prereq footnote pointing at brew.sh with expected install time + sudo-prompt acknowledgment
- **§2 Clone the repo:** git-prereq footnote covering macOS Command Line Tools install + Linux `apt`/`dnf`
- **§3 Configure your app name:** `$EDITOR ops/fly.toml` → `open -e` / `nano` (matches README)
- **§Rollback:** same `$EDITOR` → `open -e` / `nano` replacement for consistency (not strictly an AC item but a non-engineer hitting their first rollback is the worst time to discover their `$EDITOR` is unset; flagging in case reviewer prefers narrower scope)

## Acceptance criteria

- [x] No command in the README §Deploy — Fly.io inline block fails on a default-shell macOS install with zero developer tooling
- [x] Every command in that block has a parenthetical comment explaining what it does in plain language
- [x] `$EDITOR` replaced with concrete editor invocations on BOTH README and install-fly.md
- [x] Homebrew prerequisite addressed on both surfaces (inlined in README, footnoted in install-fly.md)
- [x] git prerequisite addressed on install-fly.md
- [x] Single PR touches `README.md` + `docs/getting-started/install-fly.md` consistently

## Test plan

- [x] `grep '\$EDITOR'` returns zero hits across both files
- [x] Manual review of `git diff` for sentence flow + idiom consistency
- [x] Pre-commit PII scan ran clean (52 patterns × 24 added lines)
- [ ] Render of `/docs/getting-started/install-fly` on a running stack not validated locally (straight-markdown edit; no Jinja/HTMX surface)

Closes #783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)