### PR TITLE
fix(flashcards): fix truncation-driven JSONDecodeError + health-check blank error text

### DIFF
--- a/config/roles/flashcard_generator.md
+++ b/config/roles/flashcard_generator.md
@@ -15,11 +15,10 @@ Every prompt includes:
 - COMPANY BRIEFING (full, generated at apply time)
 - TAILORED RESUME (the version actually submitted)
 - INTERVIEW PREP (the detailed interview notes already generated)
-- STUDY GUIDE (the structured study guide just generated)
 
 ## Your output
 
-A JSON array of 25-40 flashcard objects. Each object has exactly three keys:
+A JSON array of 15-20 flashcard objects. Each object has exactly three keys:
 
 ```json
 [
@@ -43,11 +42,11 @@ A JSON array of 25-40 flashcard objects. Each object has exactly three keys:
 ## Card design rules
 
 1. Front: always phrased as a question or prompt. Never a statement.
-2. Back: 1-4 sentences. Include one specific example, metric, or name where possible.
+2. Back: 1-2 sentences. Include one specific example, metric, or name where possible.
 3. Tags: 1-3 tags per card. At least one card per tag.
 4. No duplicate fronts. Each card tests a distinct piece of knowledge.
 5. Draw all examples from the TAILORED RESUME, MASTER RESUME, or COMPANY BRIEFING. Never invent.
-6. Balance: roughly 8-10 behavioral, 6-8 technical, 5-6 company, 4-5 role, 2-3 elevator, 3-4 closing.
+6. Balance: roughly 5-6 behavioral, 3-4 technical, 2-3 company, 2-3 role, 1-2 elevator, 2-3 closing.
 
 ## Critical
 

--- a/src/findajob/interview/orchestrator.py
+++ b/src/findajob/interview/orchestrator.py
@@ -390,7 +390,6 @@ def _generate_study_materials(
         f"COMPANY BRIEFING:\n{briefing}\n\n"
         f"TAILORED RESUME:\n{resume}\n"
         f"\nINTERVIEW PREP:\n{interview_prep}\n"
-        f"\nSTUDY GUIDE:\n{study_guide_md}\n"
     )
 
     flashcard_json_raw = run_role(

--- a/src/findajob/notifications/health_check.py
+++ b/src/findajob/notifications/health_check.py
@@ -113,7 +113,7 @@ def cmd_health_check() -> None:
     if error_events:
         issues.append(f"ERRORS: {len(error_events)} error events in log")
         for e in error_events[:3]:
-            issues.append(f"  • [{e.get('event', '?')}] {e.get('error', e.get('note', ''))}")
+            issues.append(f"  • [{e.get('event', '?')}] {e.get('error', e.get('reason', e.get('note', '')))}")
     if null_score:
         issues.append(f"INFO: {len(null_score)} jobs scored None (likely LLM timeout)")
 


### PR DESCRIPTION
## Summary

- **Flashcard truncation (primary):** All `flashcard_generator` completions were hitting exactly 4096 output tokens (confirmed via `openrouter_truncated` events in `pipeline.jsonl`), truncating the JSON array mid-element and causing `JSONDecodeError: Expecting ',' delimiter` on every interview prep run. Fixed by removing `study_guide_md` from `flashcard_prompt` (redundant — derived from `interview_prep` which is already included) and reducing card count 25-40 → 15-20 with backs 1-4 → 1-2 sentences.
- **Health check blank error text:** `orchestrator.py` logs `flashcard_error` with key `reason=...` but `health_check.py` only checked `error` and `note` keys, rendering blank text for every `[flashcard_error]` line in health summaries. Added `reason` to the fallback chain.

## Changes

- `orchestrator.py`: remove `study_guide_md` from `flashcard_prompt`
- `flashcard_generator.md`: 25-40 → 15-20 cards, backs 1-4 → 1-2 sentences, distribution scaled to match (sums 15-21)
- `health_check.py`: `e.get('error', e.get('reason', e.get('note', '')))` — adds `reason` as middle fallback

## Test plan

- [x] `pytest tests/test_flashcards.py tests/test_health_check_dead_feeds.py tests/test_notify_health_split.py` — all pass
- [x] `ruff check` + `ruff format --check` — clean
- [ ] Deploy smoke: next interview prep run should produce a complete `.apkg` with no `flashcard_error` in `pipeline.jsonl`
- [ ] Health check: next `notify-health` run should show populated error text (not blank) if any `flashcard_error` events remain in the 25h window

🤖 Generated with [Claude Code](https://claude.com/claude-code)