### PR TITLE
feat(tools): web view for the recruiter-critique aggregate (#933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **Web view for the recruiter-critique aggregate** (#933): New `/tools/critique-review/` page renders the #265 aggregator output in the browser instead of requiring a CLI run + SSH. Computes the aggregate live on each load (fast — no LLM), and shows source-level fixes as cards (action badge · `file:line` · the source line · the recruiter's verbatim words · distinct-company chips, sorted by recurrence), a capped recurring-themes strip (top 15; the full themes-floor tuning is tracked in #932), and an empty state. Linked from the `/tools/` index. Read-only — unlike the CLI it does not write the dated report file. The page embeds real resume lines but the whole app is auth-gated, consistent with `/materials/`. The CLI and the web view share `default_source_files()` so the anchor labels can't drift between them.
+
 ## [0.31.2] — 2026-05-30
 
 ### Added

--- a/docs/architecture/file-map.md
+++ b/docs/architecture/file-map.md
@@ -50,6 +50,7 @@ When this map drifts from the actual code (renamed file, new route module, retir
 <repo>/src/findajob/onboarding/interview_runner.py # thin shim around `findajob.llm.openrouter`; preserves InterviewRunnerError.user_message contract for chat-UI verbatim render (Sonnet 4.6 pinned, #471)
 <repo>/src/findajob/discoverer/                # company discovery library — prompt, parser, runner, writer
 <repo>/src/findajob/web/routes/healthz.py    # GET /healthz
+<repo>/src/findajob/web/routes/tools_critique.py # GET /tools/critique-review/ — live recruiter-critique aggregate view (#933)
 <repo>/src/findajob/web/routes/materials.py  # GET /materials/ — candidate materials viewer; POST /materials/{fp}/files/{name} — in-browser .md editor w/ .docx auto-regen (#210); uses folder_resolver
 <repo>/src/findajob/web/folder_resolver.py   # stage→filesystem resolver with path-traversal guards
 <repo>/src/findajob/web/templates/           # Jinja2 templates — base.html + one subdir per route group + shared _*.html partials

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,7 +113,13 @@ Individually they're useful; in bulk they reveal something more: the
 which means they live at the **source** (your `master_resume.md`,
 `profile.md`, or the cover/resume role prompts), not in any one prep.
 
-Once you've accumulated ~10+ preps, run the aggregator:
+Once you've accumulated ~10+ preps, the quickest way to see this is the
+**Review recruiter critiques** tile on `/tools/` (or go straight to
+`/tools/critique-review/`) — it computes the aggregate live and renders the
+source-level fixes as cards in the browser, no terminal needed.
+
+For a written report on disk (and the `--since` / `--min-companies` knobs),
+run the CLI:
 
 ```
 python scripts/critique_review.py

--- a/scripts/critique_review.py
+++ b/scripts/critique_review.py
@@ -21,7 +21,7 @@ import argparse
 from datetime import datetime
 from pathlib import Path
 
-from findajob.critique_aggregator.pipeline import aggregate_corpus
+from findajob.critique_aggregator.pipeline import aggregate_corpus, default_source_files
 from findajob.paths import BASE
 
 
@@ -43,15 +43,11 @@ def main() -> int:
 
     base = Path(BASE)
     companies_root = base / "companies"
-    source_files = [
-        (base / "candidate_context" / "master_resume.md", "master_resume.md"),
-        (base / "candidate_context" / "profile.md", "profile.md"),
-    ]
     today = datetime.now().strftime("%Y-%m-%d")
 
     result, report = aggregate_corpus(
         companies_root,
-        source_files,
+        default_source_files(base),
         generated_for=today,
         since=args.since,
         min_companies=args.min_companies,

--- a/src/findajob/critique_aggregator/pipeline.py
+++ b/src/findajob/critique_aggregator/pipeline.py
@@ -27,6 +27,19 @@ def _file_yyyymmdd(path: Path) -> str | None:
     return match.group(1) if match else None
 
 
+def default_source_files(base: Path) -> list[tuple[Path, str]]:
+    """The (path, label) source files to anchor against, under ``base``.
+
+    Shared by the CLI and the /tools/ web view so the anchor labels — which
+    the report keys fixes on — cannot drift between the two entry points.
+    """
+    cc = base / "candidate_context"
+    return [
+        (cc / "master_resume.md", "master_resume.md"),
+        (cc / "profile.md", "profile.md"),
+    ]
+
+
 def aggregate_corpus(
     companies_root: Path,
     source_files: list[tuple[Path, str]],

--- a/src/findajob/critique_aggregator/report.py
+++ b/src/findajob/critique_aggregator/report.py
@@ -19,7 +19,7 @@ _ACTION = {
 }
 
 
-def _representative_sentence(cluster: Cluster) -> str:
+def representative_sentence(cluster: Cluster) -> str:
     """The most informative verbatim recruiter sentence in the cluster."""
     return max((it.recruiter_sentence for it in cluster.items), key=len)
 
@@ -31,9 +31,13 @@ def _dominant_section(cluster: Cluster) -> str:
     return max(counts, key=lambda section: counts[section])
 
 
+def cluster_action(cluster: Cluster) -> str:
+    """The fixed-vocabulary action verb for a cluster's dominant section."""
+    return _ACTION.get(_dominant_section(cluster), "REVIEW")
+
+
 def _render_cluster(cluster: Cluster) -> str:
-    section = _dominant_section(cluster)
-    action = _ACTION.get(section, "REVIEW")
+    action = cluster_action(cluster)
     loc = f"{cluster.anchor.file}:{cluster.anchor.line_no}"
     companies = ", ".join(cluster.companies)
     return "\n".join(
@@ -41,7 +45,7 @@ def _render_cluster(cluster: Cluster) -> str:
             f"### {action}  `{loc}`",
             f"> {cluster.anchor.text}",
             "",
-            f"Recruiter: {_representative_sentence(cluster)}",
+            f"Recruiter: {representative_sentence(cluster)}",
             "",
             f"⤷ flagged by {cluster.company_count} companies: {companies}",
             "",

--- a/src/findajob/web/routes/__init__.py
+++ b/src/findajob/web/routes/__init__.py
@@ -33,6 +33,7 @@ from findajob.web.routes import (
     stats,
     tools,
     tools_actions,
+    tools_critique,
     tools_logs,
 )
 
@@ -67,6 +68,7 @@ router.include_router(config.router)
 router.include_router(gmail_config.router)
 router.include_router(tools.router)
 router.include_router(tools_actions.router)
+router.include_router(tools_critique.router)
 router.include_router(tools_logs.router)
 router.include_router(onboarding.router)
 router.include_router(onboarding_feed_config.router)

--- a/src/findajob/web/routes/tools_critique.py
+++ b/src/findajob/web/routes/tools_critique.py
@@ -1,0 +1,65 @@
+"""`/tools/critique-review/` — view the recruiter-critique aggregate (#933).
+
+Computes the aggregate live from the corpus on each load (fast — no LLM, no
+network) and renders it. Read-only; unlike the CLI it does not write the dated
+report file. The report embeds real resume lines, but the whole app is
+auth-gated, consistent with /materials/.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from findajob.critique_aggregator.pipeline import aggregate_corpus, default_source_files
+from findajob.critique_aggregator.report import cluster_action, representative_sentence
+
+router = APIRouter()
+
+# Cap the noisy themes surface in the view (the CLI report keeps them all;
+# tuning the floor itself is tracked in #932).
+_MAX_THEMES = 15
+
+
+@router.get("/tools/critique-review/", response_class=HTMLResponse)
+def critique_review(request: Request) -> HTMLResponse:
+    companies_root: Path = request.app.state.companies_root
+    base_root: Path = request.app.state.base_root
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    result, _ = aggregate_corpus(
+        companies_root,
+        default_source_files(base_root),
+        generated_for=today,
+    )
+
+    clusters = [
+        {
+            "action": cluster_action(c),
+            "location": f"{c.anchor.file}:{c.anchor.line_no}",
+            "source_line": c.anchor.text,
+            "recruiter_sentence": representative_sentence(c),
+            "companies": c.companies,
+            "company_count": c.company_count,
+        }
+        for c in result.source_clusters
+    ]
+
+    themes = result.recurring_themes[:_MAX_THEMES]
+    hidden_themes = len(result.recurring_themes) - len(themes)
+
+    templates = request.app.state.templates
+    return templates.TemplateResponse(
+        request,
+        "tools/critique_review.html",
+        {
+            "result": result,
+            "clusters": clusters,
+            "themes": themes,
+            "hidden_themes": hidden_themes,
+            "today": today,
+        },
+    )

--- a/src/findajob/web/templates/tools/critique_review.html
+++ b/src/findajob/web/templates/tools/critique_review.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% block title %}Critique review — findajob{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto p-6">
+  <div class="flex items-baseline justify-between mb-1">
+    <h1 class="text-2xl font-semibold">Materials critique review</h1>
+    <a href="/tools/" class="text-sm underline text-slate-500">← Tools</a>
+  </div>
+  <p class="text-sm text-slate-600 mb-4">
+    Weaknesses your recruiter critiques keep flagging across <em>different</em>
+    applications — these live in your source materials, not any one prep. Fix
+    once, kill across every application. Computed live each load.
+  </p>
+
+  <div class="flex flex-wrap gap-2 text-xs text-slate-600 mb-6">
+    <span class="bg-slate-100 rounded px-2 py-1">{{ result.total_critiques }} critiques</span>
+    <span class="bg-slate-100 rounded px-2 py-1">{{ result.total_companies }} companies</span>
+    <span class="bg-slate-100 rounded px-2 py-1">{{ result.source_clusters | length }} source-level fixes</span>
+    <span class="bg-slate-100 rounded px-2 py-1">{{ result.oneoff_lines }} one-offs</span>
+    <span class="ml-auto text-slate-400">{{ today }}</span>
+  </div>
+
+  {% if result.total_critiques == 0 %}
+  <div class="border border-slate-200 rounded-lg p-6 text-center text-slate-500">
+    No critiques found yet. Recruiter critiques accumulate as you run prep on
+    jobs — come back once you have ~10 or more, and recurring source-level
+    weaknesses will surface here.
+  </div>
+  {% else %}
+
+  <section class="mb-8">
+    <h2 class="text-lg font-semibold mb-3">Source-level fixes</h2>
+    {% if clusters %}
+    <div class="space-y-3">
+      {% for c in clusters %}
+      <div class="border border-slate-200 rounded-lg p-4">
+        <div class="flex items-center gap-2 mb-2">
+          {% set badge = 'bg-amber-100 text-amber-800' if 'CUT' in c.action
+             else ('bg-blue-100 text-blue-800' if c.action == 'REWRITE'
+             else ('bg-emerald-100 text-emerald-800' if c.action == 'ADD'
+             else 'bg-slate-100 text-slate-700')) %}
+          <span class="text-xs font-semibold rounded px-2 py-0.5 {{ badge }}">{{ c.action }}</span>
+          <code class="text-xs text-slate-500">{{ c.location }}</code>
+          <span class="ml-auto text-xs text-slate-500">{{ c.company_count }} companies</span>
+        </div>
+        <blockquote class="border-l-2 border-slate-300 pl-3 text-sm text-slate-700 mb-2">
+          {{ c.source_line }}
+        </blockquote>
+        <p class="text-sm text-slate-600 italic mb-2">{{ c.recruiter_sentence }}</p>
+        <div class="flex flex-wrap gap-1">
+          {% for co in c.companies %}
+          <span class="text-xs bg-slate-100 text-slate-600 rounded px-1.5 py-0.5">{{ co }}</span>
+          {% endfor %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="text-sm text-slate-500">No line flagged by enough companies yet — nothing systemic to fix.</p>
+    {% endif %}
+  </section>
+
+  <section class="mb-8">
+    <h2 class="text-lg font-semibold mb-1">Recurring themes</h2>
+    <p class="text-sm text-slate-500 mb-3">
+      Words recurring across many critiques with no single source line — often a
+      cover-letter pattern or a profile gap.
+    </p>
+    {% if themes %}
+    <div class="flex flex-wrap gap-2">
+      {% for t in themes %}
+      <span class="text-sm bg-slate-100 rounded px-2 py-1">
+        {{ t.term }} <span class="text-slate-400">· {{ t.company_count }}</span>
+      </span>
+      {% endfor %}
+    </div>
+    {% if hidden_themes > 0 %}
+    <p class="text-xs text-slate-400 mt-2">+ {{ hidden_themes }} more (showing the top {{ themes | length }})</p>
+    {% endif %}
+    {% else %}
+    <p class="text-sm text-slate-500">No recurring themes above the floor.</p>
+    {% endif %}
+  </section>
+
+  {% endif %}
+</div>
+{% endblock %}

--- a/src/findajob/web/tools_registry.py
+++ b/src/findajob/web/tools_registry.py
@@ -42,6 +42,18 @@ TILES: list[dict[str, str]] = [
         "prompt_file": "",
     },
     {
+        "slug": "critique_review",
+        "title": "Review recruiter critiques",
+        "description": (
+            "Weaknesses your recruiter critiques keep flagging across different "
+            "applications — the ones that live in your resume, profile, or role "
+            "prompts. Fix once, kill across every application."
+        ),
+        "kind": "link",
+        "href": "/tools/critique-review/",
+        "prompt_file": "",
+    },
+    {
         "slug": "profile_refresh",
         "title": "Refresh your profile",
         "description": (

--- a/tests/test_web_critique_review.py
+++ b/tests/test_web_critique_review.py
@@ -1,0 +1,99 @@
+"""Integration tests for the /tools/critique-review/ page (#933).
+
+Computes the recruiter-critique aggregate live from app.state paths and renders
+it. Exercises the real route → pipeline → template path against a synthetic
+corpus injected via ``create_app(base_root=...)``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.web.app import create_app
+
+_MINIMAL_SCHEMA = """
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    fingerprint TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT NOT NULL,
+    stage TEXT DEFAULT 'discovered',
+    created_at TEXT DEFAULT (datetime('now')),
+    synthetic INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id TEXT NOT NULL,
+    field_changed TEXT NOT NULL,
+    old_value TEXT,
+    new_value TEXT,
+    changed_at TEXT DEFAULT (datetime('now'))
+);
+"""
+
+_CRITIQUE = '**Weak:** "the glue across the lab and ops teams" — hearsay, cut it.\n'
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def _make_client(base: Path, tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(_MINIMAL_SCHEMA)
+    conn.close()
+    app = create_app(
+        companies_root=base / "companies",
+        db_path=db,
+        base_root=base,
+    )
+    return TestClient(app)
+
+
+@pytest.fixture()
+def client_with_corpus(tmp_path: Path) -> TestClient:
+    base = tmp_path / "state"
+    _write(
+        base / "candidate_context" / "master_resume.md",
+        "Widely known as the glue across the lab and ops teams here.\n",
+    )
+    for i, co in enumerate(("Acme", "Beta", "Gamma"), start=1):
+        _write(
+            base / "companies" / f"{co}_R" / f"C Critique - {co} - R - 2026010{i}-000000.md",
+            _CRITIQUE,
+        )
+    return _make_client(base, tmp_path)
+
+
+def test_page_renders_source_cluster_with_location_and_companies(client_with_corpus):
+    resp = client_with_corpus.get("/tools/critique-review/")
+
+    assert resp.status_code == 200
+    body = resp.text
+    assert "glue across the lab and ops teams" in body  # the source line / quote
+    assert "master_resume.md:1" in body  # anchored location
+    assert "Acme" in body and "Beta" in body and "Gamma" in body  # distinct companies
+
+
+def test_empty_corpus_renders_gracefully(tmp_path: Path):
+    base = tmp_path / "state"
+    (base / "companies").mkdir(parents=True)
+    (base / "candidate_context").mkdir(parents=True)
+
+    resp = _make_client(base, tmp_path).get("/tools/critique-review/")
+
+    assert resp.status_code == 200
+    assert "critique" in resp.text.lower()  # page renders, no crash on empty
+
+
+def test_linked_from_tools_index(client_with_corpus):
+    resp = client_with_corpus.get("/tools/")
+
+    assert resp.status_code == 200
+    assert "/tools/critique-review/" in resp.text


### PR DESCRIPTION
Closes #933. Follow-up to #265 — you asked for a UI place to view the critique aggregate instead of SSH-ing to read a file.

## What
`GET /tools/critique-review/` computes the aggregate live and renders it:
- **Source-level fixes** as cards — action badge (WEAKEN/CUT · REWRITE · ADD) · `file:line` · the source line · the recruiter's **verbatim** words · distinct-company chips, sorted by recurrence.
- **Recurring themes** strip, capped to top 15 (the full themes-floor noise is tracked in #932).
- **Empty state** when no critiques yet.
- Linked from `/tools/` via a registry tile ("Review recruiter critiques").

## Design notes
- **Live compute, read-only.** No LLM, no network — fast enough to recompute each load. Unlike the CLI it does not write the dated report file.
- **No drift.** CLI and web share `default_source_files()`; `report.py`'s `cluster_action` / `representative_sentence` are now public so the route builds a view-model and the template stays dumb.
- **PII.** Page embeds real resume lines, but the whole app is auth-gated — consistent with `/materials/`.

## Test plan
- [x] Route integration test: populated corpus (cards + `file:line` + company chips), empty corpus, linked-from-`/tools/`
- [x] `mypy src/findajob/` clean (ran it locally this time), `ruff check` + `format` clean, 51 tests green
- [x] Rendered + screenshotted against a synthetic 3-cluster corpus — cards, badges, blockquotes, chips, themes all render on-brand (matches house Tailwind tokens)

## Docs (same-PR)
- `docs/usage.md` — points the #265 section at the new page
- `docs/architecture/file-map.md` — new route
- `CHANGELOG.md` — `[Unreleased] › Added`

🤖 Generated with [Claude Code](https://claude.com/claude-code)