### PR TITLE
fix(staging): self-setup waitlisted row in walkthrough (#777)

### DIFF
--- a/config/loose_ends_walkthroughs.yaml
+++ b/config/loose_ends_walkthroughs.yaml
@@ -95,6 +95,13 @@ walkthroughs:
     persona: established_user
     target_category: 2
     steps:
+      # Self-setup: waitlist a scored job via the Dashboard dropdown so
+      # the walkthrough doesn't depend on external state (#777).
+      - goto: /board/dashboard
+      - assert_present: 'tr[data-stage="scored"]'
+      - select_option:
+          row_selector: 'tr[data-stage="scored"]'
+          option_value: "waitlist"
       - goto: /board/waitlist
       - assert_present: 'tr[data-stage="waitlisted"]'
       - pick_first_row_with_stage: waitlisted


### PR DESCRIPTION
## Summary
- The `waitlist_then_reactivate` walkthrough assertion-failed at step 1 on `findajob-staging` because no `waitlisted` rows existed — the synthetic clicker doesn't exercise waitlist transitions.
- Instead of adding a clicker mode (timing race) or persistent seed row (consumed once by reactivation), the walkthrough now self-sets-up: it navigates to `/board/dashboard`, picks a scored row, waitlists it via `select_option`, then proceeds to the reactivation test.
- The walkthrough now exercises the full scored→waitlisted→reactivated cycle, testing more product surface than before.

## Test plan
- [x] YAML parses correctly via `yaml.safe_load`
- [x] `load_walkthroughs()` resolves all 8 steps through the real parser (GotoStep, AssertPresentStep, SelectOptionStep, GotoStep, AssertPresentStep, PickFirstRowStep, ClickActionStep, EvaluateDomStep)
- [x] All 62 `tests/loose_ends/` tests pass
- [ ] Walkthrough runs to `evaluate_dom` step on a fresh `findajob-staging` run — **cannot verify: staging stack is stopped as of 2026-05-24**. The self-setup steps use existing, well-tested primitives (`select_option`, `assert_present`, `goto`) and the same HTMX POST path exercised by `applied_to_interviewing_undo` and `interviewing_to_offer_path` walkthroughs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)