### PR TITLE
docs(cost.md): #822 add sprint-mode scenarios row

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Real-world per-call rates on the operator's instance (sourced from `cost_log`, l
 | Per fully-prepped job (Phase A + B + sidecar) | ~$1.10 avg |
 | Per interview-prep run | ~$0.30 avg |
 
-**Typical user: ~$20–50/mo in API spend.** Add ~$5/mo if hosted on Fly.io. The operator's instance runs at the higher end — high listing volume (4 sources, 20+ target companies) and 15–30 preps/month. Full breakdown across cadences: [`docs/getting-started/cost.md`](docs/getting-started/cost.md).
+**Typical user: ~$20–50/mo in API spend.** Add ~$5/mo if hosted on Fly.io. The operator's instance runs at the higher end — high listing volume (4 sources, 20+ target companies) and 15–30 preps/month. Sprint mode (3 preps/day) runs $82–$130/mo; see [Monthly scenarios](docs/getting-started/cost.md#monthly-scenarios) for the full cadence table.
 
 ---
 

--- a/docs/getting-started/cost.md
+++ b/docs/getting-started/cost.md
@@ -85,6 +85,9 @@ LLM cost depends almost entirely on **how much you use findajob to prep applicat
 | Triage + 1 prep / week | $9–$21 | ~$4 | $13–$25 |
 | Triage + 3 preps / week | $9–$21 | ~$12 | $21–$33 |
 | Triage + daily prep + 2 interview preps / month | $9–$21 | ~$30 + ~$0.6 | $40–$52 |
+| Triage + 3 preps / day + 4 interview preps / month (sprint mode) | $9–$21 | ~$72–$108 + ~$1.2 | $82–$130 |
+
+Sprint mode is sustainable for a few weeks during active search; not a steady-state cadence.
 
 **Onboarding** is a one-time charge of **$3–$6** for the in-app interview. It runs once when you first deploy. Re-running onboarding (rare) would charge again.
 
@@ -112,6 +115,7 @@ The Settings page shows a suggested ceiling based on your expected weekly prep c
 - 1 prep / week → ~$22
 - 3 preps / week → ~$32
 - 1 prep / day → ~$69
+- 3 preps / day (sprint mode) → ~$170
 - Heavier than that → either set a ceiling near the upper bound of your scenario row, or disable the cap and watch the cost chip in the top nav
 
 You can change the cap any time; resetting it doesn't lose state. If you'd rather not have a hard cap at all, the cost chip in the top nav shows running month-to-date spend regardless.


### PR DESCRIPTION
## Summary

Closes #822. Follow-up to #810 walk #2 polish item F6.

Adds an active-search-sprint row to the Monthly scenarios table in \`docs/getting-started/cost.md\`. Operators running 3 preps/day during active search saw their cadence not represented in the existing table (which topped out at daily prep + 2 interview preps/month → \$40-\$52). They now see a row that reflects their cost shape: \$82-\$130/mo.

## Cadence anchor — operator decision

Per body AC #2 the cadence choice is the operator's call. Per the AskUserQuestion exchange this session: **3 preps/day** chosen over 5/day or both, with the matching cap anchor extension.

Math:
- 3 preps × 30 days = 90 preps × \$1 avg = ~\$72-\$108 prep cost (range reflects \$0.80-\$1.20 per-prep variance, which compounds visibly at this volume)
- 4 interview preps typical at this submission cadence × \$0.30 ≈ ~\$1.20
- Triage \$9-\$21 (unchanged from the rest of the table)
- Total: \$82-\$130

The interview-prep column call-out (\`~\$72-\$108 + ~\$1.2\`) mirrors the existing daily-prep row's \`~\$30 + ~\$0.6\` format for visual consistency down the column.

## "Setting a reasonable cap" extension

Per body AC #5 (optional-but-recommended), the suggested-ceilings block gains a parallel anchor:

- \`3 preps / day (sprint mode) → ~\$170\`

Sized for ~30% buffer over the \$130 upper bound, matching the existing 1-prep/day anchor's character (\$69 cap = ~33% over \$52 upper bound).

## README reconcile

\`README.md:252\` (§What it costs) gains one sentence acknowledging sprint mode:

> "...15-30 preps/month. Sprint mode (3 preps/day) runs \$82-\$130/mo; see [Monthly scenarios] for the full cadence table."

Without breaking the all-in-vs-API-spend distinction #810/B.1 already fixed. \`README.md:13\` (the §What it does pitch line) left unchanged — that anchor is for one-glance readers and qualifying it would dilute the pitch.

## Notes

- Terminology unified to "sprint mode" across all three surfaces (cost.md table, cap bullet, README) after advisor cold-read flagged drift between "active-search sprint mode" / "sprint mode" / "sprint-mode operators (during active search)".
- Range numbers aligned: README and cost.md both say \$82-\$130 (was a \$80-\$130 / \$81-\$129 mismatch in the first draft).
- Pre-existing line 150 reference to "sprint mode" (forward-staged from #810) now resolves cleanly to this new row. The companion "active user" label on the same line is a separate pre-existing drift, out of scope.

## Test plan

- [x] Render cost.md locally — table row + cap bullet + trailing paragraph display correctly
- [x] Render README.md locally — sentence flows cleanly
- [x] grep for "sprint" across both files confirms terminology consistency
- [ ] Verify the \`#monthly-scenarios\` anchor in the README link resolves on the rendered PR view post-merge

No CHANGELOG entry, no \`migration-required\` label — docs-only addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)