### PR TITLE
fix(notifications): #839 — detect_rejections tags kind=rejection_detected

### DIFF
--- a/scripts/detect_rejections.py
+++ b/scripts/detect_rejections.py
@@ -180,6 +180,7 @@ def main(since_days: int | None = None) -> int:
                         f"over prior {window} days. Review queue updated."
                     ),
                     cta_url="/board/rejections-review/",
+                    kind="rejection_detected",
                 )
             elif is_backlog_run:
                 ntfy.send(
@@ -189,12 +190,14 @@ def main(since_days: int | None = None) -> int:
                         f"over prior {window} days. Review queue ready."
                     ),
                     cta_url="/board/rejections-review/",
+                    kind="rejection_detected",
                 )
             else:
                 ntfy.send(
                     title="New rejection email(s) detected",
                     body=f"{suggestions_created} new rejection(s) — review queue updated.",
                     cta_url="/board/rejections-review/",
+                    kind="rejection_detected",
                 )
 
         log_event(

--- a/tests/test_detect_rejections_script.py
+++ b/tests/test_detect_rejections_script.py
@@ -358,6 +358,46 @@ def test_matched_suggestion_persists_to_db(harness):
     assert reason == "Company passed"
 
 
+def test_ntfy_send_uses_rejection_detected_kind(harness):
+    """#839: all three ntfy.send() call sites tag kind='rejection_detected'."""
+    _write_config(harness)
+    _make_db(harness)
+
+    import sqlite3
+
+    conn = sqlite3.connect(detect_rejections.DB_PATH)
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            id, fingerprint, title, company, url, source, status, stage, synthetic
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("job-1", "fp-1", "Engineer", "Acme", "https://x", "web_manual", "manual_review", "applied", 0),
+    )
+    conn.commit()
+    conn.close()
+
+    suggestion = _make_suggestion(extracted_company="Acme")
+    outcome = FetchOutcome(
+        result=_RESULT_SUCCESS,
+        messages=[("no-reply@us.greenhouse-mail.io", b"raw")],
+        new_uid=42,
+        new_uidvalidity=99,
+    )
+
+    mock_send = patch.object(detect_rejections.ntfy, "send")
+    with (
+        patch.object(detect_rejections, "fetch_new_messages_for_rejection_scan", return_value=outcome),
+        patch.object(detect_rejections, "classify_email", return_value=suggestion),
+        patch.object(detect_rejections, "match_job", return_value=MatchResult(job_id="job-1", status="matched")),
+        mock_send as send_mock,
+    ):
+        detect_rejections.main()
+
+    assert send_mock.call_count == 1
+    assert send_mock.call_args.kwargs.get("kind") == "rejection_detected"
+
+
 # ─── #586: subject/body fallback when extraction fails ───────────────────────
 
 


### PR DESCRIPTION
## Summary

- All three `ntfy.send()` call sites in `scripts/detect_rejections.py` (steady-state, backlog scan, one-shot rescan) now pass `kind="rejection_detected"` instead of falling through to the default `kind="send_raw"`
- Added test asserting the mock `send()` receives `kind="rejection_detected"`

## Test plan

- [x] `pytest tests/test_detect_rejections_script.py` — 14/14 pass
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Manual verification: trigger a rejection scan on a live stack, check `notifications` table for `kind='rejection_detected'` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)