### PR TITLE
feat(fly): auto-derive FINDAJOB_WEB_URL + root fly.toml for web deploy

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,44 @@
+# fly.toml — Fly.io deployment template.
+#
+# The web "Launch an App from GitHub" flow reads this file automatically
+# (default config path = ./). The app name in the form overrides the
+# placeholder below.
+#
+# CLI users: see ops/fly.toml.example for the full-comment version and
+# the deploy script at ops/fly-deploy.sh.
+
+app = "findajob"
+primary_region = "iad"
+
+[build]
+  image = "ghcr.io/brockamer/findajob:latest"
+
+[env]
+  JSP_BASE = "/app/state"
+  PUID = "1000"
+  PGID = "1000"
+  TZ = "America/New_York"
+
+[http_service]
+  internal_port = 8090
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    type = "http"
+    method = "GET"
+    path = "/healthz"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "60s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"
+
+[[mounts]]
+  source = "findajob_state"
+  destination = "/app/state"
+  initial_size = "8gb"

--- a/ops/fly-deploy.sh
+++ b/ops/fly-deploy.sh
@@ -149,7 +149,9 @@ prompt_secret RAPIDAPI_KEY       "RapidAPI key"                        ""       
 prompt_secret NTFY_TOPIC         "ntfy topic"                          ""                          0  1
 prompt_secret FINDAJOB_AUTH_USER "Basic-auth username"                 ""                          0
 prompt_secret FINDAJOB_AUTH_PASS "Basic-auth password (>= 24 chars)"   ""                          1
-prompt_secret FINDAJOB_WEB_URL   "Public web URL"                      "https://$APP.fly.dev"      0
+# FINDAJOB_WEB_URL is auto-derived from FLY_APP_NAME at runtime; only
+# prompt when the operator explicitly wants a custom domain.
+prompt_secret FINDAJOB_WEB_URL   "Public web URL (auto-derived if skipped)" ""                      0  1
 
 # --- 4. Deploy ------------------------------------------------------------
 

--- a/ops/fly.toml.example
+++ b/ops/fly.toml.example
@@ -29,8 +29,9 @@ primary_region = "iad"
 # (data/, logs/, companies/, config/, candidate_context/, .backups/) live
 # under a single volume root. The entrypoint materializes them on first boot.
 # Secrets (OPENROUTER_API_KEY, RAPIDAPI_KEY, NTFY_TOPIC, FINDAJOB_AUTH_USER,
-# FINDAJOB_AUTH_PASS, FINDAJOB_WEB_URL) are set via `fly secrets set` —
-# the deploy script prompts for any that are missing.
+# FINDAJOB_AUTH_PASS) are set via `fly secrets set` — the deploy script
+# prompts for any that are missing. FINDAJOB_WEB_URL is auto-derived from
+# FLY_APP_NAME on Fly (falls back to http://localhost:8090 elsewhere).
 [env]
   JSP_BASE = "/app/state"
   PUID = "1000"

--- a/src/findajob/notifications/ntfy.py
+++ b/src/findajob/notifications/ntfy.py
@@ -41,11 +41,16 @@ def _runtime() -> dict[str, str]:
     globals literally.
     """
     env = load_env()
+    web_url = (
+        env.get("FINDAJOB_WEB_URL")
+        or os.environ.get("FINDAJOB_WEB_URL")
+    )
+    if not web_url:
+        fly_app = os.environ.get("FLY_APP_NAME")
+        web_url = f"https://{fly_app}.fly.dev" if fly_app else "http://localhost:8090"
     return {
         "ntfy_topic": env.get("NTFY_TOPIC") or os.environ.get("NTFY_TOPIC", "jobsearch-pipeline"),
-        "web_base_url": (
-            env.get("FINDAJOB_WEB_URL") or os.environ.get("FINDAJOB_WEB_URL", "http://localhost:8090")
-        ).rstrip("/"),
+        "web_base_url": web_url.rstrip("/"),
     }
 
 


### PR DESCRIPTION
## Summary
- **Auto-derive `FINDAJOB_WEB_URL`** from Fly's runtime `FLY_APP_NAME` env var — eliminates 1 required secret from Fly deploys (5 → 4)
- **Root-level `fly.toml`** — web "Launch from GitHub" defaults to config path `./`; tracked template means users don't need to type `ops/fly.toml` in the config path field
- **`FINDAJOB_WEB_URL` made optional** in `fly-deploy.sh` (auto-derived if skipped)

Part of #881 (CLI-free Fly install design). Filed #895 for the follow-on (in-app auth credential collection).

## Test plan
- [ ] 63 notification tests pass with the `FLY_APP_NAME` fallback
- [ ] Verified `FLY_APP_NAME` is set at runtime on findajob-brock: `fly ssh console --app findajob-brock -C "printenv FLY_APP_NAME"` → `findajob-brock`
- [ ] Test deploy via CLI with `[[mounts]]` fly.toml auto-provisioned 8 GB volume successfully
- [ ] `ruff check` + `ruff format --check` clean
- [ ] Full test suite passes
- [ ] Verify post-deploy: unset `FINDAJOB_WEB_URL` secret on findajob-brock, confirm ntfy notifications still carry correct click-through URLs (auto-derived from `FLY_APP_NAME`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)