### PR TITLE
feat(spend-ceiling): ntfy alert at 80% and 100% of monthly ceiling (#876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ### Added
 
+- **Spend ceiling ntfy alerts at 80% and 100%** (#876): Both the per-call gate and launch gate now fire ntfy notifications when monthly LLM spend crosses 80% ("approaching ceiling") and 100% ("ceiling reached — calls blocked"). Alerts fire at most once per threshold per calendar month, deduped via in-process cache + `notifications` table query. Notification failure never breaks the safety gate. Two new notification kinds: `spend_ceiling_warning`, `spend_ceiling_reached`.
 - **Auto-derive `FINDAJOB_WEB_URL` from Fly runtime env** (#881): On Fly.io, `FINDAJOB_WEB_URL` is now auto-derived from the `FLY_APP_NAME` env var (set by Fly at runtime) when not explicitly configured. Eliminates 1 required secret from Fly deploys. Fallback chain: `data/.env` → `FINDAJOB_WEB_URL` env → `https://{FLY_APP_NAME}.fly.dev` → `http://localhost:8090`. `fly-deploy.sh` now marks `FINDAJOB_WEB_URL` as optional (skippable).
 - **Root-level `fly.toml` for web deploy** (#881): Tracked `fly.toml` at repo root enables the Fly.io "Launch from GitHub" web flow with default config path `./`. CLI users continue using `ops/fly.toml.example` → `ops/fly.toml` unchanged.
 - **Gem GraphQL adapter** (#249): New `GemAdapter` fetches job postings from Gem-hosted boards (`jobs.gem.com`) via the public GraphQL batch endpoint. Two-phase fetch: list query + per-posting detail call for descriptions. No auth required. Opt-in via `config/active_sources.txt` (not auto-enabled).

--- a/src/findajob/notifications/ntfy.py
+++ b/src/findajob/notifications/ntfy.py
@@ -78,6 +78,8 @@ NOTIFICATION_KINDS: tuple[str, ...] = (
     "podcast_failed",
     "recall_audit_alert",
     "drift_alert",
+    "spend_ceiling_warning",
+    "spend_ceiling_reached",
 )
 
 

--- a/src/findajob/spend_ceiling.py
+++ b/src/findajob/spend_ceiling.py
@@ -13,20 +13,29 @@ Two surfaces:
   dataclass if the ceiling is exceeded, or ``None`` if OK. Takes a caller-
   supplied ``sqlite3.Connection`` so it participates in the route's existing
   DB session.
+
+Both gates fire threshold alerts (#876) at 80% and 100% of the ceiling via
+:func:`_maybe_fire_threshold_alerts`. Alerts fire at most once per threshold
+per calendar month (deduped via in-process set + ``notifications`` table).
 """
 
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from findajob.config_loader import load_spend_ceiling
 from findajob.cost_rollups import spend_this_month
 from findajob.db import connect
 from findajob.llm.openrouter import LLMSpendCeilingExceeded
 from findajob.paths import BASE
+
+log = logging.getLogger(__name__)
 
 
 def _stack_tz() -> str:
@@ -36,6 +45,10 @@ def _stack_tz() -> str:
 
 _DB_PATH = Path(BASE) / "data" / "pipeline.db"
 
+_alerts_fired: set[str] = set()
+
+_WARNING_THRESHOLD = 0.80
+
 
 @dataclass(frozen=True)
 class LaunchGateRefusal:
@@ -43,6 +56,90 @@ class LaunchGateRefusal:
 
     ceiling_usd: float
     current_sum_usd: float
+
+
+def _month_key(tz: str) -> str:
+    """Return ``YYYY-MM`` in the stack's local timezone."""
+    return datetime.now(ZoneInfo(tz)).strftime("%Y-%m")
+
+
+def _already_sent_this_month(kind: str, month: str, conn: sqlite3.Connection) -> bool:
+    """Check whether a notification of *kind* was already persisted this month.
+
+    ``notifications.sent_at`` is UTC (``datetime('now')``). We need the
+    TZ-aware month boundaries to match ``spend_this_month()``'s reset.
+    """
+    tz = _stack_tz()
+    zi = ZoneInfo(tz)
+    year, mon = int(month[:4]), int(month[5:7])
+    start_local = datetime(year, mon, 1, tzinfo=zi)
+    if mon == 12:
+        end_local = datetime(year + 1, 1, 1, tzinfo=zi)
+    else:
+        end_local = datetime(year, mon + 1, 1, tzinfo=zi)
+    start_utc = start_local.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M:%S")
+    end_utc = end_local.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M:%S")
+    row = conn.execute(
+        "SELECT 1 FROM notifications WHERE kind = ? AND sent_at >= ? AND sent_at < ? LIMIT 1",
+        (kind, start_utc, end_utc),
+    ).fetchone()
+    return row is not None
+
+
+def _maybe_fire_threshold_alerts(current: float, ceiling: float, conn: sqlite3.Connection) -> None:
+    """Fire ntfy alerts at 80% and 100% of the monthly ceiling.
+
+    Observability, not safety — wrapped in try/except so a notification
+    failure never prevents the gate from enforcing.
+    """
+    try:
+        month = _month_key(_stack_tz())
+        thresholds: list[tuple[str, float, str, str, str]] = []
+
+        if current >= ceiling:
+            thresholds.append(
+                (
+                    "spend_ceiling_reached",
+                    ceiling,
+                    f"Spend ceiling reached: ${current:.2f} / ${ceiling:.2f}",
+                    f"Monthly LLM spend has hit the ceiling (${current:.2f} / ${ceiling:.2f}). "
+                    "LLM calls are blocked until the ceiling is raised or the month resets.",
+                    "urgent",
+                )
+            )
+
+        if current >= ceiling * _WARNING_THRESHOLD:
+            thresholds.append(
+                (
+                    "spend_ceiling_warning",
+                    ceiling * _WARNING_THRESHOLD,
+                    f"Approaching spend ceiling: ${current:.2f} / ${ceiling:.2f}",
+                    f"Monthly LLM spend is at {current / ceiling:.0%} of the ceiling "
+                    f"(${current:.2f} / ${ceiling:.2f}).",
+                    "high",
+                )
+            )
+
+        for kind, _thresh, title, body, priority in thresholds:
+            cache_key = f"{kind}:{month}"
+            if cache_key in _alerts_fired:
+                continue
+            if _already_sent_this_month(kind, month, conn):
+                _alerts_fired.add(cache_key)
+                continue
+            from findajob.notifications.ntfy import send
+
+            send(
+                title=title,
+                body=body,
+                priority=priority,
+                tags="warning" if kind == "spend_ceiling_warning" else "rotating_light",
+                kind=kind,
+                cta_url=None,
+            )
+            _alerts_fired.add(cache_key)
+    except Exception:
+        log.exception("spend-ceiling alert failed (non-fatal)")
 
 
 def check_call_gate() -> None:
@@ -61,6 +158,7 @@ def check_call_gate() -> None:
     conn = connect(_DB_PATH)
     try:
         current = spend_this_month(conn, tz=_stack_tz())
+        _maybe_fire_threshold_alerts(current, ceiling, conn)
     finally:
         conn.close()
 
@@ -79,6 +177,7 @@ def check_launch_gate(conn: sqlite3.Connection) -> LaunchGateRefusal | None:
         return None
 
     current = spend_this_month(conn, tz=_stack_tz())
+    _maybe_fire_threshold_alerts(current, ceiling, conn)
     if current >= ceiling:
         return LaunchGateRefusal(ceiling_usd=ceiling, current_sum_usd=current)
 

--- a/src/findajob/web/routes/notifications.py
+++ b/src/findajob/web/routes/notifications.py
@@ -46,6 +46,8 @@ _KIND_LABELS: dict[str, str] = {
     "prep_failure": "Prep failed",
     "interview_prep_ready": "Interview prep ready",
     "interview_prep_failed": "Interview prep failed",
+    "spend_ceiling_warning": "Spend warning",
+    "spend_ceiling_reached": "Spend ceiling hit",
 }
 
 

--- a/src/findajob/web/templates/notifications/_row.html
+++ b/src/findajob/web/templates/notifications/_row.html
@@ -15,6 +15,8 @@
   "prep_failure": "bg-red-200 text-red-900 border-red-400",
   "interview_prep_ready": "bg-cyan-100 text-cyan-800 border-cyan-300",
   "interview_prep_failed": "bg-orange-100 text-orange-800 border-orange-300",
+  "spend_ceiling_warning": "bg-yellow-100 text-yellow-800 border-yellow-300",
+  "spend_ceiling_reached": "bg-red-200 text-red-900 border-red-400",
 } %}
 {% set kind_class = kind_color_map.get(item.kind, "bg-slate-100 text-slate-800 border-slate-300") %}
 {% set is_unread = item.read_at is none %}

--- a/tests/test_spend_ceiling_alerts.py
+++ b/tests/test_spend_ceiling_alerts.py
@@ -1,0 +1,257 @@
+"""Tests for spend-ceiling threshold alerts (#876).
+
+Exercises :func:`_maybe_fire_threshold_alerts` via both gates
+(``check_call_gate`` and ``check_launch_gate``), verifying:
+
+- 80% warning fires, 100% reached fires
+- Same-month dedup (in-process set + DB row)
+- Ceiling disabled → no notifications
+- Notification send failure doesn't break the gate
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from findajob import config_loader, spend_ceiling
+from findajob.llm.openrouter import LLMSpendCeilingExceeded
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _build_db(db_path: Path) -> sqlite3.Connection:
+    from findajob.db.migrate import apply_pending
+
+    conn = sqlite3.connect(str(db_path))
+    apply_pending(conn)
+    return conn
+
+
+def _insert_cost_row(conn: sqlite3.Connection, *, cost_usd: float, logged_at: str) -> None:
+    conn.execute(
+        "INSERT INTO cost_log (operation, model, cost_usd, logged_at) VALUES (?, ?, ?, ?)",
+        ("test_op", "test-model", cost_usd, logged_at),
+    )
+    conn.commit()
+
+
+def _this_month_ts() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+
+@pytest.fixture(autouse=True)
+def _clear_alerts_cache():
+    """Reset the module-level dedup set between tests."""
+    spend_ceiling._alerts_fired.clear()
+    yield
+    spend_ceiling._alerts_fired.clear()
+
+
+@pytest.fixture()
+def ceiling_db(tmp_path, monkeypatch):
+    """Provide a real DB + ceiling config wired into spend_ceiling."""
+    ceiling_path = tmp_path / "spend_ceiling.txt"
+    ceiling_path.write_text("100.00")
+    monkeypatch.setattr(config_loader, "_SPEND_CEILING_PATH", ceiling_path)
+    config_loader._reset_cache()
+
+    db_path = tmp_path / "pipeline.db"
+    conn = _build_db(db_path)
+    monkeypatch.setattr("findajob.spend_ceiling._DB_PATH", db_path)
+
+    yield conn, ceiling_path, db_path
+    conn.close()
+    config_loader._reset_cache()
+
+
+# ── threshold alert tests (unit) ────────────────────────────────────────────
+
+
+class TestWarningAt80Percent:
+    def test_fires_at_80_percent(self, ceiling_db):
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=80.00, logged_at=_this_month_ts())
+
+        alert_conn = sqlite3.connect(str(db_path))
+        _build_db(db_path)  # ensure schema exists on this connection
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling._maybe_fire_threshold_alerts(80.0, 100.0, alert_conn)
+
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args
+        assert call_kwargs.kwargs["kind"] == "spend_ceiling_warning"
+        assert "$80.00" in call_kwargs.kwargs["title"]
+        assert "$100.00" in call_kwargs.kwargs["title"]
+        alert_conn.close()
+
+    def test_no_warning_below_80_percent(self, ceiling_db):
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=79.00, logged_at=_this_month_ts())
+
+        alert_conn = sqlite3.connect(str(db_path))
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling._maybe_fire_threshold_alerts(79.0, 100.0, alert_conn)
+
+        mock_send.assert_not_called()
+        alert_conn.close()
+
+
+class TestReachedAt100Percent:
+    def test_fires_at_100_percent(self, ceiling_db):
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=100.00, logged_at=_this_month_ts())
+
+        alert_conn = sqlite3.connect(str(db_path))
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling._maybe_fire_threshold_alerts(100.0, 100.0, alert_conn)
+
+        kinds_sent = [c.kwargs["kind"] for c in mock_send.call_args_list]
+        assert "spend_ceiling_reached" in kinds_sent
+        assert "spend_ceiling_warning" in kinds_sent
+        alert_conn.close()
+
+    def test_reached_body_mentions_blocked(self, ceiling_db):
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=105.00, logged_at=_this_month_ts())
+
+        alert_conn = sqlite3.connect(str(db_path))
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling._maybe_fire_threshold_alerts(105.0, 100.0, alert_conn)
+
+        reached_calls = [c for c in mock_send.call_args_list if c.kwargs["kind"] == "spend_ceiling_reached"]
+        assert len(reached_calls) == 1
+        assert "blocked" in reached_calls[0].kwargs["body"]
+        alert_conn.close()
+
+
+class TestSameMonthDedup:
+    def test_in_process_dedup(self, ceiling_db):
+        """Second call in same process doesn't re-send."""
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=85.00, logged_at=_this_month_ts())
+
+        alert_conn = sqlite3.connect(str(db_path))
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling._maybe_fire_threshold_alerts(85.0, 100.0, alert_conn)
+            spend_ceiling._maybe_fire_threshold_alerts(85.0, 100.0, alert_conn)
+
+        assert mock_send.call_count == 1
+        alert_conn.close()
+
+    def test_cross_process_dedup_via_db(self, ceiling_db):
+        """If a notification row already exists in the DB, skip even with cleared cache."""
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=85.00, logged_at=_this_month_ts())
+
+        conn.execute(
+            "INSERT INTO notifications (kind, title, body, priority, delivery_status) VALUES (?, ?, ?, ?, ?)",
+            ("spend_ceiling_warning", "test", "test", "high", "sent"),
+        )
+        conn.commit()
+
+        alert_conn = sqlite3.connect(str(db_path))
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling._maybe_fire_threshold_alerts(85.0, 100.0, alert_conn)
+
+        mock_send.assert_not_called()
+        alert_conn.close()
+
+
+class TestCeilingDisabled:
+    def test_no_alerts_when_ceiling_none(self, tmp_path, monkeypatch):
+        """When ceiling is disabled, gates are no-op and no alerts fire."""
+        monkeypatch.setattr(config_loader, "_SPEND_CEILING_PATH", tmp_path / "nonexistent.txt")
+        config_loader._reset_cache()
+
+        db_path = tmp_path / "pipeline.db"
+        conn = _build_db(db_path)
+        _insert_cost_row(conn, cost_usd=999.00, logged_at=_this_month_ts())
+        monkeypatch.setattr("findajob.spend_ceiling._DB_PATH", db_path)
+
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling.check_call_gate()
+
+        mock_send.assert_not_called()
+        conn.close()
+        config_loader._reset_cache()
+
+
+class TestNotificationFailureDoesNotBreakGate:
+    def test_send_raises_gate_still_enforces(self, ceiling_db, monkeypatch):
+        """If notification send() raises, the gate must still block."""
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=100.00, logged_at=_this_month_ts())
+        monkeypatch.setattr("findajob.spend_ceiling._DB_PATH", db_path)
+
+        with patch("findajob.notifications.ntfy.send", side_effect=RuntimeError("ntfy down")):
+            with pytest.raises(LLMSpendCeilingExceeded):
+                spend_ceiling.check_call_gate()
+
+    def test_send_raises_launch_gate_still_refuses(self, ceiling_db):
+        """If notification send() raises, launch gate still returns refusal."""
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=100.00, logged_at=_this_month_ts())
+
+        with patch("findajob.notifications.ntfy.send", side_effect=RuntimeError("ntfy down")):
+            result = spend_ceiling.check_launch_gate(conn)
+
+        assert result is not None
+        assert result.ceiling_usd == 100.0
+
+
+# ── integration via check_call_gate / check_launch_gate ──────────────────────
+
+
+class TestCallGateFiresAlerts:
+    def test_warning_fires_through_call_gate(self, ceiling_db, monkeypatch):
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=85.00, logged_at=_this_month_ts())
+        monkeypatch.setattr("findajob.spend_ceiling._DB_PATH", db_path)
+
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            spend_ceiling.check_call_gate()
+
+        assert mock_send.call_count == 1
+        assert mock_send.call_args.kwargs["kind"] == "spend_ceiling_warning"
+
+    def test_reached_fires_then_raises(self, ceiling_db, monkeypatch):
+        conn, _, db_path = ceiling_db
+        _insert_cost_row(conn, cost_usd=100.00, logged_at=_this_month_ts())
+        monkeypatch.setattr("findajob.spend_ceiling._DB_PATH", db_path)
+
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            with pytest.raises(LLMSpendCeilingExceeded):
+                spend_ceiling.check_call_gate()
+
+        kinds_sent = [c.kwargs["kind"] for c in mock_send.call_args_list]
+        assert "spend_ceiling_reached" in kinds_sent
+
+
+class TestLaunchGateFiresAlerts:
+    def test_warning_fires_through_launch_gate(self, ceiling_db):
+        conn, _, _ = ceiling_db
+        _insert_cost_row(conn, cost_usd=85.00, logged_at=_this_month_ts())
+
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            result = spend_ceiling.check_launch_gate(conn)
+
+        assert result is None
+        assert mock_send.call_count == 1
+        assert mock_send.call_args.kwargs["kind"] == "spend_ceiling_warning"
+
+    def test_reached_fires_and_returns_refusal(self, ceiling_db):
+        conn, _, _ = ceiling_db
+        _insert_cost_row(conn, cost_usd=100.00, logged_at=_this_month_ts())
+
+        with patch("findajob.notifications.ntfy.send") as mock_send:
+            result = spend_ceiling.check_launch_gate(conn)
+
+        assert result is not None
+        assert result.ceiling_usd == 100.0
+        kinds_sent = [c.kwargs["kind"] for c in mock_send.call_args_list]
+        assert "spend_ceiling_reached" in kinds_sent


