### PR TITLE
feat(fetchers): Gem GraphQL adapter for gem.com-hosted boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 - **Auto-derive `FINDAJOB_WEB_URL` from Fly runtime env** (#881): On Fly.io, `FINDAJOB_WEB_URL` is now auto-derived from the `FLY_APP_NAME` env var (set by Fly at runtime) when not explicitly configured. Eliminates 1 required secret from Fly deploys. Fallback chain: `data/.env` → `FINDAJOB_WEB_URL` env → `https://{FLY_APP_NAME}.fly.dev` → `http://localhost:8090`. `fly-deploy.sh` now marks `FINDAJOB_WEB_URL` as optional (skippable).
 - **Root-level `fly.toml` for web deploy** (#881): Tracked `fly.toml` at repo root enables the Fly.io "Launch from GitHub" web flow with default config path `./`. CLI users continue using `ops/fly.toml.example` → `ops/fly.toml` unchanged.
+- **Gem GraphQL adapter** (#249): New `GemAdapter` fetches job postings from Gem-hosted boards (`jobs.gem.com`) via the public GraphQL batch endpoint. Two-phase fetch: list query + per-posting detail call for descriptions. No auth required. Opt-in via `config/active_sources.txt` (not auto-enabled).
 
 ## [0.31.0] — 2026-05-27
 

--- a/docs/architecture/file-map.md
+++ b/docs/architecture/file-map.md
@@ -14,7 +14,7 @@ When this map drifts from the actual code (renamed file, new route module, retir
 <repo>/src/findajob/config_seed.py          # seed_runtime_config() — entrypoint-invoked .example→live materialization for configs with hard 500-on-missing paths (#627)
 <repo>/src/findajob/ingest.py               # ingest_manual_job() — shared entry point for the /ingest/ web form
 <repo>/src/findajob/fetchers/                 # Greenhouse, Gmail job fetching; RapidAPI feeds via adapters/
-<repo>/src/findajob/fetchers/adapters/      # JobSourceAdapter Protocol + REGISTERED_ADAPTERS + per-source adapter classes (jobs_api14, jobs_api14_indeed, jobs_api14_bing, jsearch, greenhouse, ashby, lever, gmail, workday_cxs); curation.py = per-adapter signup metadata loaded by /onboarding/feed-config/
+<repo>/src/findajob/fetchers/adapters/      # JobSourceAdapter Protocol + REGISTERED_ADAPTERS + per-source adapter classes (jobs_api14, jobs_api14_indeed, jobs_api14_bing, jsearch, greenhouse, ashby, lever, gmail, workday_cxs, gem); curation.py = per-adapter signup metadata loaded by /onboarding/feed-config/
 <repo>/src/findajob/scoring.py              # score_job(), _build_feedback_block() — calls findajob.llm.openrouter (#470)
 <repo>/src/findajob/scorer_prefilter.py     # deterministic pre-filter (Stage 1 + 2)
 <repo>/src/findajob/llm/openrouter.py       # canonical OpenRouter HTTP wrapper (#470) — complete(), CompletionResult, OpenRouterError; cache_control on cached_prefix + cache_system axes

--- a/src/findajob/fetchers/adapters/gem.py
+++ b/src/findajob/fetchers/adapters/gem.py
@@ -1,0 +1,221 @@
+"""GemAdapter — Gem GraphQL board-feed ingestion (#249)."""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import ClassVar
+
+import requests
+
+from findajob.audit import log_event
+from findajob.cleaning import clean_company, clean_title
+
+from ._slugs import _parse_feed_slugs
+from .base import LiveTestResult, QueryResult
+
+_LIST_QUERY = """\
+query JobBoardList($boardId: String!) {
+  oatsExternalJobPostings(boardId: $boardId) {
+    jobPostings {
+      extId
+      title
+      locations {
+        name
+        city
+        isoCountry
+        isRemote
+      }
+      job {
+        locationType
+        employmentType
+      }
+    }
+  }
+  jobBoardExternal(vanityUrlPath: $boardId) {
+    teamDisplayName
+  }
+}"""
+
+_DETAIL_QUERY = """\
+query ExternalJobPostingQuery($boardId: String!, $extId: String!) {
+  oatsExternalJobPosting(boardId: $boardId, extId: $extId) {
+    title
+    descriptionHtml
+    extId
+    locations {
+      name
+      city
+      isoCountry
+      isRemote
+    }
+    job {
+      locationType
+      employmentType
+      teamDisplayName
+    }
+  }
+}"""
+
+
+class GemAdapter:
+    """Gem board-feed ingestion via public GraphQL batch endpoint.
+
+    Gem is a board-feed source — ``queries`` on fetch() / live_test() is
+    ignored. Slugs are parsed from config/feed_urls.txt; two phases per
+    slug: one list call, then one detail call per posting (description is
+    not on the list response). No auth required.
+    """
+
+    name: ClassVar[str] = "gem"
+    display_name: ClassVar[str] = "Gem boards"
+    source_label: ClassVar[str] = "gem_graphql"
+    required_env_vars: ClassVar[tuple[str, ...]] = ()
+
+    _SLUG_RE: ClassVar[re.Pattern] = re.compile(r"jobs\.gem\.com/([A-Za-z0-9_.-]+)")
+    _ENDPOINT: ClassVar[str] = "https://jobs.gem.com/api/public/graphql/batch"
+    _JOB_URL_TEMPLATE: ClassVar[str] = "https://jobs.gem.com/{slug}/{ext_id}"
+    _PER_BOARD_CAP: ClassVar[int] = 500
+    _UA: ClassVar[str] = "findajob-pipeline/1.0 (personal job search tool)"
+
+    def __init__(self, feed_urls_path: str | None = None) -> None:
+        if feed_urls_path is None:
+            from findajob.paths import BASE
+
+            feed_urls_path = f"{BASE}/config/feed_urls.txt"
+        self._feed_urls_path = feed_urls_path
+
+    def _parse_feeds(self) -> list[tuple[str, str]]:
+        return _parse_feed_slugs(self._feed_urls_path, self._SLUG_RE)
+
+    def is_configured(self) -> bool:
+        return bool(self._parse_feeds())
+
+    def _graphql(self, operation: str, query: str, variables: dict, timeout: int = 15) -> dict | None:
+        payload = [{"operationName": operation, "variables": variables, "query": query}]
+        headers = {"Content-Type": "application/json", "User-Agent": self._UA}
+        try:
+            resp = requests.post(self._ENDPOINT, json=payload, headers=headers, timeout=timeout)
+        except Exception as e:  # noqa: BLE001
+            log_event("gem_graphql_error", operation=operation, error=str(e))
+            return None
+        if resp.status_code != 200:
+            log_event("gem_graphql_skip", operation=operation, status=resp.status_code)
+            return None
+        try:
+            batch = resp.json()
+        except ValueError:
+            log_event("gem_graphql_invalid_json", operation=operation)
+            return None
+        if not isinstance(batch, list) or not batch:
+            return None
+        item = batch[0]
+        if "errors" in item and not item.get("data"):
+            log_event("gem_graphql_errors", operation=operation, errors=str(item["errors"][:1]))
+            return None
+        return item.get("data")
+
+    def fetch(self, queries: list[str]) -> list[dict]:
+        del queries
+        jobs: list[dict] = []
+        for slug, display_name in self._parse_feeds():
+            jobs.extend(self._fetch_board(slug, display_name))
+        return jobs
+
+    def _fetch_board(self, slug: str, display_name_override: str) -> list[dict]:
+        data = self._graphql("JobBoardList", _LIST_QUERY, {"boardId": slug}, timeout=30)
+        if data is None:
+            return []
+
+        postings = (data.get("oatsExternalJobPostings") or {}).get("jobPostings") or []
+        api_company = (data.get("jobBoardExternal") or {}).get("teamDisplayName") or ""
+        has_explicit_override = display_name_override != slug.title()
+        company = clean_company(
+            display_name_override if has_explicit_override else (api_company or display_name_override)
+        )
+
+        rows: list[dict] = []
+        for posting in postings[: self._PER_BOARD_CAP]:
+            ext_id = posting.get("extId", "")
+            if not ext_id:
+                continue
+
+            detail_data = self._graphql(
+                "ExternalJobPostingQuery",
+                _DETAIL_QUERY,
+                {"boardId": slug, "extId": ext_id},
+            )
+            detail = (detail_data or {}).get("oatsExternalJobPosting") or {}
+
+            location = self._extract_location(detail.get("locations") or posting.get("locations") or [])
+
+            rows.append(
+                {
+                    "title": clean_title(detail.get("title") or posting.get("title", "")),
+                    "company": company,
+                    "url": self._JOB_URL_TEMPLATE.format(slug=slug, ext_id=ext_id),
+                    "location": location,
+                    "source": self.source_label,
+                    "description": detail.get("descriptionHtml", ""),
+                }
+            )
+            time.sleep(0.5)
+
+        log_event("gem_fetch", slug=slug, count=len(rows))
+        return rows
+
+    @staticmethod
+    def _extract_location(locations: list[dict]) -> str:
+        if not locations:
+            return ""
+        loc = locations[0]
+        if loc.get("isRemote"):
+            return "Remote"
+        parts = [loc.get("city", ""), loc.get("name", "")]
+        return next((p for p in parts if p), "")
+
+    def live_test(self, queries: list[str]) -> LiveTestResult:
+        del queries
+        feeds = self._parse_feeds()
+        if not feeds:
+            return LiveTestResult(
+                ok=False,
+                bucket="auth",
+                per_query=[],
+                auth_error="No Gem URLs configured in feed_urls.txt.",
+            )
+        slug, _display_name = feeds[0]
+        payload = [{"operationName": "JobBoardList", "variables": {"boardId": slug}, "query": _LIST_QUERY}]
+        headers = {"Content-Type": "application/json", "User-Agent": self._UA}
+        try:
+            resp = requests.post(self._ENDPOINT, json=payload, headers=headers, timeout=15)
+        except requests.RequestException as e:
+            return LiveTestResult(ok=False, bucket="network", per_query=[], auth_error=str(e))
+        if resp.status_code != 200:
+            return LiveTestResult(
+                ok=False,
+                bucket="server",
+                per_query=[],
+                auth_error=f"HTTP {resp.status_code}: server error.",
+            )
+        try:
+            batch = resp.json()
+        except ValueError:
+            return LiveTestResult(ok=False, bucket="server", per_query=[], auth_error="Invalid JSON response.")
+        if not isinstance(batch, list) or not batch:
+            return LiveTestResult(ok=False, bucket="server", per_query=[], auth_error="Unexpected response shape.")
+        item = batch[0]
+        if "errors" in item and not item.get("data"):
+            return LiveTestResult(
+                ok=False,
+                bucket="server",
+                per_query=[],
+                auth_error="GraphQL request returned errors.",
+            )
+        data = item.get("data") or {}
+        postings = (data.get("oatsExternalJobPostings") or {}).get("jobPostings") or []
+        count = len(postings)
+        per_query = [QueryResult(query=slug, count=count)]
+        if count > 0:
+            return LiveTestResult(ok=True, bucket="success", per_query=per_query, auth_error=None)
+        return LiveTestResult(ok=True, bucket="zero_rows", per_query=per_query, auth_error=None)

--- a/src/findajob/fetchers/adapters/registry.py
+++ b/src/findajob/fetchers/adapters/registry.py
@@ -11,6 +11,7 @@ from findajob.paths import BASE
 from .algora_bounties import AlgoraBountiesAdapter
 from .ashby import AshbyAdapter
 from .base import JobSourceAdapter
+from .gem import GemAdapter
 from .gmail import GmailLinkedInAdapter
 from .greenhouse import GreenhouseAdapter
 from .himalayas import HimalayasAdapter
@@ -43,6 +44,7 @@ REGISTERED_ADAPTERS: list[type[JobSourceAdapter]] = [
     JobicyAdapter,  # type: ignore[list-item]  # #853 — opt-in, not auto-enabled
     AlgoraBountiesAdapter,  # type: ignore[list-item]  # #853 Phase 3 — opt-in
     HNFirebaseAdapter,  # type: ignore[list-item]  # #853 Phase 3 — opt-in
+    GemAdapter,  # type: ignore[list-item]  # #249 — opt-in, not auto-enabled
 ]
 
 # Default when config/active_sources.txt is missing or empty: every adapter

--- a/tests/test_gem_adapter.py
+++ b/tests/test_gem_adapter.py
@@ -1,0 +1,295 @@
+"""Unit tests for GemAdapter (#249)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from findajob.fetchers.adapters.gem import GemAdapter
+
+
+@pytest.fixture
+def feed_urls(tmp_path: Path):
+    def _write(urls: list[str]) -> str:
+        p = tmp_path / "feed_urls.txt"
+        p.write_text("\n".join(urls) + "\n")
+        return str(p)
+
+    return _write
+
+
+def _batch_response(data: dict) -> MagicMock:
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = [{"data": data}]
+    return resp
+
+
+def _error_response() -> MagicMock:
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = [{"errors": [{"message": "Something went wrong."}]}]
+    return resp
+
+
+# ───────────────────── is_configured ─────────────────────
+
+
+def test_is_configured_true_when_gem_url_present(feed_urls) -> None:
+    adapter = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/groq"]))
+    assert adapter.is_configured() is True
+
+
+def test_is_configured_false_when_no_gem_url(feed_urls) -> None:
+    adapter = GemAdapter(feed_urls_path=feed_urls(["https://boards.greenhouse.io/anthropic"]))
+    assert adapter.is_configured() is False
+
+
+def test_is_configured_false_when_file_missing(tmp_path: Path) -> None:
+    assert GemAdapter(feed_urls_path=str(tmp_path / "nope.txt")).is_configured() is False
+
+
+# ───────────────────── fetch() ─────────────────────
+
+
+def test_fetch_returns_normalized_rows(feed_urls) -> None:
+    list_data = {
+        "oatsExternalJobPostings": {
+            "jobPostings": [
+                {
+                    "extId": "abc123",
+                    "title": "Software Engineer",
+                    "locations": [
+                        {"name": "San Francisco, CA", "city": "San Francisco", "isoCountry": "US", "isRemote": False},
+                    ],
+                    "job": {"locationType": "IN_PERSON", "employmentType": "FULL_TIME"},
+                }
+            ]
+        },
+        "jobBoardExternal": {"teamDisplayName": "Groq"},
+    }
+    detail_data = {
+        "oatsExternalJobPosting": {
+            "title": "Software Engineer",
+            "descriptionHtml": "<p>Join us.</p>",
+            "extId": "abc123",
+            "locations": [
+                {"name": "San Francisco, CA", "city": "San Francisco", "isoCountry": "US", "isRemote": False},
+            ],
+            "job": {"locationType": "IN_PERSON", "employmentType": "FULL_TIME", "teamDisplayName": "Groq"},
+        }
+    }
+
+    responses = [_batch_response(list_data), _batch_response(detail_data)]
+    with patch("findajob.fetchers.adapters.gem.requests.post", side_effect=responses):
+        rows = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/groq  # Groq"])).fetch([])
+
+    assert len(rows) == 1
+    assert rows[0]["source"] == "gem_graphql"
+    assert rows[0]["title"] == "Software Engineer"
+    assert rows[0]["company"] == "Groq"
+    assert rows[0]["url"] == "https://jobs.gem.com/groq/abc123"
+    assert rows[0]["location"] == "San Francisco"
+    assert "<p>" in rows[0]["description"]
+
+
+def test_fetch_uses_api_company_when_no_inline_comment(feed_urls) -> None:
+    list_data = {
+        "oatsExternalJobPostings": {
+            "jobPostings": [
+                {
+                    "extId": "xyz",
+                    "title": "Engineer",
+                    "locations": [],
+                    "job": {"locationType": "REMOTE", "employmentType": "FULL_TIME"},
+                }
+            ]
+        },
+        "jobBoardExternal": {"teamDisplayName": "Groq"},
+    }
+    detail_data = {
+        "oatsExternalJobPosting": {
+            "title": "Engineer",
+            "descriptionHtml": "",
+            "extId": "xyz",
+            "locations": [],
+            "job": {"locationType": "REMOTE", "employmentType": "FULL_TIME", "teamDisplayName": "Groq"},
+        }
+    }
+
+    responses = [_batch_response(list_data), _batch_response(detail_data)]
+    with patch("findajob.fetchers.adapters.gem.requests.post", side_effect=responses):
+        rows = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/groq"])).fetch([])
+
+    assert rows[0]["company"] == "Groq"
+
+
+def test_fetch_inline_comment_overrides_api_company(feed_urls) -> None:
+    list_data = {
+        "oatsExternalJobPostings": {
+            "jobPostings": [
+                {
+                    "extId": "xyz",
+                    "title": "Engineer",
+                    "locations": [],
+                    "job": {"locationType": "REMOTE", "employmentType": "FULL_TIME"},
+                }
+            ]
+        },
+        "jobBoardExternal": {"teamDisplayName": "Groq Inc"},
+    }
+    detail_data = {
+        "oatsExternalJobPosting": {
+            "title": "Engineer",
+            "descriptionHtml": "",
+            "extId": "xyz",
+            "locations": [],
+            "job": {"locationType": "REMOTE", "employmentType": "FULL_TIME", "teamDisplayName": "Groq Inc"},
+        }
+    }
+
+    responses = [_batch_response(list_data), _batch_response(detail_data)]
+    with patch("findajob.fetchers.adapters.gem.requests.post", side_effect=responses):
+        rows = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/groq-ai  # Groq"])).fetch([])
+
+    assert rows[0]["company"] == "Groq"
+
+
+def test_fetch_remote_location(feed_urls) -> None:
+    list_data = {
+        "oatsExternalJobPostings": {
+            "jobPostings": [
+                {
+                    "extId": "r1",
+                    "title": "Engineer",
+                    "locations": [{"name": "United States", "city": "", "isoCountry": None, "isRemote": True}],
+                    "job": {"locationType": "REMOTE", "employmentType": "FULL_TIME"},
+                }
+            ]
+        },
+        "jobBoardExternal": {"teamDisplayName": "Acme"},
+    }
+    detail_data = {
+        "oatsExternalJobPosting": {
+            "title": "Engineer",
+            "descriptionHtml": "<p>Remote role.</p>",
+            "extId": "r1",
+            "locations": [{"name": "United States", "city": "", "isoCountry": None, "isRemote": True}],
+            "job": {"locationType": "REMOTE", "employmentType": "FULL_TIME", "teamDisplayName": "Acme"},
+        }
+    }
+
+    responses = [_batch_response(list_data), _batch_response(detail_data)]
+    with patch("findajob.fetchers.adapters.gem.requests.post", side_effect=responses):
+        rows = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme  # Acme"])).fetch([])
+
+    assert rows[0]["location"] == "Remote"
+
+
+def test_fetch_skips_posting_without_ext_id(feed_urls) -> None:
+    list_data = {
+        "oatsExternalJobPostings": {
+            "jobPostings": [
+                {
+                    "extId": "",
+                    "title": "Ghost Posting",
+                    "locations": [],
+                    "job": {"locationType": "IN_PERSON", "employmentType": "FULL_TIME"},
+                }
+            ]
+        },
+        "jobBoardExternal": {"teamDisplayName": "Acme"},
+    }
+
+    with patch("findajob.fetchers.adapters.gem.requests.post", return_value=_batch_response(list_data)):
+        rows = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme"])).fetch([])
+
+    assert rows == []
+
+
+def test_fetch_survives_detail_failure(feed_urls) -> None:
+    list_data = {
+        "oatsExternalJobPostings": {
+            "jobPostings": [
+                {
+                    "extId": "abc",
+                    "title": "Engineer",
+                    "locations": [{"name": "NYC", "city": "New York", "isoCountry": "US", "isRemote": False}],
+                    "job": {"locationType": "IN_PERSON", "employmentType": "FULL_TIME"},
+                }
+            ]
+        },
+        "jobBoardExternal": {"teamDisplayName": "Acme"},
+    }
+
+    responses = [_batch_response(list_data), _error_response()]
+    with patch("findajob.fetchers.adapters.gem.requests.post", side_effect=responses):
+        rows = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme  # Acme"])).fetch([])
+
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Engineer"
+    assert rows[0]["description"] == ""
+    assert rows[0]["location"] == "New York"
+
+
+def test_fetch_list_graphql_error_returns_empty(feed_urls) -> None:
+    with patch("findajob.fetchers.adapters.gem.requests.post", return_value=_error_response()):
+        rows = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme"])).fetch([])
+
+    assert rows == []
+
+
+# ───────────────────── live_test() buckets ─────────────────────
+
+
+def test_live_test_success_bucket(feed_urls) -> None:
+    data = {
+        "oatsExternalJobPostings": {"jobPostings": [{"extId": "1"}, {"extId": "2"}]},
+        "jobBoardExternal": {"teamDisplayName": "Acme"},
+    }
+    with patch("findajob.fetchers.adapters.gem.requests.post", return_value=_batch_response(data)):
+        result = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme"])).live_test([])
+
+    assert result.ok is True
+    assert result.bucket == "success"
+    assert result.per_query[0].count == 2
+
+
+def test_live_test_zero_rows_bucket(feed_urls) -> None:
+    data = {
+        "oatsExternalJobPostings": {"jobPostings": []},
+        "jobBoardExternal": {"teamDisplayName": "Acme"},
+    }
+    with patch("findajob.fetchers.adapters.gem.requests.post", return_value=_batch_response(data)):
+        result = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme"])).live_test([])
+
+    assert result.ok is True
+    assert result.bucket == "zero_rows"
+
+
+def test_live_test_server_bucket_on_graphql_error(feed_urls) -> None:
+    with patch("findajob.fetchers.adapters.gem.requests.post", return_value=_error_response()):
+        result = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme"])).live_test([])
+
+    assert result.ok is False
+    assert result.bucket == "server"
+
+
+def test_live_test_network_bucket(feed_urls) -> None:
+    import requests as req
+
+    with patch(
+        "findajob.fetchers.adapters.gem.requests.post",
+        side_effect=req.RequestException("dns fail"),
+    ):
+        result = GemAdapter(feed_urls_path=feed_urls(["https://jobs.gem.com/acme"])).live_test([])
+
+    assert result.ok is False
+    assert result.bucket == "network"
+
+
+def test_live_test_auth_bucket_when_no_slugs_configured(tmp_path: Path) -> None:
+    result = GemAdapter(feed_urls_path=str(tmp_path / "nope.txt")).live_test([])
+    assert result.ok is False
+    assert result.bucket == "auth"
+    assert "No Gem URLs" in (result.auth_error or "")


### PR DESCRIPTION
## Summary

- New `GemAdapter` at `src/findajob/fetchers/adapters/gem.py` implements `JobSourceAdapter` for Gem-hosted job boards (`jobs.gem.com`)
- Uses the public GraphQL batch endpoint (`POST /api/public/graphql/batch`) — no auth required
- Two-phase fetch pattern (like Workday CXS): list query → per-posting detail call for `descriptionHtml`
- Registered in `REGISTERED_ADAPTERS` as opt-in only (not in `_DEFAULT_ACTIVE_SOURCES`)
- 15 unit tests covering `is_configured`, `fetch` normalization, and `live_test` bucket routing

### AC divergences worth noting

- **Pickup trigger:** "Second Tier 1 target migrating to Gem" — satisfied by operator decision to promote to Up Next and pull
- **"HTML description run through pandoc":** Adapter stores raw `descriptionHtml` to match the actual Ashby/Lever/Greenhouse pattern; pandoc conversion runs downstream in the triage pipeline, not in the adapter
- **API schema drift since #199 survey:** Issue body's technical notes reference `JobBoardList` / `ExternalJobPostingQuery` as GraphQL field names, but the live schema uses `oatsExternalJobPostings` / `oatsExternalJobPosting` as the actual query fields (operation names are correct). Probed and verified 2026-05-27 against live Groq board.

Closes #249

## Test plan

- [x] 15 unit tests in `test_gem_adapter.py` — all pass
- [x] Protocol invariant tests pass (conformance, discovery, registry membership)
- [x] Full test suite (3452 tests) passes with zero regressions
- [x] `ruff check` + `ruff format --check` clean
- [ ] Browser verification: N/A — no UI changes; adapter is opt-in and exercises at runtime only when a Gem URL is in `feed_urls.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)