### PR TITLE
docs(readme): #805 surface JSearch alongside jobs-api14 in setup sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Changed
+
+- **#805 docs(readme): surface JSearch alongside jobs-api14 in setup sections.** Documentation drift from #408 (curated RapidAPI feed picker, shipped 2026-04-09): the picker treats jobs-api14 and JSearch as peers (both written by the onboarding interview to `config/active_sources.txt`, both sharing `RAPIDAPI_KEY`), and `docs/getting-started/api-keys.md` + `docs/getting-started/install-docker.md` document them that way — but the README's §Pre-Deploy Requirements still listed only "RapidAPI (jobs-api14)" as if it were the sole option. New users hitting jobs-api14's 150 req/mo cap had no signpost to JSearch's 200 req/mo BASIC tier as an alternative. README §Pre-Deploy now names both with parallel quota framing and points at `/settings/active-sources/` for the flip; `docs/getting-started/configure.md`'s `## config/jsearch_queries.txt` section gains a one-paragraph activation note pointing at the same UI surface. README §Step 1 left unchanged: the generic "RapidAPI (optional)" already covers both adapters since they share a key. **No `migration-required`** — documentation only.
+
 ## [0.27.7] — 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ One required API key (both paths):
 
 One optional API key (both paths):
 
-- **RapidAPI (jobs-api14 or JSearch)** — LinkedIn / Indeed / Bing search ingestion. BASIC plans are free with no credit card: 150 req/month on jobs-api14, 200 req/month on JSearch. The onboarding picker chooses one per stack (both share the same `RAPIDAPI_KEY`); you can flip later at `/settings/active-sources/`. Skipping it means findajob ingests only from the direct ATS feeds (Greenhouse, Ashby, Lever, Workday) at the companies you named in onboarding, plus your Gmail job alerts. Most users want LinkedIn too — it catches roles the direct feeds miss.
+- **RapidAPI (jobs-api14 or JSearch)** — LinkedIn / Indeed search ingestion. BASIC plans are free with no credit card: 150 req/month on jobs-api14, 200 req/month on JSearch. The onboarding picker chooses one per stack (both share the same `RAPIDAPI_KEY`); you can flip later at `/settings/active-sources/`. Skipping it means findajob ingests only from the direct ATS feeds (Greenhouse, Ashby, Lever, Workday) at the companies you named in onboarding, plus your Gmail job alerts. Most users want LinkedIn too — it catches roles the direct feeds miss.
 
 Sign-up walkthroughs: [`docs/getting-started/api-keys.md`](docs/getting-started/api-keys.md). Both keys get pasted into the in-app onboarding form once your stack is up.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ One required API key (both paths):
 
 One optional API key (both paths):
 
-- **RapidAPI (jobs-api14)** — LinkedIn / Indeed / Bing search ingestion. BASIC plan is 150 req/month free, no credit card. Skipping it means findajob ingests only from the direct ATS feeds (Greenhouse, Ashby, Lever, Workday) at the companies you named in onboarding, plus your Gmail job alerts. Most users want LinkedIn too — it catches roles the direct feeds miss.
+- **RapidAPI (jobs-api14 or JSearch)** — LinkedIn / Indeed / Bing search ingestion. BASIC plans are free with no credit card: 150 req/month on jobs-api14, 200 req/month on JSearch. The onboarding picker chooses one per stack (both share the same `RAPIDAPI_KEY`); you can flip later at `/settings/active-sources/`. Skipping it means findajob ingests only from the direct ATS feeds (Greenhouse, Ashby, Lever, Workday) at the companies you named in onboarding, plus your Gmail job alerts. Most users want LinkedIn too — it catches roles the direct feeds miss.
 
 Sign-up walkthroughs: [`docs/getting-started/api-keys.md`](docs/getting-started/api-keys.md). Both keys get pasted into the in-app onboarding form once your stack is up.
 

--- a/docs/getting-started/configure.md
+++ b/docs/getting-started/configure.md
@@ -51,6 +51,12 @@ The resume tailor selects and reorders content from this file — it doesn't add
 > onboarding overwrites them, but backs up the prior content under
 > `.backups/{UTC-stamp}/`.
 
+> **Activating JSearch.** This file's queries only run if `jsearch` is
+> listed in `config/active_sources.txt`. The onboarding picker writes
+> that for new stacks; to flip JSearch on or off later, tick the
+> checkbox at `/settings/active-sources/`. Stacks shipping the default
+> `['jobs-api14']` need this step before any queries here are used.
+
 LinkedIn and Indeed search queries. One per line. Blank lines and `#` comments ignored.
 
 **Critical rules:**


### PR DESCRIPTION
## Summary

- README §Pre-Deploy now names both `jobs-api14` and `JSearch` with parallel BASIC-tier quota framing (150 vs 200 req/month) and points at `/settings/active-sources/` for the flip.
- `docs/getting-started/configure.md` §`config/jsearch_queries.txt`: one activation paragraph explaining the `active_sources.txt` / `/settings/active-sources/` step before queries from that file run.
- CHANGELOG `[Unreleased]` §Changed entry.

## Investigation finding

Documentation drift, **not** intentional advanced-feature gating. JSearch shipped via #408 (curated RapidAPI feed picker framework, PR #413) and was further built out via #414 (PR #421, shared `RAPIDAPI_KEY` + num_pages env var). The onboarding picker treats jobs-api14 and JSearch as peers, and downstream docs (`api-keys.md`, `install-docker.md`) reflect that — but the README's §Pre-Deploy and §Step 1 sections were not updated in the same PR, so new users reading the setup happy-path saw "RapidAPI (jobs-api14)" as if it were the sole option.

## Out of scope (per issue #805's acceptance)

§Step 1 line 221 — `OpenRouter (required) + RapidAPI (optional)` is generic enough to cover both adapters since they share `RAPIDAPI_KEY`. Left unchanged.

## Adjacent drift spotted

Not in this PR's scope (issue specifically targeted README), surfaced for a follow-up:
- `docs/getting-started/install-fly.md:28` — same `jobs-api14`-only framing.
- `docs/getting-started/start-here-fly.md:56` — walkthrough sends users specifically to the `jobs-api14` endpoint page.

## Test plan

- [ ] Spot-check README renders cleanly on GitHub (paragraph wrapping, no broken table cell at the §System Capabilities line which already mentioned JSearch).
- [ ] Spot-check `configure.md` callout renders as a blockquote like the existing #283 note above it.
- [ ] No tests required (docs only, no `migration-required`).

Closes #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)