### PR TITLE
feat(observability): #798 complete_stream emits openrouter_truncated on finish_reason=length

### DIFF
--- a/src/findajob/llm/openrouter.py
+++ b/src/findajob/llm/openrouter.py
@@ -444,6 +444,14 @@ def complete_stream(
         ``GeneratorExit`` (e.g. client disconnect) triggers the ``finally``
         without needing an explicit close call on the caller's side.
 
+    Emits ``openrouter_truncated`` (#798):
+        When the terminal chunk carries ``finish_reason='length'``, emits a
+        ``openrouter_truncated`` event to pipeline.jsonl BEFORE yielding the
+        terminal ``StreamFinish``. Mirrors the wrapper-level emission for
+        :func:`complete` (#737) so a single ``grep openrouter_truncated``
+        surfaces length-finishes from both paths. ``job_id`` is always
+        ``None`` today — no streaming consumer has job context.
+
     TODO(#740 route): SSE route handler POST /onboarding/interview/turn-stream
     TODO(#740 frontend): vanilla JS EventSource consumer
     """
@@ -688,6 +696,21 @@ def complete_stream(
             resp.close()
         except Exception:  # noqa: BLE001
             pass
+
+    # #798: partial-truncation observability — mirrors complete()'s wrapper-level
+    # emission (#737) so a single `pipeline.jsonl | grep openrouter_truncated`
+    # surfaces length-finishes from both the direct and streaming paths.
+    # job_id=None: complete_stream() has no job-scoped consumer today
+    # (onboarding turns aren't job-scoped); a future streaming consumer with
+    # job context can add a kwarg without changing the event shape.
+    if last_finish_reason == "length":
+        log_event(
+            "openrouter_truncated",
+            role=role,
+            job_id=None,
+            completion_tokens=last_usage["completion_tokens"],
+            content_chars=len("".join(accumulated)),
+        )
 
     # Emit the finish event.
     yield StreamFinish(

--- a/tests/test_openrouter_stream_truncation_log.py
+++ b/tests/test_openrouter_stream_truncation_log.py
@@ -1,0 +1,288 @@
+"""Streaming-path regression guard for the centralized ``openrouter_truncated``
+emission (#798 — follow-up to #737).
+
+The direct ``complete()`` path emits ``openrouter_truncated`` in two branches:
+partial truncation (success-with-length) and null-content (failure-with-length).
+See ``tests/test_openrouter_truncation_log.py``.
+
+The streaming ``complete_stream()`` path has only one length-finish shape: SSE
+delta accumulation always produces partial content before the terminal chunk
+carries ``finish_reason='length'``. The route layer
+(``findajob.web.routes.onboarding_interview._stream_turn``) translates the
+``StreamFinish`` with length-finish into a user-facing error; the emission
+itself happens inside the generator BEFORE the terminal yield so the
+diagnostic survives any caller-side translation.
+
+These tests drive ``complete_stream()`` end-to-end by stubbing
+``urllib.request.urlopen`` at the module level, mirroring the fixture pattern
+in ``tests/test_openrouter_stream.py``.
+
+Event schema (same as the wrapper-level emission for ``complete()``):
+
+- ``role`` — the role= kwarg passed to ``complete_stream()``.
+- ``job_id`` — always ``None`` today. ``complete_stream()`` does not currently
+  take a job_id kwarg (no streaming consumer has job context).
+- ``completion_tokens`` — from the terminal chunk's ``usage.completion_tokens``.
+- ``content_chars`` — ``len("".join(accumulated))``. Always ``> 0`` for the
+  streaming path (delta-by-delta accumulation precludes the null-content shape).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from findajob.llm.openrouter import complete_stream
+
+# ---------------------------------------------------------------------------
+# Fixture helpers — mirrored from tests/test_openrouter_stream.py
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamResp:
+    """Fake urllib response that yields SSE lines from raw bytes."""
+
+    def __init__(self, raw: bytes) -> None:
+        self._stream = io.BytesIO(raw)
+        self.close_called = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> bytes:
+        line = self._stream.readline()
+        if not line:
+            raise StopIteration
+        return line
+
+    def close(self) -> None:
+        self.close_called = True
+
+
+def _make_sse_bytes(*data_payloads: str) -> bytes:
+    """Build an SSE byte stream terminated with a ``[DONE]`` sentinel."""
+    lines: list[bytes] = []
+    for payload in data_payloads:
+        lines.append(f"data: {payload}\n\n".encode())
+    lines.append(b"data: [DONE]\n\n")
+    return b"".join(lines)
+
+
+def _delta_chunk(
+    content: str,
+    *,
+    gen_id: str = "gen-test-trunc",
+    finish_reason: str | None = None,
+    usage: dict | None = None,
+) -> str:
+    """Build an SSE data-chunk JSON string."""
+    chunk: dict = {
+        "id": gen_id,
+        "object": "chat.completion.chunk",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": content, "role": "assistant"},
+                "finish_reason": finish_reason,
+                "native_finish_reason": None,
+            }
+        ],
+    }
+    if usage is not None:
+        chunk["usage"] = usage
+    return json.dumps(chunk)
+
+
+def _setup_role(tmp_path: Path, model: str = "openrouter:anthropic/claude-haiku-4-5") -> Path:
+    roles = tmp_path / "roles"
+    roles.mkdir()
+    (roles / "test_role.md").write_text(f"---\nmodel: {model}\n---\nYou are a test assistant.\n")
+    return roles
+
+
+def _captured_events(events: list[tuple[str, dict]], name: str) -> list[dict]:
+    return [kw for e, kw in events if e == name]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_emits_on_length_finish_partial_stream(monkeypatch, tmp_path: Path) -> None:
+    """finish_reason='length' with accumulated partial content — emission fires.
+
+    The emission must land BEFORE the generator yields the terminal
+    ``StreamFinish`` chunk so a downstream consumer that translates the
+    length-finish into an error (the onboarding-interview route does this)
+    still leaves the diagnostic in pipeline.jsonl.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    roles = _setup_role(tmp_path)
+    payloads = [
+        _delta_chunk("partial output "),
+        _delta_chunk("before the cap"),
+        _delta_chunk(
+            "",
+            finish_reason="length",
+            usage={
+                "prompt_tokens": 12,
+                "completion_tokens": 4096,
+                "prompt_tokens_details": {"cached_tokens": 0},
+                "cost": 0.002,
+            },
+        ),
+    ]
+    raw = _make_sse_bytes(*payloads)
+    fake_resp = _FakeStreamResp(raw)
+    events: list[tuple[str, dict]] = []
+
+    def _capture(event: str, **kw: object) -> None:
+        events.append((event, kw))
+
+    with (
+        patch("findajob.llm.openrouter.urllib.request.urlopen", return_value=fake_resp),
+        patch("findajob.llm.openrouter.log_event", side_effect=_capture),
+        patch("findajob.llm.openrouter._check_call_gate", return_value=None),
+    ):
+        chunks = list(complete_stream(role="test_role", prompt="test", roles_dir=roles))
+
+    # The generator still yields the terminal StreamFinish — emission does not
+    # replace or suppress it.
+    assert len(chunks) == 1
+    finish = chunks[0]
+    assert finish["type"] == "finish"
+    assert finish["finish_reason"] == "length"
+    assert finish["text"] == "partial output before the cap"
+
+    truncated = _captured_events(events, "openrouter_truncated")
+    assert len(truncated) == 1
+    payload = truncated[0]
+    assert payload["role"] == "test_role"
+    assert payload["job_id"] is None
+    assert payload["completion_tokens"] == 4096
+    assert payload["content_chars"] == len("partial output before the cap")
+    assert payload["content_chars"] > 0  # streaming-path discriminator
+
+
+def test_does_not_emit_on_stop(monkeypatch, tmp_path: Path) -> None:
+    """finish_reason='stop' — normal completion. No truncation event."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    roles = _setup_role(tmp_path)
+    payloads = [
+        _delta_chunk("full response"),
+        _delta_chunk(
+            "",
+            finish_reason="stop",
+            usage={
+                "prompt_tokens": 12,
+                "completion_tokens": 200,
+                "prompt_tokens_details": {"cached_tokens": 0},
+                "cost": 0.001,
+            },
+        ),
+    ]
+    raw = _make_sse_bytes(*payloads)
+    fake_resp = _FakeStreamResp(raw)
+    events: list[tuple[str, dict]] = []
+
+    def _capture(event: str, **kw: object) -> None:
+        events.append((event, kw))
+
+    with (
+        patch("findajob.llm.openrouter.urllib.request.urlopen", return_value=fake_resp),
+        patch("findajob.llm.openrouter.log_event", side_effect=_capture),
+        patch("findajob.llm.openrouter._check_call_gate", return_value=None),
+    ):
+        chunks = list(complete_stream(role="test_role", prompt="test", roles_dir=roles))
+
+    assert chunks[0]["finish_reason"] == "stop"
+    assert _captured_events(events, "openrouter_truncated") == []
+
+
+def test_does_not_emit_on_missing_finish_reason(monkeypatch, tmp_path: Path) -> None:
+    """No terminal finish_reason at all — must not synthesize a truncation event."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    roles = _setup_role(tmp_path)
+    payloads = [
+        _delta_chunk("some content"),
+        # Terminal chunk carries usage but no finish_reason.
+        _delta_chunk(
+            "",
+            usage={
+                "prompt_tokens": 12,
+                "completion_tokens": 50,
+                "prompt_tokens_details": {"cached_tokens": 0},
+                "cost": 0.0005,
+            },
+        ),
+    ]
+    raw = _make_sse_bytes(*payloads)
+    fake_resp = _FakeStreamResp(raw)
+    events: list[tuple[str, dict]] = []
+
+    def _capture(event: str, **kw: object) -> None:
+        events.append((event, kw))
+
+    with (
+        patch("findajob.llm.openrouter.urllib.request.urlopen", return_value=fake_resp),
+        patch("findajob.llm.openrouter.log_event", side_effect=_capture),
+        patch("findajob.llm.openrouter._check_call_gate", return_value=None),
+    ):
+        chunks = list(complete_stream(role="test_role", prompt="test", roles_dir=roles))
+
+    assert chunks[0]["finish_reason"] is None
+    assert _captured_events(events, "openrouter_truncated") == []
+
+
+def test_does_not_emit_on_mid_stream_network_error(monkeypatch, tmp_path: Path) -> None:
+    """Mid-stream failure yields StreamError(kind='network'); no truncation event.
+
+    The truncation emission lives in the success-finish branch only. A network
+    drop during streaming should not synthesize a length diagnostic.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test")
+    roles = _setup_role(tmp_path)
+
+    class _ExplodingResp:
+        """Yields one delta, then raises ConnectionResetError on the next read."""
+
+        def __init__(self) -> None:
+            self._lines = iter(
+                [
+                    f"data: {_delta_chunk('partial')}\n\n".encode(),
+                ]
+            )
+            self.close_called = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self) -> bytes:
+            try:
+                return next(self._lines)
+            except StopIteration:
+                raise ConnectionResetError("simulated mid-stream drop") from None
+
+        def close(self) -> None:
+            self.close_called = True
+
+    fake_resp = _ExplodingResp()
+    events: list[tuple[str, dict]] = []
+
+    def _capture(event: str, **kw: object) -> None:
+        events.append((event, kw))
+
+    with (
+        patch("findajob.llm.openrouter.urllib.request.urlopen", return_value=fake_resp),
+        patch("findajob.llm.openrouter.log_event", side_effect=_capture),
+        patch("findajob.llm.openrouter._check_call_gate", return_value=None),
+    ):
+        chunks = list(complete_stream(role="test_role", prompt="test", roles_dir=roles))
+
+    # The mid-stream failure should yield a StreamError, not a StreamFinish.
+    assert any(c.get("type") == "error" for c in chunks)
+    assert not any(c.get("type") == "finish" for c in chunks)
+    assert _captured_events(events, "openrouter_truncated") == []


### PR DESCRIPTION
## Summary

Closes #798. Follow-up to #737.

`complete_stream()` now emits `openrouter_truncated` to `pipeline.jsonl` when the terminal SSE chunk carries `finish_reason='length'`, BEFORE yielding the terminal `StreamFinish`. After this change, a single `grep openrouter_truncated` surfaces length-finishes from both the direct `complete()` path (post-#737) and the streaming path. Today the only `complete_stream()` consumer is the onboarding-interview turn route (`findajob.web.routes.onboarding_interview._stream_turn`); future streaming consumers inherit the diagnostic uniformly.

Same event schema as the #737 wrapper-level emission:
- `role` — from the `role=` kwarg.
- `job_id` — `None`. `complete_stream()` does not currently take a `job_id` kwarg, and its one production caller has no job context. A future streaming consumer with job context can add the kwarg without changing the event shape.
- `completion_tokens` — from `last_usage["completion_tokens"]`.
- `content_chars` — `len("".join(accumulated))`. Always `> 0` on the streaming path (SSE delta accumulation precludes the null-content shape that `complete()` handles in a second branch).

## Body-vs-code note

The issue body anchored the emission at line 507 "before yielding the `StreamError`". The actual emission site is before `yield StreamFinish(...)` at line 693 — the streaming path doesn't yield a length-flavored `StreamError`. The route layer (`onboarding_interview.py:491`) is what translates `StreamFinish` with `finish_reason='length'` into `_translate(OpenRouterError("max_tokens cap hit", kind="length"))` for the user. Intent matches the body (emit before the terminal yield); only the line anchor was off.

## Tests

`tests/test_openrouter_stream_truncation_log.py` — new sibling to `test_openrouter_truncation_log.py`. Four cases against fake SSE bodies, mirroring the established fixture pattern from `test_openrouter_stream.py`:

- `test_emits_on_length_finish_partial_stream` — terminal chunk carries `finish_reason='length'` with accumulated content; emission fires with correct schema; `StreamFinish` is still yielded.
- `test_does_not_emit_on_stop` — `finish_reason='stop'` normal completion.
- `test_does_not_emit_on_missing_finish_reason` — terminal chunk has no `finish_reason`.
- `test_does_not_emit_on_mid_stream_network_error` — `ConnectionResetError` mid-stream yields `StreamError(kind='network')`; no length diagnostic synthesized.

All 22 tests across the three openrouter-emission/stream files green. 218 adjacent tests (`-k "openrouter or stream or onboarding_interview or truncat"`) green. Lint + format + mypy clean on the modified module.

## Test plan

- [x] `pytest tests/test_openrouter_stream_truncation_log.py tests/test_openrouter_truncation_log.py tests/test_openrouter_stream.py` — 22/22
- [x] `pytest tests/ -k "openrouter or stream or onboarding_interview or truncat"` — 218/218
- [x] `ruff check src/findajob/llm/openrouter.py tests/test_openrouter_stream_truncation_log.py`
- [x] `ruff format --check src/findajob/llm/openrouter.py tests/test_openrouter_stream_truncation_log.py`
- [x] `mypy src/findajob/llm/openrouter.py` — Success
- [ ] Post-merge: tail `pipeline.jsonl` on a stack after an onboarding-interview turn that hits the max_tokens cap; confirm a real `openrouter_truncated` event lands with the expected schema. Functional verification not done pre-merge — the path requires a real OpenRouter call hitting the cap, which the test suite intentionally fakes.

## No CHANGELOG entry

Purely additive observability on a path that previously emitted nothing for length-finishes. No schema change, no consumer reading and depending on its absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)