### PR TITLE
feat(#229): Tuning loop Phase 1 — schema + config-drift detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **Tuning loop Phase 1** (#229): `config_changes` and `recall_audit` tables; `jobs.company_tier` and `jobs.scored_by` columns; config-drift detector wired into triage, `/config/` POST, and onboarding injector; tier resolver; backfill scripts.
+
+### Migration required
+
+- Schema: run `scripts/init_db.py` on upgrade (auto-runs at container start). Backfill existing rows: `uv run python scripts/backfill_company_tier.py && uv run python scripts/backfill_scored_by.py` (both idempotent).
+
 ## [0.28.0] — 2026-05-24
 
 ### Changed

--- a/scripts/backfill_company_tier.py
+++ b/scripts/backfill_company_tier.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Backfill jobs.company_tier for existing rows. Idempotent."""
+
+from __future__ import annotations
+
+from findajob.db import connect
+from findajob.paths import BASE
+from findajob.tiers import load_tier1_companies, resolve_tier
+
+DB_PATH = f"{BASE}/data/pipeline.db"
+
+
+def main() -> None:
+    load_tier1_companies.cache_clear()
+    conn = connect(DB_PATH, timeout=30)
+    rows = conn.execute("SELECT id, company FROM jobs").fetchall()
+    for job_id, company in rows:
+        conn.execute("UPDATE jobs SET company_tier=? WHERE id=?", (resolve_tier(company), job_id))
+    conn.commit()
+    conn.close()
+    print(f"Backfilled company_tier on {len(rows)} rows.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_scored_by.py
+++ b/scripts/backfill_scored_by.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Backfill jobs.scored_by for existing rows. Idempotent.
+
+Heuristic classification from score_flag_reason and ai_notes.
+Ambiguous rows default to 'llm'.
+"""
+
+from __future__ import annotations
+
+from findajob.db import connect
+from findajob.paths import BASE
+
+DB_PATH = f"{BASE}/data/pipeline.db"
+
+
+def classify(score_flag_reason: str | None, ai_notes: str | None) -> str:
+    sfr = (score_flag_reason or "").lower()
+    notes = (ai_notes or "").lower()
+    if "pre-filter hard reject" in sfr or "pre-filter hard reject" in notes:
+        return "prefilter_stage1"
+    if "excluded employer" in sfr or "excluded employer" in notes:
+        return "prefilter_stage1"
+    if "pre-filter in-domain/no-jd" in sfr or "pre-filter in-domain/no-jd" in notes:
+        return "prefilter_stage2"
+    return "llm"
+
+
+def main() -> None:
+    conn = connect(DB_PATH, timeout=30)
+    rows = conn.execute("SELECT id, score_flag_reason, ai_notes FROM jobs").fetchall()
+    for job_id, sfr, notes in rows:
+        conn.execute("UPDATE jobs SET scored_by=? WHERE id=?", (classify(sfr, notes), job_id))
+    conn.commit()
+    conn.close()
+    print(f"Backfilled scored_by on {len(rows)} rows.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/findajob/db/migrate.py
+++ b/src/findajob/db/migrate.py
@@ -243,7 +243,8 @@ def _rebuild_table_with_indexes(
     The recipe: PRAGMA foreign_keys=OFF, rename original to ``legacy_alias``,
     run the migration's CREATE TABLE, INSERT INTO new SELECT FROM old over
     the column set the two schemas share, re-execute every CREATE INDEX from
-    the migration, DROP the legacy shell.
+    the migration and from any later migration that targets the same table,
+    DROP the legacy shell.
 
     Column-set discipline: the source schema may carry drift columns the
     head schema no longer defines (see ``_DOCUMENTED_DEAD_COLUMNS`` in the
@@ -270,8 +271,52 @@ def _rebuild_table_with_indexes(
     shell. Without re-applying them, the rebuilt table runs without
     ``idx_jobs_fingerprint`` / ``idx_jobs_stage`` / etc., silently
     degrading every dashboard query.
+
+    Later-migration index forward-compatibility: the primary DDL lives in
+    ``migration_filename`` (typically ``0001_initial.sql``), but later
+    migrations may add more indexes on the same table via their own SQL
+    files (e.g. ``idx_jobs_company_tier`` added in ``0007_tuning_loop_phase1.sql``).
+    After the named-file indexes are applied, a second pass over all
+    migration files (excluding ``migration_filename`` itself) gathers any
+    additional ``CREATE INDEX ... ON {table}`` statements and executes them.
+    All index statements carry ``IF NOT EXISTS`` so the pass is idempotent.
     """
     create_sql, index_sqls = _extract_table_ddl(migration_filename, table)
+
+    # Read the stamped schema version so we know which later migrations have
+    # already been applied to this DB. Columns + indexes from those migrations
+    # must be re-applied after the rebuild; columns from migrations NOT YET
+    # stamped must not be touched here (the migration runner will add them).
+    _stamped_version: int = _read_schema_version(conn) or 0
+
+    # Collect ADD COLUMN and index statements for this table from later migration files.
+    # Applied in migration order so column additions precede their dependent indexes.
+    _later_add_col_re = re.compile(
+        rf"ALTER\s+TABLE\s+{re.escape(table)}\s+ADD\s+COLUMN\s+[^;]+;",
+        re.IGNORECASE,
+    )
+    _later_index_re = re.compile(
+        rf"CREATE\s+(?:UNIQUE\s+)?INDEX(?:\s+IF\s+NOT\s+EXISTS)?\s+\S+\s+ON\s+{re.escape(table)}\s*\([^)]*\)(?:\s+WHERE\s+[^;]*)?;",
+        re.IGNORECASE,
+    )
+    # Tuple of (migration_version, add_col_stmts, index_stmts) per migration file,
+    # sorted by file name. Only files with version <= _stamped_version are eligible
+    # (those migrations have already run; their schema changes must survive the rebuild).
+    _later_col_and_idx: list[tuple[list[str], list[str]]] = []
+    for _mig_path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+        if _mig_path.name == migration_filename:
+            continue  # already handled by _extract_table_ddl above
+        _m = _FILENAME_RE.match(_mig_path.name)
+        if not _m:
+            continue
+        _mig_version = int(_m.group(1))
+        if _mig_version > _stamped_version:
+            continue  # migration not yet applied — runner will handle it
+        _sql = _mig_path.read_text(encoding="utf-8")
+        _cols = [m.group(0) for m in _later_add_col_re.finditer(_sql)]
+        _idxs = [m.group(0) for m in _later_index_re.finditer(_sql)]
+        if _cols or _idxs:
+            _later_col_and_idx.append((_cols, _idxs))
 
     legacy_cols = [row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()]
 
@@ -292,6 +337,24 @@ def _rebuild_table_with_indexes(
             conn.execute(f"DROP TABLE {legacy_alias}")
             for index_sql in index_sqls:
                 conn.execute(index_sql)
+            # Re-apply ADD COLUMN + index statements from every migration that
+            # has already been stamped (version <= _stamped_version). The rebuild
+            # drops the table, losing those columns and indexes; we must restore
+            # them so the post-rebuild schema matches what the migration runner
+            # had previously established.
+            # Guard: skip ADD COLUMN if the column already exists (handles the
+            # case where the rebuild is somehow triggered multiple times, or
+            # where a future migration both rebuilds and alters).
+            for _add_cols, _idxs in _later_col_and_idx:
+                present_cols = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+                for add_col_sql in _add_cols:
+                    _col_match = re.search(r"ADD\s+COLUMN\s+(\w+)", add_col_sql, re.IGNORECASE)
+                    col_name = _col_match.group(1) if _col_match else None
+                    if col_name and col_name in present_cols:
+                        continue  # already present — idempotent skip
+                    conn.execute(add_col_sql)
+                for index_sql in _idxs:
+                    conn.execute(index_sql)
             conn.commit()
         except Exception:
             conn.rollback()

--- a/src/findajob/metrics/config_changes.py
+++ b/src/findajob/metrics/config_changes.py
@@ -1,0 +1,77 @@
+"""Config-change detector for hybrid-windowing causal attribution.
+
+Hashes each tracked lever's content and writes a ``config_changes`` row
+when the hash differs from the most recent row for that lever.
+
+Called from three surfaces:
+- ``src/findajob/triage/orchestrator.py`` — pre-scoring
+- ``src/findajob/web/routes/config.py`` — after /config/ POST
+- ``src/findajob/onboarding/injector.py`` — after paste-back
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+
+import findajob.paths as _paths
+
+_LEVERS: dict[str, str] = {
+    "profile": "candidate_context/profile.md",
+    "master_resume": "candidate_context/master_resume.md",
+    "scorer_prompt": "config/roles/job_scorer.md",
+    "resume_tailor_prompt": "config/roles/resume_tailor.md",
+    "cover_letter_prompt": "config/roles/cover_letter_writer.md",
+    "briefing_writer_prompt": "config/roles/briefing_writer.md",
+    "outreach_drafter_prompt": "config/roles/outreach_drafter.md",
+    "company_researcher_prompt": "config/roles/company_researcher.md",
+    "queries": "config/jsearch_queries.txt",
+    "excluded_employers": "config/excluded_employers.yaml",
+    "feed_urls": "config/feed_urls.txt",
+    "prefilter_rules": "config/prefilter_rules.yaml",
+    "in_domain_patterns": "config/in_domain_patterns.yaml",
+    "target_companies": "config/target_companies.md",
+}
+
+
+def _hash_file(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except (FileNotFoundError, OSError):
+        return None
+
+
+def _latest_hash(conn: sqlite3.Connection, lever: str) -> str | None:
+    row = conn.execute(
+        "SELECT content_hash FROM config_changes WHERE lever=? ORDER BY id DESC LIMIT 1",
+        (lever,),
+    ).fetchone()
+    return row[0] if row else None
+
+
+def detect_and_record(
+    conn: sqlite3.Connection,
+    *,
+    changed_by: str = "manual",
+    change_summary: str | None = None,
+) -> list[str]:
+    """Scan tracked levers and insert rows for any with changed hashes.
+
+    Returns list of lever names that were recorded (empty if nothing changed).
+    """
+    recorded: list[str] = []
+    base = Path(_paths.BASE)
+    for lever, relpath in _LEVERS.items():
+        current = _hash_file(base / relpath)
+        if current is None:
+            continue
+        if current == _latest_hash(conn, lever):
+            continue
+        conn.execute(
+            "INSERT INTO config_changes (lever, changed_by, change_summary, content_hash) VALUES (?, ?, ?, ?)",
+            (lever, changed_by, change_summary, current),
+        )
+        conn.commit()
+        recorded.append(lever)
+    return recorded

--- a/src/findajob/migrations/0007_tuning_loop_phase1.sql
+++ b/src/findajob/migrations/0007_tuning_loop_phase1.sql
@@ -1,0 +1,38 @@
+-- Migration 0007: tuning loop Phase 1
+-- Adds config_changes and recall_audit tables, and company_tier + scored_by
+-- columns to jobs. All DDL is idempotent (CREATE IF NOT EXISTS / ADD COLUMN
+-- with no-op on duplicate-column error handled by the migration runner).
+
+CREATE TABLE IF NOT EXISTS config_changes (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    lever        TEXT NOT NULL,
+    changed_at   TEXT DEFAULT (datetime('now')),
+    changed_by   TEXT DEFAULT 'manual',
+    change_summary TEXT,
+    content_hash TEXT,
+    diff_summary TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_config_changes_lever_time
+    ON config_changes (lever, changed_at);
+
+CREATE TABLE IF NOT EXISTS recall_audit (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id             TEXT NOT NULL,
+    audited_at         TEXT DEFAULT (datetime('now')),
+    original_score     INTEGER,
+    original_scored_by TEXT,
+    auditor_model      TEXT NOT NULL,
+    audited_score      INTEGER,
+    upgraded           INTEGER DEFAULT 0,
+    audit_notes        TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_recall_audit_time
+    ON recall_audit (audited_at);
+
+ALTER TABLE jobs ADD COLUMN company_tier TEXT DEFAULT 'unknown';
+ALTER TABLE jobs ADD COLUMN scored_by TEXT DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_jobs_company_tier ON jobs (company_tier);
+CREATE INDEX IF NOT EXISTS idx_jobs_scored_by ON jobs (scored_by);

--- a/src/findajob/onboarding/injector.py
+++ b/src/findajob/onboarding/injector.py
@@ -557,9 +557,10 @@ def inject(
 
     # Config-drift detection — record all levers that just landed.
     try:
+        from findajob.db import connect as _db_connect  # noqa: PLC0415
         from findajob.metrics.config_changes import detect_and_record as _detect  # noqa: PLC0415
 
-        _drift_conn = sqlite3.connect(str(base_root / "data" / "pipeline.db"), timeout=5)
+        _drift_conn = _db_connect(base_root / "data" / "pipeline.db", timeout=5)
         _detect(_drift_conn, changed_by="onboarding", change_summary="onboarding paste-back")
         _drift_conn.close()
     except Exception:  # noqa: BLE001 — drift detection must never fail onboarding

--- a/src/findajob/onboarding/injector.py
+++ b/src/findajob/onboarding/injector.py
@@ -555,6 +555,16 @@ def inject(
     except Exception:  # noqa: BLE001 — warnings must never fail onboarding
         pass
 
+    # Config-drift detection — record all levers that just landed.
+    try:
+        from findajob.metrics.config_changes import detect_and_record as _detect  # noqa: PLC0415
+
+        _drift_conn = sqlite3.connect(str(base_root / "data" / "pipeline.db"), timeout=5)
+        _detect(_drift_conn, changed_by="onboarding", change_summary="onboarding paste-back")
+        _drift_conn.close()
+    except Exception:  # noqa: BLE001 — drift detection must never fail onboarding
+        pass
+
     # Post-commit discovery hook. Soft-fail: any failure here does NOT
     # roll back the seven-file commit (sentinel is already written).
     try:

--- a/src/findajob/scorer_prefilter.py
+++ b/src/findajob/scorer_prefilter.py
@@ -31,6 +31,7 @@ from findajob.config_loader import (
     load_hard_reject_rules,
     load_in_domain_rules,
 )
+from findajob.tiers import resolve_tier
 
 
 def _hard_reject_match(title: str) -> str | None:
@@ -92,6 +93,8 @@ def prefilter_score(title: str, company: str, jd_usable: bool) -> tuple[dict[str
             "ai_notes": reason,
             "score_flag_reason": reason,
             "remote_status": "Unknown",
+            "scored_by": "prefilter_stage1",
+            "company_tier": resolve_tier(company),
         }, reason
 
     excluded = _excluded_employer_match(company)
@@ -107,6 +110,8 @@ def prefilter_score(title: str, company: str, jd_usable: bool) -> tuple[dict[str
             "ai_notes": reason,
             "score_flag_reason": "excluded_employer",
             "remote_status": "Unknown",
+            "scored_by": "prefilter_stage1",
+            "company_tier": resolve_tier(company),
         }, reason
 
     # ── Stage 2: In-domain title, JD absent → score 5 ─────────────────────────
@@ -122,6 +127,8 @@ def prefilter_score(title: str, company: str, jd_usable: bool) -> tuple[dict[str
             "ai_notes": reason,
             "score_flag_reason": None,
             "remote_status": "Unknown",
+            "scored_by": "prefilter_stage2",
+            "company_tier": resolve_tier(company),
         }, reason
 
     return None, None

--- a/src/findajob/scoring.py
+++ b/src/findajob/scoring.py
@@ -13,6 +13,7 @@ from findajob.llm.openrouter import CompletionResult, OpenRouterError, complete
 from findajob.llm_parsing import extract_json_payload, validate_llm_json
 from findajob.paths import BASE
 from findajob.scorer_prefilter import _hard_reject_match, prefilter_score
+from findajob.tiers import resolve_tier
 
 DB_PATH: str = f"{BASE}/data/pipeline.db"
 SCHEMA_PATH: str = f"{BASE}/config/scoring_schema.json"
@@ -185,23 +186,21 @@ def score_job(
             company=company,
             latency_ms=latency_ms,
         )
-        return (
-            _manual_review(
-                f"Scorer {e.kind}",
-                f"Scorer failed: {e.kind} ({e.status_code or 'n/a'})",
-            ),
-            latency_ms,
-            None,
+        _err = _manual_review(
+            f"Scorer {e.kind}",
+            f"Scorer failed: {e.kind} ({e.status_code or 'n/a'})",
         )
+        _err["scored_by"] = "llm"
+        _err["company_tier"] = resolve_tier(company)
+        return _err, latency_ms, None
     latency_ms = int((time.time() - start) * 1000)
 
     if not result.text.strip():
         log_event("score_error", reason="empty_output", title=title, company=company)
-        return (
-            _manual_review("Scorer empty output", "Scorer returned empty output"),
-            latency_ms,
-            result,
-        )
+        _empty = _manual_review("Scorer empty output", "Scorer returned empty output")
+        _empty["scored_by"] = "llm"
+        _empty["company_tier"] = resolve_tier(company)
+        return _empty, latency_ms, result
 
     parsed, error = validate_llm_json(_normalize_llm_output(result.text), SCHEMA_PATH)
 
@@ -229,21 +228,24 @@ def score_job(
                     "comp_estimate": "",
                     "ai_notes": "LLM validation failed; hard-reject title pattern matched",
                     "remote_status": "Unknown",
+                    "scored_by": "prefilter_stage1",
+                    "company_tier": resolve_tier(company),
                 },
                 latency_ms,
                 result,
             )
-        return (
-            _manual_review(
-                f"Validation: {error}",
-                "Scorer output failed validation",
-            ),
-            latency_ms,
-            result,
+        _val_err = _manual_review(
+            f"Validation: {error}",
+            "Scorer output failed validation",
         )
+        _val_err["scored_by"] = "llm"
+        _val_err["company_tier"] = resolve_tier(company)
+        return _val_err, latency_ms, result
 
     assert parsed is not None  # guaranteed: error is None means parsed is valid
     if parsed.get("relevance_score") is None:
         log_event("score_error", reason="null_score", title=title, company=company)
 
+    parsed["scored_by"] = "llm"
+    parsed["company_tier"] = resolve_tier(company)
     return parsed, latency_ms, result

--- a/src/findajob/tiers.py
+++ b/src/findajob/tiers.py
@@ -1,0 +1,40 @@
+"""Tier resolver for jobs.company_tier population.
+
+Reads ``config/companies_of_interest.txt`` (one company per line,
+case-insensitive) and classifies:
+
+* ``'tier1'`` — name matches a line in the file
+* ``'other'`` — file exists but no match
+* ``'unknown'`` — file missing, empty company, or read error
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from findajob.paths import BASE
+
+
+def _coi_path() -> Path:
+    return Path(BASE) / "config" / "companies_of_interest.txt"
+
+
+@lru_cache(maxsize=1)
+def load_tier1_companies() -> frozenset[str]:
+    """Lowercased frozenset of Tier 1 company names."""
+    try:
+        text = _coi_path().read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return frozenset()
+    return frozenset(line.strip().lower() for line in text.splitlines() if line.strip())
+
+
+def resolve_tier(company: str | None) -> str:
+    """Return 'tier1', 'other', or 'unknown' for a company name."""
+    if not company:
+        return "unknown"
+    if not _coi_path().is_file():
+        return "unknown"
+    names = load_tier1_companies()
+    return "tier1" if company.strip().lower() in names else "other"

--- a/src/findajob/triage/orchestrator.py
+++ b/src/findajob/triage/orchestrator.py
@@ -40,6 +40,7 @@ from findajob.fetchers import (
 )
 from findajob.fetchers.adapters import iter_configured_adapters
 from findajob.fetchers.adapters.gmail import GmailLinkedInAdapter
+from findajob.metrics.config_changes import detect_and_record
 from findajob.onboarding import is_complete as _onboarding_is_complete
 from findajob.paths import BASE, load_env
 from findajob.scoring import _build_feedback_block, score_job
@@ -231,6 +232,11 @@ def main(gmail_since_days: int | None = None):
         log_event("pipeline_complete", new=0, dupes=0, scored=0)
         conn.close()
         return
+
+    try:
+        detect_and_record(conn, changed_by="manual", change_summary="pre-triage drift scan")
+    except Exception:
+        pass
 
     new_count = 0
     dupe_count = 0

--- a/src/findajob/triage/orchestrator.py
+++ b/src/findajob/triage/orchestrator.py
@@ -41,6 +41,7 @@ from findajob.fetchers import (
 from findajob.fetchers.adapters import iter_configured_adapters
 from findajob.fetchers.adapters.gmail import GmailLinkedInAdapter
 from findajob.metrics.config_changes import detect_and_record
+from findajob.notifications.ntfy import quick_notify
 from findajob.onboarding import is_complete as _onboarding_is_complete
 from findajob.paths import BASE, load_env
 from findajob.scoring import _build_feedback_block, score_job

--- a/src/findajob/triage/orchestrator.py
+++ b/src/findajob/triage/orchestrator.py
@@ -501,6 +501,7 @@ def main(gmail_since_days: int | None = None):
                         relevance_score=?, interview_likelihood=?, strengths_alignment=?,
                         industry_sector=?, comp_estimate=?, ai_notes=?,
                         score_status=?, score_flag_reason=?, remote_status=?,
+                        scored_by=?, company_tier=?,
                         stage=?, stage_updated=?, status=?, updated_at=?
                     WHERE id=?
                 """,
@@ -514,6 +515,8 @@ def main(gmail_since_days: int | None = None):
                         scored.get("score_status", "manual_review"),
                         scored.get("score_flag_reason", ""),
                         scored.get("remote_status", "Unknown"),
+                        scored.get("scored_by", ""),
+                        scored.get("company_tier", "unknown"),
                         stage,
                         now,
                         status,

--- a/src/findajob/web/routes/config.py
+++ b/src/findajob/web/routes/config.py
@@ -113,12 +113,11 @@ def config_save(
         raise
 
     try:
-        import sqlite3 as _sql
-
+        from findajob.db import connect as _db_connect
         from findajob.metrics.config_changes import detect_and_record
         from findajob.paths import BASE as _BASE
 
-        _conn = _sql.connect(f"{_BASE}/data/pipeline.db", timeout=5)
+        _conn = _db_connect(f"{_BASE}/data/pipeline.db", timeout=5)
         detect_and_record(_conn, changed_by="manual", change_summary=f"edit via /config/ — {relpath}")
         _conn.close()
     except Exception:

--- a/src/findajob/web/routes/config.py
+++ b/src/findajob/web/routes/config.py
@@ -112,6 +112,18 @@ def config_save(
             os.unlink(tmp_name)
         raise
 
+    try:
+        import sqlite3 as _sql
+
+        from findajob.metrics.config_changes import detect_and_record
+        from findajob.paths import BASE as _BASE
+
+        _conn = _sql.connect(f"{_BASE}/data/pipeline.db", timeout=5)
+        detect_and_record(_conn, changed_by="manual", change_summary=f"edit via /config/ — {relpath}")
+        _conn.close()
+    except Exception:
+        pass
+
     templates = request.app.state.templates
     return templates.TemplateResponse(
         request=request,

--- a/tests/fixtures/schema_baseline_fresh.json
+++ b/tests/fixtures/schema_baseline_fresh.json
@@ -19,6 +19,12 @@
       "type": "index"
     },
     {
+      "name": "idx_config_changes_lever_time",
+      "sql": "CREATE INDEX idx_config_changes_lever_time ON config_changes(lever,changed_at)",
+      "tbl_name": "config_changes",
+      "type": "index"
+    },
+    {
       "name": "idx_cost_log_job_id",
       "sql": "CREATE INDEX idx_cost_log_job_id ON cost_log(job_id)",
       "tbl_name": "cost_log",
@@ -31,6 +37,12 @@
       "type": "index"
     },
     {
+      "name": "idx_jobs_company_tier",
+      "sql": "CREATE INDEX idx_jobs_company_tier ON jobs(company_tier)",
+      "tbl_name": "jobs",
+      "type": "index"
+    },
+    {
       "name": "idx_jobs_fingerprint",
       "sql": "CREATE INDEX idx_jobs_fingerprint ON jobs(fingerprint)",
       "tbl_name": "jobs",
@@ -39,6 +51,12 @@
     {
       "name": "idx_jobs_loose_fingerprint",
       "sql": "CREATE INDEX idx_jobs_loose_fingerprint ON jobs(loose_fingerprint)",
+      "tbl_name": "jobs",
+      "type": "index"
+    },
+    {
+      "name": "idx_jobs_scored_by",
+      "sql": "CREATE INDEX idx_jobs_scored_by ON jobs(scored_by)",
       "tbl_name": "jobs",
       "type": "index"
     },
@@ -82,6 +100,12 @@
       "name": "idx_onboarding_sessions_completed",
       "sql": "CREATE INDEX idx_onboarding_sessions_completed ON onboarding_sessions(completed_at)",
       "tbl_name": "onboarding_sessions",
+      "type": "index"
+    },
+    {
+      "name": "idx_recall_audit_time",
+      "sql": "CREATE INDEX idx_recall_audit_time ON recall_audit(audited_at)",
+      "tbl_name": "recall_audit",
       "type": "index"
     },
     {
@@ -269,6 +293,71 @@
       "name": "background_tasks",
       "sql": "CREATE TABLE background_tasks(id INTEGER PRIMARY KEY AUTOINCREMENT,job_id TEXT NOT NULL,kind TEXT NOT NULL CHECK(kind IN('prep','prep_phase_b','interview_prep','speculative_research')),started_at TEXT NOT NULL DEFAULT(datetime('now')),finished_at TEXT,status TEXT NOT NULL DEFAULT 'running' CHECK(status IN('running','succeeded','failed')),error_message TEXT,pid INTEGER)",
       "tbl_name": "background_tasks",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "lever",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": "datetime('now')",
+          "name": "changed_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": "'manual'",
+          "name": "changed_by",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "change_summary",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 5,
+          "dflt_value": null,
+          "name": "content_hash",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": null,
+          "name": "diff_summary",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "config_changes",
+      "sql": "CREATE TABLE config_changes(id INTEGER PRIMARY KEY AUTOINCREMENT,lever TEXT NOT NULL,changed_at TEXT DEFAULT(datetime('now')),changed_by TEXT DEFAULT 'manual',change_summary TEXT,content_hash TEXT,diff_summary TEXT)",
+      "tbl_name": "config_changes",
       "type": "table"
     },
     {
@@ -755,11 +844,27 @@
           "notnull": 0,
           "pk": 0,
           "type": "TEXT"
+        },
+        {
+          "cid": 35,
+          "dflt_value": "'unknown'",
+          "name": "company_tier",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 36,
+          "dflt_value": "''",
+          "name": "scored_by",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
         }
       ],
       "foreign_keys": [],
       "name": "jobs",
-      "sql": "CREATE TABLE jobs(id TEXT PRIMARY KEY,fingerprint TEXT UNIQUE NOT NULL,loose_fingerprint TEXT,url TEXT NOT NULL,title TEXT NOT NULL,company TEXT NOT NULL,location TEXT DEFAULT '',source TEXT NOT NULL,raw_jd_text TEXT,relevance_score INTEGER CHECK(relevance_score BETWEEN 1 AND 10),interview_likelihood INTEGER CHECK(interview_likelihood BETWEEN 1 AND 10),strengths_alignment TEXT,industry_sector TEXT,comp_estimate TEXT DEFAULT '',ai_notes TEXT,score_status TEXT CHECK(score_status IN('scored','manual_review')),score_flag_reason TEXT,remote_status TEXT DEFAULT 'Unknown',network_depth INTEGER DEFAULT 0,known_contacts TEXT DEFAULT '',stage TEXT DEFAULT 'discovered' CHECK(stage IN('discovered','enriched','scored','manual_review','prep_in_progress','briefing_ready','materials_drafted','waitlisted','applied','response_received','interview','offer','rejected','not_selected','withdrawn')),stage_updated TEXT,status TEXT DEFAULT 'active' CHECK(status IN('active','manual_review','skipped','applied','rejected','interviewing','offer')),apply_flag INTEGER DEFAULT 0,reject_reason TEXT DEFAULT '',prep_folder_path TEXT,gdrive_folder_url TEXT,fit_score REAL,probability_score REAL,user_notes TEXT DEFAULT '',created_at TEXT DEFAULT(datetime('now')),updated_at TEXT DEFAULT(datetime('now')),dupe_of TEXT DEFAULT '',synthetic INTEGER NOT NULL DEFAULT 0,speculative_briefing_folder TEXT)",
+      "sql": "CREATE TABLE jobs(id TEXT PRIMARY KEY,fingerprint TEXT UNIQUE NOT NULL,loose_fingerprint TEXT,url TEXT NOT NULL,title TEXT NOT NULL,company TEXT NOT NULL,location TEXT DEFAULT '',source TEXT NOT NULL,raw_jd_text TEXT,relevance_score INTEGER CHECK(relevance_score BETWEEN 1 AND 10),interview_likelihood INTEGER CHECK(interview_likelihood BETWEEN 1 AND 10),strengths_alignment TEXT,industry_sector TEXT,comp_estimate TEXT DEFAULT '',ai_notes TEXT,score_status TEXT CHECK(score_status IN('scored','manual_review')),score_flag_reason TEXT,remote_status TEXT DEFAULT 'Unknown',network_depth INTEGER DEFAULT 0,known_contacts TEXT DEFAULT '',stage TEXT DEFAULT 'discovered' CHECK(stage IN('discovered','enriched','scored','manual_review','prep_in_progress','briefing_ready','materials_drafted','waitlisted','applied','response_received','interview','offer','rejected','not_selected','withdrawn')),stage_updated TEXT,status TEXT DEFAULT 'active' CHECK(status IN('active','manual_review','skipped','applied','rejected','interviewing','offer')),apply_flag INTEGER DEFAULT 0,reject_reason TEXT DEFAULT '',prep_folder_path TEXT,gdrive_folder_url TEXT,fit_score REAL,probability_score REAL,user_notes TEXT DEFAULT '',created_at TEXT DEFAULT(datetime('now')),updated_at TEXT DEFAULT(datetime('now')),dupe_of TEXT DEFAULT '',synthetic INTEGER NOT NULL DEFAULT 0,speculative_briefing_folder TEXT,company_tier TEXT DEFAULT 'unknown',scored_by TEXT DEFAULT '')",
       "tbl_name": "jobs",
       "type": "table"
     },
@@ -1007,6 +1112,87 @@
       "name": "onboarding_sessions",
       "sql": "CREATE TABLE onboarding_sessions(id TEXT PRIMARY KEY,history_json TEXT NOT NULL,captured_blocks_json TEXT NOT NULL DEFAULT '{}',started_at TEXT NOT NULL,last_turn_at TEXT NOT NULL,completed_at TEXT,error_state TEXT,user_openrouter_key TEXT DEFAULT NULL,user_rapidapi_key TEXT DEFAULT NULL,cumulative_cost_usd REAL NOT NULL DEFAULT 0)",
       "tbl_name": "onboarding_sessions",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "cid": 0,
+          "dflt_value": null,
+          "name": "id",
+          "notnull": 0,
+          "pk": 1,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 1,
+          "dflt_value": null,
+          "name": "job_id",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 2,
+          "dflt_value": "datetime('now')",
+          "name": "audited_at",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 3,
+          "dflt_value": null,
+          "name": "original_score",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 4,
+          "dflt_value": null,
+          "name": "original_scored_by",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 5,
+          "dflt_value": null,
+          "name": "auditor_model",
+          "notnull": 1,
+          "pk": 0,
+          "type": "TEXT"
+        },
+        {
+          "cid": 6,
+          "dflt_value": null,
+          "name": "audited_score",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 7,
+          "dflt_value": "0",
+          "name": "upgraded",
+          "notnull": 0,
+          "pk": 0,
+          "type": "INTEGER"
+        },
+        {
+          "cid": 8,
+          "dflt_value": null,
+          "name": "audit_notes",
+          "notnull": 0,
+          "pk": 0,
+          "type": "TEXT"
+        }
+      ],
+      "foreign_keys": [],
+      "name": "recall_audit",
+      "sql": "CREATE TABLE recall_audit(id INTEGER PRIMARY KEY AUTOINCREMENT,job_id TEXT NOT NULL,audited_at TEXT DEFAULT(datetime('now')),original_score INTEGER,original_scored_by TEXT,auditor_model TEXT NOT NULL,audited_score INTEGER,upgraded INTEGER DEFAULT 0,audit_notes TEXT)",
+      "tbl_name": "recall_audit",
       "type": "table"
     },
     {

--- a/tests/test_backfill_phase1.py
+++ b/tests/test_backfill_phase1.py
@@ -1,0 +1,117 @@
+"""Tests for the Phase 1 backfill scripts."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def seeded_db(tmp_path):
+    base = tmp_path / "repo"
+    (base / "data").mkdir(parents=True)
+    (base / "config").mkdir()
+    (base / "config" / "companies_of_interest.txt").write_text("Acme Corp\nGlobex\n")
+
+    env = os.environ.copy()
+    env["JSP_BASE"] = str(base)
+    repo_root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "init_db.py")],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+
+    conn = sqlite3.connect(str(base / "data" / "pipeline.db"))
+    conn.executemany(
+        """INSERT INTO jobs (id, fingerprint, url, title, company, source, ai_notes, score_flag_reason, relevance_score)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("j1", "fp1", "u", "Program Manager", "Acme Corp", "greenhouse_json", "Normal LLM notes", None, 7),
+            (
+                "j2",
+                "fp2",
+                "u",
+                "SWE",
+                "Globex",
+                "jobsapi_indeed",
+                "Hard reject — title is outside candidate domain.",
+                'Pre-filter hard reject: title matched "SWE"',
+                1,
+            ),
+            (
+                "j3",
+                "fp3",
+                "u",
+                "DC Technician",
+                "Unknown Co",
+                "jsearch",
+                "Title is directionally in-domain. JD unavailable — scored 5 per policy.",
+                "Pre-filter in-domain/no-JD: scored 5",
+                5,
+            ),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return base, env
+
+
+def test_backfill_company_tier(seeded_db):
+    base, env = seeded_db
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "backfill_company_tier.py")],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    conn = sqlite3.connect(str(base / "data" / "pipeline.db"))
+    rows = {r[0]: r[1] for r in conn.execute("SELECT id, company_tier FROM jobs").fetchall()}
+    conn.close()
+    assert rows["j1"] == "tier1"
+    assert rows["j2"] == "tier1"
+    assert rows["j3"] == "other"
+
+
+def test_backfill_scored_by(seeded_db):
+    base, env = seeded_db
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "backfill_scored_by.py")],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    conn = sqlite3.connect(str(base / "data" / "pipeline.db"))
+    rows = {r[0]: r[1] for r in conn.execute("SELECT id, scored_by FROM jobs").fetchall()}
+    conn.close()
+    assert rows["j1"] == "llm"
+    assert rows["j2"] == "prefilter_stage1"
+    assert rows["j3"] == "prefilter_stage2"
+
+
+def test_backfill_idempotent(seeded_db):
+    base, env = seeded_db
+    repo_root = Path(__file__).resolve().parents[1]
+    for _ in range(2):
+        subprocess.run(
+            [sys.executable, str(repo_root / "scripts" / "backfill_company_tier.py")],
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+    conn = sqlite3.connect(str(base / "data" / "pipeline.db"))
+    count = conn.execute("SELECT COUNT(*) FROM jobs WHERE company_tier='tier1'").fetchone()[0]
+    conn.close()
+    assert count == 2

--- a/tests/test_config_drift_detector.py
+++ b/tests/test_config_drift_detector.py
@@ -1,0 +1,100 @@
+"""Tests for the config-drift detector."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import findajob.paths as _findajob_paths
+
+
+@pytest.fixture
+def fresh_db(tmp_path, monkeypatch):
+    base = tmp_path / "repo"
+    (base / "data").mkdir(parents=True)
+    (base / "config").mkdir()
+    (base / "candidate_context").mkdir()
+
+    env = os.environ.copy()
+    env["JSP_BASE"] = str(base)
+    repo_root = Path(__file__).resolve().parents[1]
+    subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "init_db.py")],
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.setattr(_findajob_paths, "BASE", str(base))
+    conn = sqlite3.connect(str(base / "data" / "pipeline.db"))
+    return conn, base
+
+
+def test_first_call_records_existing_levers(fresh_db):
+    conn, base = fresh_db
+    from findajob.metrics.config_changes import detect_and_record
+
+    (base / "candidate_context" / "profile.md").write_text("PROFILE V1")
+    (base / "config" / "jsearch_queries.txt").write_text("query one\n")
+
+    detect_and_record(conn, changed_by="test")
+    rows = conn.execute("SELECT lever, changed_by FROM config_changes").fetchall()
+    levers = {r[0] for r in rows}
+    assert "profile" in levers
+    assert "queries" in levers
+    assert all(r[1] == "test" for r in rows)
+
+
+def test_unchanged_content_no_new_row(fresh_db):
+    conn, base = fresh_db
+    from findajob.metrics.config_changes import detect_and_record
+
+    (base / "candidate_context" / "profile.md").write_text("PROFILE V1")
+
+    detect_and_record(conn, changed_by="test")
+    detect_and_record(conn, changed_by="test")
+
+    n = conn.execute("SELECT COUNT(*) FROM config_changes WHERE lever='profile'").fetchone()[0]
+    assert n == 1
+
+
+def test_changed_content_inserts_new_row(fresh_db):
+    conn, base = fresh_db
+    from findajob.metrics.config_changes import detect_and_record
+
+    profile = base / "candidate_context" / "profile.md"
+    profile.write_text("PROFILE V1")
+    detect_and_record(conn, changed_by="test")
+
+    profile.write_text("PROFILE V2")
+    detect_and_record(conn, changed_by="test")
+
+    rows = conn.execute("SELECT content_hash FROM config_changes WHERE lever='profile' ORDER BY id").fetchall()
+    assert len(rows) == 2
+    assert rows[0][0] != rows[1][0]
+
+
+def test_missing_file_skipped_silently(fresh_db):
+    conn, base = fresh_db
+    from findajob.metrics.config_changes import detect_and_record
+
+    (base / "candidate_context" / "profile.md").write_text("x")
+
+    detect_and_record(conn, changed_by="test")
+    levers = {r[0] for r in conn.execute("SELECT lever FROM config_changes").fetchall()}
+    assert "profile" in levers
+    assert "queries" not in levers
+
+
+def test_changed_by_propagates(fresh_db):
+    conn, base = fresh_db
+    from findajob.metrics.config_changes import detect_and_record
+
+    (base / "candidate_context" / "profile.md").write_text("x")
+
+    detect_and_record(conn, changed_by="onboarding")
+    row = conn.execute("SELECT changed_by FROM config_changes WHERE lever='profile'").fetchone()
+    assert row[0] == "onboarding"

--- a/tests/test_config_drift_detector.py
+++ b/tests/test_config_drift_detector.py
@@ -1,4 +1,5 @@
 """Tests for the config-drift detector."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_config_route_drift_wire.py
+++ b/tests/test_config_route_drift_wire.py
@@ -1,4 +1,5 @@
 """Verify /config/ POST triggers drift detection."""
+
 from pathlib import Path
 
 

--- a/tests/test_config_route_drift_wire.py
+++ b/tests/test_config_route_drift_wire.py
@@ -1,0 +1,8 @@
+"""Verify /config/ POST triggers drift detection."""
+from pathlib import Path
+
+
+def test_config_save_calls_detect_and_record():
+    src = Path(__file__).resolve().parents[1] / "src" / "findajob" / "web" / "routes" / "config.py"
+    text = src.read_text()
+    assert "detect_and_record" in text, "/config/ POST must call detect_and_record"

--- a/tests/test_init_db_schema.py
+++ b/tests/test_init_db_schema.py
@@ -77,7 +77,17 @@ def test_config_changes_table_exists(fresh_db):
 def test_recall_audit_table_exists(fresh_db):
     """Migration 0007: recall_audit table must have all required columns."""
     cols = _columns(fresh_db, "recall_audit")
-    assert cols >= {"id", "job_id", "audited_at", "original_score", "original_scored_by", "auditor_model", "audited_score", "upgraded", "audit_notes"}
+    assert cols >= {
+        "id",
+        "job_id",
+        "audited_at",
+        "original_score",
+        "original_scored_by",
+        "auditor_model",
+        "audited_score",
+        "upgraded",
+        "audit_notes",
+    }
 
 
 def test_jobs_has_company_tier_column(fresh_db):

--- a/tests/test_init_db_schema.py
+++ b/tests/test_init_db_schema.py
@@ -66,3 +66,27 @@ def test_jobs_has_user_notes_column(fresh_db):
     """board_actions /notes handler writes to jobs.user_notes from the Applied tab."""
     cols = _columns(fresh_db, "jobs")
     assert "user_notes" in cols
+
+
+def test_config_changes_table_exists(fresh_db):
+    """Migration 0007: config_changes table must have all required columns."""
+    cols = _columns(fresh_db, "config_changes")
+    assert cols >= {"id", "lever", "changed_at", "changed_by", "change_summary", "content_hash", "diff_summary"}
+
+
+def test_recall_audit_table_exists(fresh_db):
+    """Migration 0007: recall_audit table must have all required columns."""
+    cols = _columns(fresh_db, "recall_audit")
+    assert cols >= {"id", "job_id", "audited_at", "original_score", "original_scored_by", "auditor_model", "audited_score", "upgraded", "audit_notes"}
+
+
+def test_jobs_has_company_tier_column(fresh_db):
+    """Migration 0007: jobs.company_tier column added for tier-aware scoring."""
+    cols = _columns(fresh_db, "jobs")
+    assert "company_tier" in cols
+
+
+def test_jobs_has_scored_by_column(fresh_db):
+    """Migration 0007: jobs.scored_by column tracks which model scored the job."""
+    cols = _columns(fresh_db, "jobs")
+    assert "scored_by" in cols

--- a/tests/test_injector_drift_wire.py
+++ b/tests/test_injector_drift_wire.py
@@ -1,0 +1,14 @@
+"""Verify onboarding injector calls detect_and_record after paste-back."""
+from pathlib import Path
+
+
+def test_injector_calls_detect_and_record():
+    src = Path(__file__).resolve().parents[1] / "src" / "findajob" / "onboarding" / "injector.py"
+    text = src.read_text()
+    assert "detect_and_record" in text, "injector must call detect_and_record"
+
+
+def test_injector_drift_detection_uses_onboarding_changed_by():
+    src = Path(__file__).resolve().parents[1] / "src" / "findajob" / "onboarding" / "injector.py"
+    text = src.read_text()
+    assert 'changed_by="onboarding"' in text

--- a/tests/test_injector_drift_wire.py
+++ b/tests/test_injector_drift_wire.py
@@ -1,4 +1,5 @@
 """Verify onboarding injector calls detect_and_record after paste-back."""
+
 from pathlib import Path
 
 

--- a/tests/test_scorer_prefilter.py
+++ b/tests/test_scorer_prefilter.py
@@ -502,6 +502,7 @@ class TestPrefilterScoreExcludedEmployer:
 
 def test_stage1_hard_reject_returns_scored_by():
     from findajob.scorer_prefilter import prefilter_score
+
     result, _ = prefilter_score("Software Engineer at Acme", "Acme", jd_usable=True)
     if result is not None:
         assert result["scored_by"] == "prefilter_stage1"
@@ -510,6 +511,7 @@ def test_stage1_hard_reject_returns_scored_by():
 
 def test_stage2_indomain_nojd_returns_scored_by():
     from findajob.scorer_prefilter import prefilter_score
+
     result, _ = prefilter_score("Data Center Operations Manager", "Acme", jd_usable=False)
     if result is not None:
         assert result["scored_by"] == "prefilter_stage2"

--- a/tests/test_scorer_prefilter.py
+++ b/tests/test_scorer_prefilter.py
@@ -344,6 +344,8 @@ class TestPrefilterScore:
             "ai_notes",
             "score_flag_reason",
             "remote_status",
+            "scored_by",
+            "company_tier",
         }
         assert set(result.keys()) == expected_keys
         assert result["remote_status"] == "Unknown"
@@ -363,6 +365,8 @@ class TestPrefilterScore:
             "ai_notes",
             "score_flag_reason",
             "remote_status",
+            "scored_by",
+            "company_tier",
         }
         assert set(result.keys()) == expected_keys
         assert result["score_flag_reason"] is None  # not flagged
@@ -494,3 +498,19 @@ class TestPrefilterScoreExcludedEmployer:
         """Non-excluded company falls through to normal flow."""
         result, _ = prefilter_score("Product Manager", "Google", jd_usable=True)
         assert result is None  # falls through to LLM
+
+
+def test_stage1_hard_reject_returns_scored_by():
+    from findajob.scorer_prefilter import prefilter_score
+    result, _ = prefilter_score("Software Engineer at Acme", "Acme", jd_usable=True)
+    if result is not None:
+        assert result["scored_by"] == "prefilter_stage1"
+        assert "company_tier" in result
+
+
+def test_stage2_indomain_nojd_returns_scored_by():
+    from findajob.scorer_prefilter import prefilter_score
+    result, _ = prefilter_score("Data Center Operations Manager", "Acme", jd_usable=False)
+    if result is not None:
+        assert result["scored_by"] == "prefilter_stage2"
+        assert "company_tier" in result

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -176,10 +176,15 @@ def test_build_feedback_block_excludes_synthetic(tmp_path, monkeypatch):
 
 def test_score_job_llm_branch_has_scored_by(monkeypatch):
     from unittest.mock import MagicMock
+
     from findajob.scoring import score_job
 
     fake_result = MagicMock()
-    fake_result.text = '{"score_status":"scored","relevance_score":7,"interview_likelihood":6,"strengths_alignment":"good","industry_sector":"tech","comp_estimate":"","ai_notes":"","score_flag_reason":null,"remote_status":"Remote"}'
+    fake_result.text = (
+        '{"score_status":"scored","relevance_score":7,"interview_likelihood":6,'
+        '"strengths_alignment":"good","industry_sector":"tech","comp_estimate":"",'
+        '"ai_notes":"","score_flag_reason":null,"remote_status":"Remote"}'
+    )
     fake_result.usage = MagicMock(prompt_tokens=100, completion_tokens=50, cost=0.001)
 
     monkeypatch.setattr("findajob.scoring.complete", lambda **kw: fake_result)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -172,3 +172,25 @@ def test_build_feedback_block_excludes_synthetic(tmp_path, monkeypatch):
     assert "[SPEC]" not in block, "synthetic rejection title leaked into feedback block"
     # Should report "1x" (the real one), not "2x"
     assert '1x "Fit Mismatch"' in block
+
+
+def test_score_job_llm_branch_has_scored_by(monkeypatch):
+    from unittest.mock import MagicMock
+    from findajob.scoring import score_job
+
+    fake_result = MagicMock()
+    fake_result.text = '{"score_status":"scored","relevance_score":7,"interview_likelihood":6,"strengths_alignment":"good","industry_sector":"tech","comp_estimate":"","ai_notes":"","score_flag_reason":null,"remote_status":"Remote"}'
+    fake_result.usage = MagicMock(prompt_tokens=100, completion_tokens=50, cost=0.001)
+
+    monkeypatch.setattr("findajob.scoring.complete", lambda **kw: fake_result)
+    monkeypatch.setattr("findajob.scoring.prefilter_score", lambda *a, **kw: (None, None))
+
+    result, latency, completion = score_job(
+        title="Operations Program Manager",
+        company="Some Company",
+        location="Remote",
+        jd_text="A long usable JD about running operations programs. " * 20,
+        candidate_profile="CANDIDATE PROFILE: example",
+    )
+    assert result["scored_by"] == "llm"
+    assert "company_tier" in result

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -1,0 +1,50 @@
+"""Tests for company tier resolution."""
+from __future__ import annotations
+
+import pytest
+
+from findajob.tiers import load_tier1_companies, resolve_tier
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    load_tier1_companies.cache_clear()
+    yield
+    load_tier1_companies.cache_clear()
+
+
+def test_exact_match_returns_tier1(tmp_path, monkeypatch):
+    coi = tmp_path / "config" / "companies_of_interest.txt"
+    coi.parent.mkdir()
+    coi.write_text("Acme Corporation\nGlobex\n")
+    monkeypatch.setattr("findajob.tiers._coi_path", lambda: coi)
+    assert resolve_tier("Acme Corporation") == "tier1"
+    assert resolve_tier("Globex") == "tier1"
+
+
+def test_case_insensitive(tmp_path, monkeypatch):
+    coi = tmp_path / "config" / "companies_of_interest.txt"
+    coi.parent.mkdir()
+    coi.write_text("Acme Corporation\n")
+    monkeypatch.setattr("findajob.tiers._coi_path", lambda: coi)
+    assert resolve_tier("ACME CORPORATION") == "tier1"
+    assert resolve_tier("acme corporation") == "tier1"
+
+
+def test_no_match_returns_other(tmp_path, monkeypatch):
+    coi = tmp_path / "config" / "companies_of_interest.txt"
+    coi.parent.mkdir()
+    coi.write_text("Acme Corporation\n")
+    monkeypatch.setattr("findajob.tiers._coi_path", lambda: coi)
+    assert resolve_tier("Globex") == "other"
+
+
+def test_missing_file_returns_unknown(tmp_path, monkeypatch):
+    missing = tmp_path / "does" / "not" / "exist.txt"
+    monkeypatch.setattr("findajob.tiers._coi_path", lambda: missing)
+    assert resolve_tier("Acme") == "unknown"
+
+
+def test_empty_company_returns_unknown():
+    assert resolve_tier("") == "unknown"
+    assert resolve_tier(None) == "unknown"

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -1,4 +1,5 @@
 """Tests for company tier resolution."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_triage_config_drift_wire.py
+++ b/tests/test_triage_config_drift_wire.py
@@ -1,4 +1,5 @@
 """Verify triage orchestrator calls detect_and_record before scoring."""
+
 from pathlib import Path
 
 

--- a/tests/test_triage_config_drift_wire.py
+++ b/tests/test_triage_config_drift_wire.py
@@ -1,0 +1,17 @@
+"""Verify triage orchestrator calls detect_and_record before scoring."""
+from pathlib import Path
+
+
+def test_triage_imports_detect_and_record():
+    src = Path(__file__).resolve().parents[1] / "src" / "findajob" / "triage" / "orchestrator.py"
+    text = src.read_text()
+    assert "from findajob.metrics.config_changes import detect_and_record" in text
+
+
+def test_triage_calls_detect_and_record_before_scoring():
+    src = Path(__file__).resolve().parents[1] / "src" / "findajob" / "triage" / "orchestrator.py"
+    text = src.read_text()
+    call_idx = text.find("detect_and_record(")
+    score_idx = text.find("scored_count")
+    assert call_idx > 0, "detect_and_record call not found"
+    assert call_idx < score_idx, "detect_and_record must be called before scoring loop"

--- a/tests/test_triage_persists_phase1_columns.py
+++ b/tests/test_triage_persists_phase1_columns.py
@@ -1,0 +1,25 @@
+"""Verify triage UPDATE includes scored_by + company_tier columns."""
+from pathlib import Path
+
+
+def _scoring_update_block() -> str:
+    """Return the scoring UPDATE block from the orchestrator source."""
+    src = Path(__file__).resolve().parents[1] / "src" / "findajob" / "triage" / "orchestrator.py"
+    text = src.read_text()
+    # The scoring UPDATE is the one that sets relevance_score — unique to this block.
+    idx = text.find("relevance_score=?")
+    assert idx > 0, "could not find scoring UPDATE block (relevance_score=? not found)"
+    # Walk back to the UPDATE keyword
+    start = text.rfind("UPDATE jobs SET", 0, idx)
+    assert start > 0, "could not find UPDATE jobs SET before relevance_score=?"
+    return text[start : start + 600]
+
+
+def test_triage_update_includes_scored_by():
+    block = _scoring_update_block()
+    assert "scored_by=?" in block, "scored_by not in triage scoring UPDATE"
+
+
+def test_triage_update_includes_company_tier():
+    block = _scoring_update_block()
+    assert "company_tier=?" in block, "company_tier not in triage scoring UPDATE"

--- a/tests/test_triage_persists_phase1_columns.py
+++ b/tests/test_triage_persists_phase1_columns.py
@@ -1,4 +1,5 @@
 """Verify triage UPDATE includes scored_by + company_tier columns."""
+
 from pathlib import Path
 
 


### PR DESCRIPTION
## Summary

- Migration 0007: `config_changes` + `recall_audit` tables; `jobs.company_tier` + `jobs.scored_by` columns
- Tier resolver (`src/findajob/tiers.py`) classifies companies from `companies_of_interest.txt`
- Config-drift detector (`src/findajob/metrics/config_changes.py`) hashes 14 levers, wired into triage + /config/ POST + onboarding injector
- `scored_by` + `company_tier` populated at score time (prefilter + LLM paths + triage UPDATE)
- Backfill scripts for existing rows (both idempotent)
- Fix: `_rebuild_table_with_indexes` now re-applies columns/indexes from later migrations after constraint rebuilds

Spec: `docs/superpowers/specs/2026-05-24-tuning-loop-rewrite.md` §4. Blocks #230.

## Migration required

- `scripts/init_db.py` runs automatically at container start (applies 0007)
- After upgrade: `uv run python scripts/backfill_company_tier.py && uv run python scripts/backfill_scored_by.py`

## Test plan

- [x] Unit tests pass (`uv run pytest -q` — 3350 passed)
- [x] Linters clean (ruff check, ruff format --check, mypy)
- [x] Smoke: init_db.py against scratch DB — schema verified
- [ ] Smoke: backfill scripts against prod DB copy — deterministic population
- [ ] Smoke: edit one config file via /config/ → `config_changes` row with changed_by='manual'
- [ ] Smoke: run triage → pre-triage `config_changes` row lands
- [ ] Browser: verify no regression on existing /stats/* pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)