### PR TITLE
docs(v2 P1.2): PII review pass across all tracked docs and templates (#902)

### DIFF
--- a/src/findajob/web/templates/ingest/form.html
+++ b/src/findajob/web/templates/ingest/form.html
@@ -126,7 +126,7 @@
     </label>
     <label class="block">
       <span class="text-sm font-medium text-slate-700">Hint (optional)</span>
-      <input type="text" name="hint" placeholder="data center team / ML platform org / …" autocomplete="off"
+      <input type="text" name="hint" placeholder="a specific team, office, or function …" autocomplete="off"
              class="mt-1 block w-full rounded border-slate-300 shadow-sm focus:border-slate-500 focus:ring-slate-500 text-sm">
       <span class="text-xs text-slate-500 mt-1 block">Helps focus the research on a specific function/team.</span>
     </label>

--- a/src/findajob/web/templates/materials/folder.html
+++ b/src/findajob/web/templates/materials/folder.html
@@ -325,7 +325,7 @@
           {% endif %}
           {# Primary action — View for .md/.txt (server-rendered HTML), Blob-download
              for binaries. Button (not anchor) so there's no native browser default
-             to race against — reverse proxies (Synology, #327) strip
+             to race against — reverse proxies (#327) strip
              Content-Disposition / rewrite Content-Type on docx responses, and any
              native navigation that slips through renders the bytes as text. The JS
              fetch builds a Blob locally and triggers a synthetic <a download> on a


### PR DESCRIPTION
Closes #902. PII review gate for the **Documentation v2** milestone — runs after the structural moves (#901, #903, #904, all merged) and before the Phase 2 rewrite wave.

## Method

Needles were derived from the canonical enforcement layer — the `PATTERNS` array in `.git/hooks/pre-commit` — rather than hand-rolled, so the audit and the hook can't disagree on what counts as PII (53 patterns, matched case-insensitive ERE exactly as the hook applies them). Scope was enumerated with `git ls-files` so completeness is provable, not best-effort. Two classes the name-needles can't catch got dedicated manual passes:

- **Operator topology** — deploy paths, hostnames, ports, consumer-infra brand names, domains.
- **Field-locked content** — hardcoded company lists, single-industry vocabulary, examples assuming a specific career field.

## Audit checklist (pass/fail per bucket)

| Bucket | Files | Result |
|---|---|---|
| `docs/**/*.md` | 26 | ✅ pass |
| `src/findajob/web/templates/**/*.html` | 102 | ⚠️ 1 fixed → ✅ |
| `config/tool_prompts/*.md` | 3 | ✅ pass |
| `README.md` | 1 | ✅ pass |
| `CONTRIBUTING.md` | 1 | ✅ pass |
| `CLAUDE.md`, `CHANGELOG.md` (bonus — see scope note) | 2 | ✅ pass |
| **Total** | **133** | **2 findings, both fixed** |

### Findings (both fixed in this PR)

1. **`templates/materials/folder.html`** — a developer comment named a specific consumer-infra (reverse-proxy) product, which is operator-topology per the generalization rules. Removed; the surrounding `#327` issue reference and the technical explanation are retained. *Note: the string already existed in `main`'s HEAD and history, so this is a scrub-forward — the removal adds no new exposure.*
2. **`templates/ingest/form.html`** — the ingest "Hint" field placeholder used examples locked to one industry. Neutralized to a field-agnostic example, since the tool serves job-seekers across fields.

### Verified clean (manual passes)

- `/opt/stacks/...` references in install docs all use placeholders (`findajob-<handle>`, `findajob-<you>`) — generalized, install-instruction context.
- No hostnames, per-stack ports, or other infra brands in scope.
- README operator stats are attributed to "the operator" generically — no name, field, or company; reject-reason examples are field-neutral.
- CONTRIBUTING dev-setup uses the public repo clone URL + `uv sync`; no operator-specific environment assumptions.
- Tool prompts contain no field-locked examples or target-company names.

### Scope note

`CLAUDE.md` and `CHANGELOG.md` are tracked but outside #902's declared four buckets. Because #901 absorbed maintainer-doc content into `CLAUDE.md` the same day, I ran the needle pass on both anyway — both clean. They otherwise rely on the pre-commit hook, as designed.

## Unblocks

This gate clears the Phase 2 rewrite issues: **#905, #906, #907, #908, #909, #910, #912, #913**.

## Test plan

- [x] 133-file needle pass: 133/133 clean post-fix
- [x] Manual topology + field-lock passes
- [x] `grep tests/` for the changed placeholder — no test assertions on it
- [x] pre-commit hook clean on commit
- [ ] Browser render of the two templates not exercised — both changes are a Jinja-comment edit and an input `placeholder` attribute; no logic or structure touched.
