### PR TITLE
docs: move [Unreleased] -> [0.27.10] in CHANGELOG (#69 process)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.27.10] — 2026-05-23
+
 ### Fixed
 
 - **#765 follow-up: `JobsApi14BingAdapter._compose_row` unwraps `/v2/bing/get`'s top-level `data` envelope (was reading fields directly off the response).** First-pass fix shipped under the original #765 entry below assumed the get-response was flat (`detail["applyUrl"]`); live capture against the operator's stack 2026-05-23 showed it's actually nested (`detail["data"]["applyUrl"]`, alongside `_links`, `errors`, `warnings`, `hasError`, `hasWarning`). Synthetic unit-test fixtures matched the flat assumption, so CI was green; production triage on the operator's stack produced zero rows across 5 queries (52 search rows → 0 composed). `_compose_row` now reads from `detail.get("data") or {}` with the `companyName` / `applyUrl` / `description` keys looked up on the unwrapped record. A separate defensive guard in `_call_with_retry` catches responses missing the `data` envelope (e.g. the `{"message": "...exceeded the rate limit per second..."}` shape captured during a transient PRO-tier burst) and emits `jobsapi_bing_unrecognized_response` log events with a body excerpt rather than passing through silently — the original #601/#765 silent-zero-rows failure class is exactly "unexpected response shape produces empty rows", and the loud-log makes the next variant immediately visible in `pipeline.jsonl`. Test suite gains three guards: `test_fetch_handles_recorded_real_get_response_shape` uses an inline recorded fixture (`_REAL_GET_RESPONSE_2026_05_23`) capturing the full envelope including `_links`/`errors`/`warnings`/`descriptionHtml` so a future "let me simplify the fixture" cleanup can't drift back to the flat-shape assumption; `test_fetch_logs_unrecognized_response_when_envelope_missing` exercises the `{"message": ...}` rate-limit shape and asserts both the empty-row outcome AND the loud-log emission with the rate-limit phrase preserved in the body excerpt; `test_recorded_get_response_is_real_envelope_shape` is a structural sanity-check that locks the recorded-fixture's outer keys (`data`, `hasError`, `errors`, `warnings`, `_links`, `hasWarning`) so the fixture itself stays representative. Also helper-extracts `_get_envelope(record, has_error=...)` so the remaining unit-test fixtures wrap their records under `data` automatically — keeps the test code readable while pinning the real shape. Module docstring updated with a "Response envelope" section pointing at the live-capture date. **No `migration-required`** — same internal-adapter-shape category as the original #765 fix; adapter remains opt-in-default-off.
@@ -1330,7 +1332,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.27.9...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.27.10...HEAD
+[0.27.10]: https://github.com/brockamer/findajob/releases/tag/v0.27.10
 [0.27.9]: https://github.com/brockamer/findajob/releases/tag/v0.27.9
 [0.27.8]: https://github.com/brockamer/findajob/releases/tag/v0.27.8
 [0.27.7]: https://github.com/brockamer/findajob/releases/tag/v0.27.7

--- a/docs/architecture/file-map.md
+++ b/docs/architecture/file-map.md
@@ -74,7 +74,7 @@ When this map drifts from the actual code (renamed file, new route module, retir
 <repo>/config/scoring_schema.json           # JSON schema for LLM scorer output validation
 <repo>/config/rapidapi_feeds.yaml            # operator-curated feed table (gitignored; see rapidapi_feeds.yaml.example)
 <repo>/config/active_sources.txt           # per-stack active adapter list (gitignored; interview-emitted via 3h picker)
-<repo>/config/jsearch_queries.txt          # LinkedIn/Indeed search queries (gitignored; interview-emitted, conditional on 3g 'a' selection)
+<repo>/config/jsearch_queries.txt          # LinkedIn/Indeed/Bing search queries (gitignored; interview-emitted, conditional on 3g 'a' selection)
 <repo>/config/feed_urls.txt                 # Greenhouse / Lever / Ashby career-page feed URLs (gitignored; interview-emitted, conditional on 3g 'b' selection)
 <repo>/candidate_context/linkedin-alerts.md # LinkedIn-alerts setup checklist (interview-emitted, conditional on 3g 'c' selection)
 <repo>/config/gmail.json                    # Gmail IMAP/app-password config (gitignored, chmod 600)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,12 +28,17 @@ section is a post-onboarding reference for what each source does and
 how to tune it.
 
 ### Paid job-search service (RapidAPI feed — pluggable)
-The pipeline supports multiple RapidAPI-flavored job feeds (jobs-api14,
-JSearch, with more coming). During onboarding, **Section 3h** reads the
-operator-curated feed table and recommends the best feed for your field.
-Your choice is stored in `config/active_sources.txt`; the
-`/onboarding/feed-config/` form collects the per-feed API key and runs a
-live connection test.
+The pipeline supports multiple RapidAPI-flavored job feeds (jobs-api14
+for LinkedIn, jobs-api14-indeed for Indeed, jobs-api14-bing for Bing,
+and JSearch — all share the same `RAPIDAPI_KEY`). During onboarding,
+**Section 3h** reads the operator-curated feed table and recommends a
+default feed for your field; the picker writes one slug to
+`config/active_sources.txt`. The `/onboarding/feed-config/` form
+collects the per-feed API key and runs a live connection test.
+
+Additional adapters (Indeed, Bing) are opt-in after install via
+`/settings/active-sources/` — they share the jobs-api14 RapidAPI key
+so no extra credential is required to flip them on.
 
 The active feed is called daily with the queries in
 `config/jsearch_queries.txt`. Free tiers cover ~150–200 calls/month.


### PR DESCRIPTION
## Summary

Cuts **v0.27.10** after #831 (JobsApi14BingAdapter two-call shape) and #832 (get-envelope unwrap follow-up). Both adapter-shape fixes are non-`migration-required`; the adapter remains opt-in-default-off but is now functional when enabled.

Folds two small docs cleanups for jobs-api14-bing consistency:

- `docs/usage.md` — drops the "with more coming" stub; lists the four RapidAPI-flavored feeds (jobs-api14 / jobs-api14-indeed / jobs-api14-bing / JSearch) with a one-line note that Indeed and Bing are operator opt-in via `/settings/active-sources/` after install.
- `docs/architecture/file-map.md` — extends `jsearch_queries.txt`'s role description to include Bing (the same shared file feeds all three jobs-api14 adapters).

## Why fold the docs into the release PR

The two doc fixes are post-merge cleanup of the #765 surface — they wouldn't change shipping behavior but they would leave the v0.27.10 release notes pointing at stale docs in `[Unreleased]` if landed separately. Bundling keeps the release narrative coherent.

## Release-process gates (per docs/maintainers/release-process.md)

- [x] `[Unreleased]` block moved to `## [0.27.10] — 2026-05-23` (PT)
- [x] Empty `[Unreleased]` re-inserted at top
- [x] Bottom cross-reference: new `[0.27.10]: ...releases/tag/v0.27.10`; `[Unreleased]: compare/v0.27.10...HEAD`
- [x] No PRs in the v0.27.9 → v0.27.10 range carry `migration-required`
- [ ] Pre-tag smoke check on `<deployment-host>` (will run after this PR merges and `:latest` rebuilds off the resulting commit)
- [ ] `findajob-staging` green-check (same — runs against the post-merge `:latest`)
- [ ] Tag `v0.27.10` after smoke + soak gates clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)