### PR TITLE
fix(fly-deploy): make RAPIDAPI_KEY and NTFY_TOPIC optional (#878)

### DIFF
--- a/ops/fly-deploy.sh
+++ b/ops/fly-deploy.sh
@@ -101,12 +101,13 @@ has_secret() {
         | grep -qxF "$1"
 }
 
-# prompt_secret <NAME> <prompt-label> [default] [sensitive=1|0]
+# prompt_secret <NAME> <prompt-label> [default] [sensitive=1|0] [optional=1|0]
 prompt_secret() {
     local name="$1"
     local label="$2"
     local default="${3:-}"
     local sensitive="${4:-0}"
+    local optional="${5:-0}"
     if has_secret "$name"; then
         echo "    skip   $name (already set — rotate with: fly secrets set $name=... --app $APP)"
         return
@@ -115,6 +116,8 @@ prompt_secret() {
     local prompt_suffix=""
     if [ -n "$default" ]; then
         prompt_suffix=" [default: $default]"
+    elif [ "$optional" = "1" ]; then
+        prompt_suffix=" (optional — press Enter to skip)"
     fi
     if [ "$sensitive" = "1" ]; then
         printf "    %s%s: " "$label" "$prompt_suffix" >&2
@@ -129,6 +132,10 @@ prompt_secret() {
         val="$default"
     fi
     if [ -z "$val" ]; then
+        if [ "$optional" = "1" ]; then
+            echo "    skip   $name (not provided)"
+            return
+        fi
         echo "ERROR: $name is required and was empty." >&2
         exit 1
     fi
@@ -138,8 +145,8 @@ prompt_secret() {
 
 echo "==> Configuring secrets (already-set values skipped)..."
 prompt_secret OPENROUTER_API_KEY "OpenRouter API key"                  ""                          1
-prompt_secret RAPIDAPI_KEY       "RapidAPI key"                        ""                          1
-prompt_secret NTFY_TOPIC         "ntfy topic"                          ""                          0
+prompt_secret RAPIDAPI_KEY       "RapidAPI key"                        ""                          1  1
+prompt_secret NTFY_TOPIC         "ntfy topic"                          ""                          0  1
 prompt_secret FINDAJOB_AUTH_USER "Basic-auth username"                 ""                          0
 prompt_secret FINDAJOB_AUTH_PASS "Basic-auth password (>= 24 chars)"   ""                          1
 prompt_secret FINDAJOB_WEB_URL   "Public web URL"                      "https://$APP.fly.dev"      0


### PR DESCRIPTION
## Summary
- `prompt_secret` in `ops/fly-deploy.sh` exited 1 on empty input for secrets the docs mark as skippable
- Added 5th positional `optional` flag — empty input prints "skip" and returns instead of erroring
- Applied to `RAPIDAPI_KEY` and `NTFY_TOPIC`; prompt now shows `(optional — press Enter to skip)`

## Test plan
- [ ] `bash -n ops/fly-deploy.sh` passes (verified locally)
- [ ] Manual run: enter empty for RAPIDAPI_KEY → script continues without error
- [ ] Manual run: enter empty for NTFY_TOPIC → script continues without error
- [ ] Existing secrets (already set via `fly secrets`) still skip as before
- [ ] `start-here-fly.md` Step 8 wording ("press Enter to skip") still accurate — no doc change needed

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)