### PR DESCRIPTION
## Summary

- ntfy notifications fire at 80% ("approaching ceiling") and 100% ("ceiling reached — calls blocked") of the monthly spend ceiling
- Hooks into **both** enforcement gates (per-call in `openrouter.complete()` + launch gate in route handlers) so no threshold crossing goes unnoticed
- Two-tier dedup: module-level set (zero overhead after first check per process) + `notifications` table query (survives container restarts) — at most one alert per threshold per calendar month
- Notification failure is wrapped in try/except — observability never breaks the safety gate

## Files changed

| File | Change |
|------|--------|
| `src/findajob/spend_ceiling.py` | `_maybe_fire_threshold_alerts()` helper + hooks in both gates |
| `src/findajob/notifications/ntfy.py` | 2 new kinds: `spend_ceiling_warning`, `spend_ceiling_reached` |
| `src/findajob/web/routes/notifications.py` | Kind labels for notification dashboard |
| `src/findajob/web/templates/notifications/_row.html` | Color badges (yellow warning, red reached) |
| `tests/test_spend_ceiling_alerts.py` | 13 tests: thresholds, dedup, disabled ceiling, send failure resilience |
| `CHANGELOG.md` | Entry under [Unreleased] |

## Test plan

- [x] 80% warning fires at threshold (unit)
- [x] No warning below 80% (unit)
- [x] 100% reached fires + warning fires together (unit)
- [x] Reached body mentions "blocked" (unit)
- [x] In-process dedup — second call doesn't re-send (unit)
- [x] Cross-process dedup — existing DB row prevents re-send (unit)
- [x] Ceiling disabled → no alerts (unit)
- [x] `send()` raises → call gate still raises `LLMSpendCeilingExceeded` (unit)
- [x] `send()` raises → launch gate still returns `LaunchGateRefusal` (unit)
- [x] Warning fires through `check_call_gate()` integration path (integration)
- [x] Reached fires then raises through `check_call_gate()` (integration)
- [x] Warning fires through `check_launch_gate()` (integration)
- [x] Reached fires and returns refusal through `check_launch_gate()` (integration)
- [x] Existing spend ceiling tests pass (6/6 regression)
- [ ] Browser: cannot verify notification dashboard rendering without dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)