### PR TITLE
docs: move [Unreleased] → [0.27.9] in CHANGELOG (#69 process)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.27.9] — 2026-05-22
+
 ### Fixed
 
 - **#804 bug(detect-rejections): Tesla rejection emails surfaced in the review queue.** Tesla emails rejections from `noreply@tesla.com` (their own infrastructure, not a third-party ATS), and the default `rejection_sender_allowlist` only covered Greenhouse, Ashby, Lever, Workday, SmartRecruiters, Microsoft careers, and Oracle. Tesla emails were silently invisible to the detector — `SEARCH FROM "tesla.com"` was never issued, so the message wasn't fetched, classified, or surfaced in `/board/rejections-review/`. Added `tesla.com` to `DEFAULT_REJECTION_ALLOWLIST` in `findajob.gmail_imap` and to `SENDER_FINGERPRINTS` in `findajob.rejection_detector.patterns` (the parity test at `tests/test_gmail_imap_rejection_scan.py:68` enforces both surfaces stay in sync). New sanitized Tesla fixture under `tests/fixtures/rejection_emails/tesla/rejection.eml` is exercised by the layer1-high-confidence parametrize set, plus a focused regression test on the `FirstName Thank you for your interest in COMPANY` subject shape (distinct to Tesla's template, where the recipient's first name prefixes the subject line — `re.search` semantics make the leading token a non-issue, but pinning the behavior protects against future tightening of `_INTEREST_RE`). Companion `scripts/detect_rejections.py --since-days N` flag for one-shot historical rescan: bypasses the UID checkpoint and date-windows the IMAP search to the prior `N` days (capped at `_MAX_BACKLOG_WINDOW_DAYS=60`), emits a distinct `rejection_oneshot_rescan_started` event and `rejection_scan_completed{is_oneshot_rescan: true}` payload key, does not mutate `rejection_backlog_scan_complete`, and relies on the existing `new_uid > current` guard so historical UIDs don't roll the checkpoint backward. The `INSERT OR IGNORE` on `gmail_message_id` makes the operation safe to re-run. Documented in `docs/usage.md` § Rejection detection alongside the steady-state and first-run schedules. **No `migration-required`** — the allowlist's `persisted ∪ DEFAULT` floor (#658) means each stack picks up `tesla.com` on next config load, no schema or env-var changes.
@@ -1314,7 +1316,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.27.8...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.27.9...HEAD
+[0.27.9]: https://github.com/brockamer/findajob/releases/tag/v0.27.9
 [0.27.8]: https://github.com/brockamer/findajob/releases/tag/v0.27.8
 [0.27.7]: https://github.com/brockamer/findajob/releases/tag/v0.27.7
 [0.27.6]: https://github.com/brockamer/findajob/releases/tag/v0.27.6


### PR DESCRIPTION
Cuts **v0.27.9** containing #804 Tesla rejection allowlist fix.

Following the canonical `#69 process` pattern from #808 / #812.

## Summary

- Rename `## [Unreleased]` → `## [0.27.9] — 2026-05-22` over the existing `### Fixed` block (one entry: #804).
- Insert fresh empty `## [Unreleased]` block above.
- Update CHANGELOG version cross-reference footer: `[Unreleased]` now compares against `v0.27.9`, new `[0.27.9]` link added.

Per CHANGELOG entry, **no `migration-required`** for this release.

## Test plan

- [x] `grep -c "## \[0.27.9\]" CHANGELOG.md` returns `1`
- [ ] After merge: run staging green-check + pre-tag smoke check, then tag `v0.27.9`
- [ ] Cohort deploy across all 8 stacks with `verify_auth`
- [ ] Tesla `--since-days 7` backfill on findajob-brock; confirm review-queue row

🤖 Generated with [Claude Code](https://claude.com/claude-code)