### PR TITLE
feat(docs/gmail): #796 sub-finding B — inline disclosure + CI sync check (re-open of #801)

### DIFF
--- a/docs/getting-started/gmail.md
+++ b/docs/getting-started/gmail.md
@@ -19,12 +19,52 @@ test mechanic are identical.
 
 ## What findajob will and won't access
 
-<!-- gmail-disclosure-sync -->
+> ⓘ **What findajob does — and doesn't do — with your Gmail.**
 
-(The above marker is replaced with the disclosure language at render
-time. The single source of truth for that text is the Jinja partial at
-`src/findajob/web/templates/_gmail_disclosure.html`. Editing it changes
-both this page and the `/config/gmail/` page in lockstep.)
+findajob reads job-alert emails from senders you list (LinkedIn by
+default) so it can score them and surface them on your board. It
+**does not** read other mail, send mail, modify labels, or move
+messages. Your app password lives only on this stack — never on a
+server we control.
+
+findajob is open source. You can audit the exact code that touches
+your mailbox before granting access:
+
+- [`src/findajob/gmail_imap.py`](https://github.com/brockamer/findajob/blob/main/src/findajob/gmail_imap.py) — IMAP client
+- [`src/findajob/fetchers/adapters/gmail.py:GmailLinkedInAdapter`](https://github.com/brockamer/findajob/blob/main/src/findajob/fetchers/adapters/gmail.py)
+
+<details>
+<summary>Show full disclosure</summary>
+
+### 1. Exact scope (what we touch)
+
+- IMAP `LOGIN` to `imap.gmail.com:993`
+- IMAP `SEARCH (FROM "<sender>")` for each allowlisted sender, with `UID > <last seen>`
+- IMAP `FETCH (BODY.PEEK[])` of message bodies
+- IMAP `LOGOUT`
+
+That is the entire wire protocol. No `STORE`, no `COPY`, no `EXPUNGE`, no `APPEND`, no folder traversal beyond INBOX.
+
+### 2. What we can't do
+
+- findajob has no SMTP code path. It cannot send mail.
+- findajob never calls `STORE`/`MOVE`/`EXPUNGE`. It cannot modify, label, or delete your messages.
+- findajob never reads outside your allowlisted senders. The `SEARCH FROM` filter is applied server-side by Gmail before anything is fetched.
+
+### 3. Where your credentials live
+
+- `config/gmail.json` on this stack only (chmod 600). Bind-mounted to the host filesystem at `state/config/gmail.json`. Never transmitted off this machine. Never logged. Never sent to any LLM, scoring service, or external API.
+- Both `config/gmail.json` and `config/gmail_state.json` are gitignored — they cannot be accidentally committed.
+
+### 4. How to revoke access
+
+- **At Google (instant, total revocation):** [myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords) — revoke the app password labeled `findajob-<your-handle>`.
+- **In findajob (instant, this stack only):** click *Disconnect Gmail integration* on `/config/gmail/`. Wipes both config files. Google-side app password remains valid until separately revoked there.
+- **Recommendation:** revoke at Google for any "I want this to stop now" scenario.
+
+</details>
+
+The single source of truth for this text is `src/findajob/web/templates/_gmail_disclosure.html` (the Jinja partial used by `/config/gmail/` and the onboarding gate). The CI test in `tests/test_gmail_disclosure_sync.py` asserts the text above stays in sync with that partial — edits must touch both files.
 
 ## Step-by-step setup
 
@@ -85,8 +125,7 @@ ingestion volume).
 
 ## How to revoke access
 
-See the **How to revoke access** section of the disclosure above. Two
-surfaces:
+See **§4 How to revoke access** in the disclosure above. Two surfaces:
 
 1. **At Google** — instant, total revocation:
    <https://myaccount.google.com/apppasswords>.

--- a/src/findajob/web/routes/docs.py
+++ b/src/findajob/web/routes/docs.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
-from findajob.web import constants
 from findajob.web.markdown import render_markdown
 
 router = APIRouter()
@@ -89,13 +88,6 @@ def docs_page(slug: str, request: Request) -> HTMLResponse:
     body = path.read_text(encoding="utf-8", errors="replace")
     templates = request.app.state.templates
     rendered_md = render_markdown(body, source=rel)
-    if slug == "getting-started/gmail":
-        _MARKER = "<!-- gmail-disclosure-sync -->"
-        if _MARKER in rendered_md:
-            partial_html = templates.get_template("_gmail_disclosure.html").render(
-                {"github_blob_url": constants.github_blob_url}
-            )
-            rendered_md = rendered_md.replace(_MARKER, partial_html, 1)
     return templates.TemplateResponse(
         request=request,
         name="docs/page.html",

--- a/src/findajob/web/templates/_gmail_disclosure.html
+++ b/src/findajob/web/templates/_gmail_disclosure.html
@@ -87,9 +87,10 @@
                target="_blank" rel="noopener">myaccount.google.com/apppasswords</a>
             → revoke the app password labeled <code>findajob-&lt;your-handle&gt;</code>.</li>
           <li><strong>In findajob (instant, this stack only):</strong>
-            click <em>Disconnect Gmail integration</em> below. Wipes both
-            config files. Google-side app password remains valid until
-            separately revoked there.</li>
+            click <em>Disconnect Gmail integration</em> on
+            <code>/config/gmail/</code>. Wipes both config files.
+            Google-side app password remains valid until separately
+            revoked there.</li>
           <li><strong>Recommendation:</strong> revoke at Google for any "I
             want this to stop now" scenario.</li>
         </ul>

--- a/tests/test_gmail_disclosure_sync.py
+++ b/tests/test_gmail_disclosure_sync.py
@@ -1,29 +1,124 @@
-"""Asserts the disclosure-language sync chain stays intact.
+"""Asserts the disclosure language stays in sync between two surfaces.
 
-The Jinja partial templates/_gmail_disclosure.html is the single source
-of truth. docs/getting-started/gmail.md must contain the marker comment so the
-docs renderer knows where to substitute. If either drifts, this test
-catches it.
+The Jinja partial `src/findajob/web/templates/_gmail_disclosure.html` is
+the source of truth for the disclosure rendered on `/config/gmail/` and
+the onboarding gate. `docs/getting-started/gmail.md` repeats the same
+language statically so the GitHub-rendered view shows the disclosure
+*before* a stranger deploys findajob (the moment they're deciding whether
+to trust the project with Gmail credentials — #796 sub-finding B).
+
+Both files must say the same thing. This test normalizes both to a flat
+token stream (HTML tags stripped, entities resolved, markdown syntax
+stripped, lowercased, non-alphanumeric collapsed) and asserts the
+partial's token sequence appears as a subsequence of the doc's token
+sequence — i.e., every word from the partial appears in the doc in the
+same order, with extra contextual words allowed in the doc (H2 heading
+text, footer pointer, first-time-reader framing).
+
+When the test fails, the message names the specific token that broke the
+match and the surrounding context, so maintainers can locate the diverged
+sentence without re-reading both files.
 """
 
+from __future__ import annotations
+
+import re
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 PARTIAL = REPO / "src" / "findajob" / "web" / "templates" / "_gmail_disclosure.html"
 DOC = REPO / "docs" / "getting-started" / "gmail.md"
-MARKER = "<!-- gmail-disclosure-sync -->"
+
+# The doc's disclosure section runs from the "## What findajob will and
+# won't access" heading to the next H2.
+_DOC_SECTION_START_RE = re.compile(r"^## What findajob will and won't access\s*$", re.MULTILINE)
+_DOC_SECTION_END_RE = re.compile(r"^## ", re.MULTILINE)
+
+# The maintainer-pointer paragraph at the bottom of the doc's disclosure
+# section is not part of the partial; drop it before comparing.
+_DOC_FOOTER_RE = re.compile(
+    r"The single source of truth for this text.*?must touch both files\.",
+    re.DOTALL,
+)
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_JINJA_RE = re.compile(r"\{\{[^}]+\}\}|\{%[^%]+%\}|\{#.*?#\}", re.DOTALL)
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+_HTML_ENTITY_RE = re.compile(r"&#?[a-zA-Z0-9]+;")
+_NON_ALNUM_RE = re.compile(r"[^a-z0-9]+")
+_WHITESPACE_RE = re.compile(r"\s+")
 
 
-def test_disclosure_partial_exists():
-    assert PARTIAL.exists()
+def _extract_doc_section() -> str:
+    body = DOC.read_text(encoding="utf-8")
+    start_match = _DOC_SECTION_START_RE.search(body)
+    assert start_match is not None, "gmail.md is missing the disclosure H2 heading"
+    after_heading = body[start_match.end() :]
+    end_match = _DOC_SECTION_END_RE.search(after_heading)
+    assert end_match is not None, "gmail.md disclosure section has no following H2 terminator"
+    return after_heading[: end_match.start()]
 
 
-def test_gmail_doc_exists():
-    assert DOC.exists()
+def _normalize(text: str) -> list[str]:
+    """Reduce text to a list of lowercase word tokens.
+
+    Strips HTML tags, resolves the four common HTML entities so
+    angle-bracketed placeholders like `&lt;your-handle&gt;` survive into
+    the comparison (and are then stripped uniformly by HTML-tag removal,
+    matching the doc's `<your-handle>` literal). Markdown emphasis and
+    link syntax are stripped; the visible link text is preserved.
+    """
+    # Resolve the common HTML entities BEFORE stripping tags, so the
+    # `<your-handle>` placeholder is treated symmetrically in both files.
+    text = text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&").replace("&nbsp;", " ")
+    text = _JINJA_RE.sub("", text)
+    text = _HTML_TAG_RE.sub("", text)
+    text = _HTML_ENTITY_RE.sub("", text)
+    text = _MD_LINK_RE.sub(r"\1", text)
+    text = text.replace("**", "").replace("__", "")  # markdown bold
+    text = text.lower()
+    text = _NON_ALNUM_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    return text.split()
 
 
-def test_gmail_doc_has_marker():
-    assert MARKER in DOC.read_text(), (
-        f"docs/getting-started/gmail.md must contain the {MARKER!r} comment marker "
-        f"so the docs renderer can substitute the disclosure partial."
-    )
+def test_disclosure_partial_exists() -> None:
+    assert PARTIAL.exists(), f"Source-of-truth partial missing: {PARTIAL}"
+
+
+def test_gmail_doc_exists() -> None:
+    assert DOC.exists(), f"User-facing doc missing: {DOC}"
+
+
+def test_disclosure_text_matches_partial() -> None:
+    """The partial's tokens must appear as a subsequence of the doc's tokens.
+
+    Asymmetric, not strict equality: the doc may include extra framing
+    the partial doesn't carry (H2 heading text, maintainer footer,
+    first-time-reader context). What must NOT happen is the partial
+    saying something the doc omits — that's a disclosure-gap bug on the
+    pre-deploy surface, exactly the failure mode this test exists to
+    catch.
+    """
+    partial_tokens = _normalize(PARTIAL.read_text(encoding="utf-8"))
+    doc_section = _extract_doc_section()
+    doc_section = _DOC_FOOTER_RE.sub("", doc_section)
+    doc_tokens = _normalize(doc_section)
+
+    doc_cursor = 0
+    for partial_idx, token in enumerate(partial_tokens):
+        try:
+            found_at = doc_tokens.index(token, doc_cursor)
+        except ValueError:
+            partial_context = " ".join(partial_tokens[max(0, partial_idx - 5) : partial_idx + 6])
+            doc_context = " ".join(doc_tokens[max(0, doc_cursor - 5) : doc_cursor + 6])
+            raise AssertionError(
+                "Disclosure drift: gmail.md is missing prose from the partial.\n"
+                f"Partial token {partial_idx} ({token!r}) not found in gmail.md "
+                f"after position {doc_cursor}.\n\n"
+                f"Partial context (around token {partial_idx}):\n  …{partial_context}…\n\n"
+                f"Doc context (around cursor {doc_cursor}):\n  …{doc_context}…\n\n"
+                "Either restore the partial's wording in gmail.md, or update the "
+                "partial if the doc's wording is the new canonical version."
+            ) from None
+        doc_cursor = found_at + 1

--- a/tests/test_gmail_disclosure_sync.py
+++ b/tests/test_gmail_disclosure_sync.py
@@ -9,15 +9,23 @@ to trust the project with Gmail credentials — #796 sub-finding B).
 
 Both files must say the same thing. This test normalizes both to a flat
 token stream (HTML tags stripped, entities resolved, markdown syntax
-stripped, lowercased, non-alphanumeric collapsed) and asserts the
-partial's token sequence appears as a subsequence of the doc's token
-sequence — i.e., every word from the partial appears in the doc in the
-same order, with extra contextual words allowed in the doc (H2 heading
-text, footer pointer, first-time-reader framing).
+stripped, lowercased, non-alphanumeric collapsed) and asserts the two
+token sequences match as a bidirectional subsequence — every word in
+each file appears in the other in the same order, with no excess.
 
-When the test fails, the message names the specific token that broke the
-match and the surrounding context, so maintainers can locate the diverged
-sentence without re-reading both files.
+The bidirectional check matters: the partial is the in-app
+credential-entry surface (the page where the user types their Gmail
+app password). If only the doc-direction were checked, someone could
+quietly weaken the partial — removing "never sent to any LLM" from the
+in-app disclosure — and the test would still pass because the
+partial's shorter token list is trivially a subsequence of the doc's.
+That failure mode is the privacy-disclosure equivalent of the bug
+that triggered #796 in the first place.
+
+When the test fails, the message names the specific token that broke
+the match in whichever direction failed, plus surrounding context from
+both files, so maintainers can locate the diverged sentence without
+re-reading both surfaces.
 """
 
 from __future__ import annotations
@@ -90,35 +98,56 @@ def test_gmail_doc_exists() -> None:
     assert DOC.exists(), f"User-facing doc missing: {DOC}"
 
 
-def test_disclosure_text_matches_partial() -> None:
-    """The partial's tokens must appear as a subsequence of the doc's tokens.
+def _check_subsequence(
+    source_tokens: list[str],
+    target_tokens: list[str],
+    source_label: str,
+    target_label: str,
+) -> None:
+    """Assert source_tokens appears as a subsequence of target_tokens.
 
-    Asymmetric, not strict equality: the doc may include extra framing
-    the partial doesn't carry (H2 heading text, maintainer footer,
-    first-time-reader context). What must NOT happen is the partial
-    saying something the doc omits — that's a disclosure-gap bug on the
-    pre-deploy surface, exactly the failure mode this test exists to
-    catch.
+    On mismatch, raises AssertionError naming the diverging token, its
+    index in the source, and context windows from both sides.
+    """
+    target_cursor = 0
+    for source_idx, token in enumerate(source_tokens):
+        try:
+            found_at = target_tokens.index(token, target_cursor)
+        except ValueError:
+            source_context = " ".join(source_tokens[max(0, source_idx - 5) : source_idx + 6])
+            target_context = " ".join(target_tokens[max(0, target_cursor - 5) : target_cursor + 6])
+            raise AssertionError(
+                f"Disclosure drift: {target_label} is missing prose from {source_label}.\n"
+                f"{source_label} token {source_idx} ({token!r}) not found in {target_label} "
+                f"after position {target_cursor}.\n\n"
+                f"{source_label} context (around token {source_idx}):\n  …{source_context}…\n\n"
+                f"{target_label} context (around cursor {target_cursor}):\n  …{target_context}…\n\n"
+                f"Either restore {source_label}'s wording in {target_label}, or update "
+                f"{source_label} if {target_label}'s wording is the new canonical version."
+            ) from None
+        target_cursor = found_at + 1
+
+
+def test_disclosure_text_matches_partial() -> None:
+    """Bidirectional subsequence equivalence between the partial and the doc section.
+
+    The H2 heading and the maintainer footer in gmail.md are stripped
+    before comparison — those are legitimate doc-only framing. Anything
+    else that diverges in either direction is drift the test surfaces.
     """
     partial_tokens = _normalize(PARTIAL.read_text(encoding="utf-8"))
     doc_section = _extract_doc_section()
     doc_section = _DOC_FOOTER_RE.sub("", doc_section)
     doc_tokens = _normalize(doc_section)
 
-    doc_cursor = 0
-    for partial_idx, token in enumerate(partial_tokens):
-        try:
-            found_at = doc_tokens.index(token, doc_cursor)
-        except ValueError:
-            partial_context = " ".join(partial_tokens[max(0, partial_idx - 5) : partial_idx + 6])
-            doc_context = " ".join(doc_tokens[max(0, doc_cursor - 5) : doc_cursor + 6])
-            raise AssertionError(
-                "Disclosure drift: gmail.md is missing prose from the partial.\n"
-                f"Partial token {partial_idx} ({token!r}) not found in gmail.md "
-                f"after position {doc_cursor}.\n\n"
-                f"Partial context (around token {partial_idx}):\n  …{partial_context}…\n\n"
-                f"Doc context (around cursor {doc_cursor}):\n  …{doc_context}…\n\n"
-                "Either restore the partial's wording in gmail.md, or update the "
-                "partial if the doc's wording is the new canonical version."
-            ) from None
-        doc_cursor = found_at + 1
+    # Direction 1: every partial token must appear in the doc. Catches
+    # "doc dropped a privacy claim the partial still asserts."
+    _check_subsequence(partial_tokens, doc_tokens, "_gmail_disclosure.html", "gmail.md")
+
+    # Direction 2: every doc-section token must appear in the partial.
+    # Catches the inverse — "partial was quietly weakened; the in-app
+    # credential-entry surface now says less than the doc promises."
+    # This is the more privacy-sensitive direction, since the partial
+    # is what users see when they're about to type their Gmail app
+    # password.
+    _check_subsequence(doc_tokens, partial_tokens, "gmail.md", "_gmail_disclosure.html")


### PR DESCRIPTION
## Summary

Closes #796 sub-finding B. **Replaces closed #801** (auto-closed when its parent base branch `feat/796-walk1-doc-fixes` was deleted after #800's squash-merge). Same content, rebased onto main.

The Gmail privacy disclosure was previously rendered only at request time on `/docs/getting-started/gmail` — a marker comment (`<!-- gmail-disclosure-sync -->`) in `gmail.md` was substituted with the styled Jinja partial. The GitHub-rendered view of `gmail.md` (the surface a stranger sees *before* deciding to deploy findajob and trust it with Gmail credentials) showed only the marker comment and a meta-explanation of the rendering mechanism — exactly hiding the wrong thing at exactly the wrong moment.

This PR inlines the disclosure text statically in `gmail.md` so the GitHub view shows it, and replaces the existing marker-presence test with a bidirectional content-equivalence test that catches drift between the two surfaces in either direction.

### Changes

- **`docs/getting-started/gmail.md`** — replace the marker + meta-explanation with the full disclosure inlined as markdown: heading, two intro paragraphs (what findajob does/doesn't do), two audit-source links pinned to `main`, and a `<details>`-collapsed 4-section deep dive (exact wire protocol scope, can't-do list, credential storage, revocation procedures). Footer paragraph points maintainers at the source-of-truth file and the sync test.
- **`src/findajob/web/routes/docs.py`** — remove the special-case marker-substitution branch (dead code now that the doc is self-contained); drop the unused `constants` import.
- **`src/findajob/web/templates/_gmail_disclosure.html`** — reword "click Disconnect Gmail integration *below*" → "on `/config/gmail/`" so both surfaces use the same URL-anchored wording instead of UI-position-dependent language. Mild redundancy on the in-app `/config/gmail/` page (the URL is the current page) but a much cleaner contract for the docs surface.
- **`tests/test_gmail_disclosure_sync.py`** — replace the marker-presence assertion with a bidirectional content-equivalence test. Normalization: strip HTML tags + Jinja directives + markdown link syntax + emphasis markers, resolve common HTML entities, lowercase, collapse non-alphanumeric to spaces. Assertion: each file's token sequence appears as a subsequence of the other (modulo the H2 heading and maintainer footer in the doc). The bidirectional check catches drift in either direction — the partial-direction case matters specifically because the partial is the in-app credential-entry trust surface and silent weakening would be a privacy-disclosure bug, exactly the kind of bug that prompted #796.

### Design choice: CI test vs pre-commit hook vs build-time generator

Consulted `advisor()` before locking the sync mechanism. The three options in #796's body were CI assertion, pre-commit hook, or template-rendered static asset. Chose CI assertion (pytest):

- **Build-time generator** (refactor source-of-truth to markdown, render to HTML for the in-app view) was the cleanest architecturally but the biggest change — loses the Tailwind styling without additional rendering work, and #796's body explicitly recommended "build-time check that confirms the static text matches", not a re-architecture.
- **Pre-commit hook** would slow the commit loop (pre-commit already does PII scan + format checks). CI is where this belongs.
- **CI assertion** matches #796's recommendation exactly, is the smallest change, and gives clear failure output. The trade-off — edits must touch both files — is what #796 explicitly accepted.

## Test plan

- [x] `uv run pytest tests/test_gmail_disclosure_sync.py -v` — 3/3 pass (the bidirectional content-equivalence assertion actually caught a real drift case during dev: the partial said "click Disconnect below" but the doc-surface needs URL-anchored wording — fixed by aligning the partial)
- [x] `uv run pytest tests/ -k gmail` — 98/98 pass (covers the in-app `/config/gmail/` + `/onboarding/gmail-config/` routes that still consume the partial, plus the existing transparency invariants suite)
- [x] `uv run pytest tests/test_web_docs.py` — 15/15 pass (covers the docs route after removing the marker-substitution branch)
- [x] `uv run ruff check + format --check` on edited Python — clean
- [x] Pre-commit PII scan ran (52 patterns × 160 added lines, no matches)
- [x] PII hand-check on diff for tester real names + operator topology — clean
- [x] GitHub markdown render of inlined `<details>` block verified via `gh api -X POST /markdown` — H3 + lists + code spans + entity-escaped `<your-handle>` placeholders all render cleanly
- [ ] In-browser visual eyeball of the reworded `/config/gmail/` page in-app (not run — purely text replacement, no markup change; 98 gmail tests cover the rendering paths)
- [ ] Container integration smoke (`scripts/test_container_integration.sh`) on the operator's primary docker host post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
