### PR TITLE
fix(restore): #841 — shutil.move for cross-filesystem Docker bind-mounts

### DIFF
--- a/src/findajob/web/restore.py
+++ b/src/findajob/web/restore.py
@@ -151,14 +151,14 @@ def restore_from_tarball(raw: bytes, base: Path) -> RestoreResult:
                 for child in existing.iterdir():
                     if child.name in skip_names:
                         continue
-                    child.rename(rollback_dest / child.name)
+                    shutil.move(str(child), str(rollback_dest / child.name))
             else:
                 existing.mkdir(parents=True, exist_ok=True)
 
             for child in staged.iterdir():
                 if child.name in skip_names:
                     continue
-                child.rename(existing / child.name)
+                shutil.move(str(child), str(existing / child.name))
 
         for secret_rel in _SECRETS_FILES:
             secret_path = base / secret_rel
@@ -223,7 +223,7 @@ def _attempt_rollback(base: Path, rollback: Path) -> None:
             target.mkdir(parents=True, exist_ok=True)
         for child in rb.iterdir():
             try:
-                child.rename(target / child.name)
+                shutil.move(str(child), str(target / child.name))
             except OSError:
                 pass
 


### PR DESCRIPTION
## Summary

Docker bind-mounts put each state subdir (`data/`, `config/`, `companies/`) on potentially different filesystems. `os.rename()` fails with `EXDEV` (cross-device link) when the staging dir (inside `data/`) tries to move files to `config/` or other bind-mount targets. `shutil.move()` falls back to copy+delete across filesystem boundaries.

Surfaced during manual verification on `findajob-staging` (Docker). Safety backup preserved the stack.

## Test plan

- [x] 18 restore + route tests pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)