### PR TITLE
fix(notifications): #838 — analyze_feedback --notify routes through ntfy.send()

### DIFF
--- a/src/findajob/analyze_feedback.py
+++ b/src/findajob/analyze_feedback.py
@@ -24,10 +24,8 @@ hack the M3 cleanup PR (#544) flagged for follow-up.
 from __future__ import annotations
 
 import json
-import os
 import re
 import sqlite3
-import subprocess
 import sys
 from collections import Counter
 from datetime import datetime
@@ -35,7 +33,7 @@ from typing import Any
 
 from findajob.config_loader import load_reject_reasons
 from findajob.db import connect
-from findajob.paths import BASE, load_env
+from findajob.paths import BASE
 
 DB_PATH = f"{BASE}/data/pipeline.db"
 
@@ -442,9 +440,8 @@ def main() -> None:
     print(report)
 
     if notify_flag:
-        env = load_env()
-        topic = env.get("NTFY_TOPIC") or os.environ.get("NTFY_TOPIC", "jobsearch-pipeline")
-        # Send abbreviated summary via ntfy
+        from findajob.notifications.ntfy import send
+
         total = data.get("total_feedback", 0)
         fp = data.get("false_positives", 0)
         fp_pct = data.get("fp_pct", 0)
@@ -455,22 +452,9 @@ def main() -> None:
             f"Top reason: {top_reason[0]} ({top_reason[1]})\n"
             f"Run: python3 scripts/analyze_feedback.py"
         )
-        subprocess.run(
-            [
-                "curl",
-                "-s",
-                "-X",
-                "POST",
-                f"https://ntfy.sh/{topic}",
-                "-H",
-                "Title: JSP Feedback Analysis",
-                "-H",
-                "Tags: magnifying_glass",
-                "-H",
-                "Content-Type: text/plain; charset=utf-8",
-                "-d",
-                body,
-            ],
-            check=False,
-            capture_output=True,
+        send(
+            title="JSP Feedback Analysis",
+            body=body,
+            tags="magnifying_glass",
+            kind="feedback_review",
         )

--- a/tests/test_analyze_feedback.py
+++ b/tests/test_analyze_feedback.py
@@ -14,7 +14,7 @@ import sqlite3
 
 import pytest
 
-from findajob.analyze_feedback import _prefilter_candidates, analyze, format_report
+from findajob.analyze_feedback import _prefilter_candidates, analyze, format_report, main
 
 
 @pytest.fixture
@@ -144,3 +144,50 @@ def test_prefilter_candidates_filters_title_signal_reasons_only(monkeypatch):
     candidates = _prefilter_candidates(rejected, applied, min_recurrences=2)
     # Should be empty — only 1 row contributes to the count after filter.
     assert candidates == []
+
+
+def test_main_notify_calls_ntfy_send_with_feedback_review_kind(tmp_path, monkeypatch):
+    """--notify flag routes through ntfy.send() with kind='feedback_review' (#838)."""
+    import findajob.analyze_feedback as af
+
+    db_path = str(tmp_path / "pipeline.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE feedback_log (
+            id INTEGER PRIMARY KEY, job_id TEXT, title TEXT, company TEXT,
+            relevance_score INTEGER, reject_reason TEXT
+        );
+        CREATE TABLE jobs (
+            id TEXT PRIMARY KEY, title TEXT, company TEXT, source TEXT,
+            url TEXT, stage TEXT, dupe_of TEXT DEFAULT '', relevance_score INTEGER
+        );
+        INSERT INTO feedback_log (job_id, title, company, relevance_score, reject_reason)
+            VALUES ('j1', 'Engineer', 'Acme', 7, 'Low Fit Score');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(af, "DB_PATH", db_path)
+    monkeypatch.setattr(
+        af,
+        "load_reject_reasons",
+        lambda: (["Low Fit Score"], frozenset({"Low Fit Score"})),
+    )
+    monkeypatch.setattr("sys.argv", ["analyze_feedback.py", "--notify"])
+
+    calls: list[dict] = []
+
+    def fake_send(*, title, body, tags, kind):
+        calls.append({"title": title, "body": body, "tags": tags, "kind": kind})
+
+    monkeypatch.setattr("findajob.notifications.ntfy.send", fake_send)
+
+    main()
+
+    assert len(calls) == 1
+    assert calls[0]["kind"] == "feedback_review"
+    assert calls[0]["title"] == "JSP Feedback Analysis"
+    assert calls[0]["tags"] == "magnifying_glass"
+    assert "rejections" in calls[0]["body"]


### PR DESCRIPTION
## Summary

- Replaces direct `subprocess.run(["curl", ...])` in `analyze_feedback.main()` with `findajob.notifications.ntfy.send(kind="feedback_review")`
- Removes unused `subprocess`, `os`, and `load_env` imports
- Adds test verifying `--notify` calls `send()` with correct `kind`, `title`, `tags`

## Test plan

- [x] `pytest tests/test_analyze_feedback.py` — 5/5 pass
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Manual verification: run `analyze_feedback.py --notify` on a live stack, check `notifications` table for `kind='feedback_review'` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)