### PR TITLE
docs(v2 P2.3): parallel rewrite batch — 6 core docs for non-technical audience (#923)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Added
+
+- **`/docs/updating` page** (#910, part of epic #923): New "How to update findajob" doc covering the three update paths — Fly (`fly deploy --config ops/fly.toml`), Docker with Watchtower (automatic within an hour), and Docker without Watchtower (`docker compose pull && docker compose up -d`) — what an update preserves (everything in `state/`: data, config, interview answers, prep materials), and how to check the running version. Registered in the `/docs/` route allowlist and the container-integration smoke slug loop.
+
+### Changed
+
+- **Documentation v2 — core docs rewritten for a non-technical job-seeker audience** (epic #923): `getting-started/api-keys.md` leads with the one required account (OpenRouter), frames RapidAPI as optional with the consequence of skipping it spelled out, and moves legacy per-adapter env vars + pagination tuning behind an Advanced fold. `usage.md` drops the operator-only POST-handler/stage-name tables and the `/tools/` operator-controls section, keeping the daily-loop walkthrough and tab-by-tab guide. `CONTRIBUTING.md` slims to ~60 lines (dev setup, commit conventions, PR process) and points at `CLAUDE.md` and `architecture.md` for invariants and design rather than restating them. `maintainers/generalization.md` gains contributor-audience framing and trims shipped items to one line each. `operations/README.md` trims to the operator essentials with Docker+Fly command pairs; its script-reference section moves into `CLAUDE.md` § Scripts Reference so the operator audience and the agent audience read it from one place.
+
 ## [0.31.3] — 2026-05-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,5 +390,112 @@ Specs (`docs/superpowers/specs/`) describe **what** and **why** — the design +
 - Preserve the scheduler-driven daily run in all changes.
 - Working features first, polish later.
 
+---
+
+## Scripts Reference
+
+<!-- Absorbed from docs/operations/README.md, 2026-05-30 -->
+
+All scripts live in `scripts/`. Diag scripts live in `scripts/diag/` and are run manually only. All scripts import `BASE` and `PANDOC` from `findajob.paths` (`src/findajob/paths.py`). Never hardcode binary paths in scripts — add overrides to `config/paths.env` instead.
+
+**Docker vs Fly:** Docker: `docker compose exec scheduler <cmd>` · Fly: `fly ssh console --app <app> --command "<cmd>"`
+
+### Core pipeline scripts
+
+#### `triage.py`
+**Run by:** scheduler (daily 00:00 PT). No arguments.
+**Manual run:** `docker compose exec scheduler python3 scripts/triage.py`
+
+Fetches jobs from all sources, deduplicates, enriches with JD text, then scores with LLM in parallel (6 concurrent threads), writes to SQLite.
+
+**Sources:**
+- LinkedIn / Indeed via RapidAPI jobs-api14 + JSearch (per `config/active_sources.txt`).
+- Gmail IMAP (LinkedIn job alerts, Indeed digests, recruiter messages — config at `/config/gmail/`).
+- Greenhouse / Lever / Ashby JSON APIs (slugs / URLs in `config/feed_urls.txt`).
+
+**Key events logged:** `triage_started`, `job_ingested`, `job_deduplicated`, `job_scored`, `pipeline_complete`.
+
+#### `scripts/prep_application.py` (entry-point shim)
+*Entry-point shim; implementation in `src/findajob/prep/orchestrator.py`.*
+
+**Run by:** `POST /board/jobs/{fp}/prep` or `/regenerate` (detached subprocess); also callable manually. Args: `company title url job_id`.
+**Manual run:** `docker compose exec scheduler python3 scripts/prep_application.py "Acme" "Engineer" "https://..." "<job_id>"`
+
+Generates a full application package for one job. LLM calls run sequentially.
+
+**Outputs (in `companies/{Company}_{AbbrevTitle}_{date}_{time}/`):**
+- `tailored_resume_DRAFT.md` + `.docx`
+- `tailored_resume_CHANGES.md`
+- `cover_letter_DRAFT.md` + `.docx`
+- `company_briefing.md` + `.docx`
+- `outreach_*.txt` (one per matching contact, if any)
+- `job_description.txt`
+- `REVIEW_CHECKLIST.md`
+
+After completion: updates DB to `stage=materials_drafted`, sends ntfy notification.
+
+#### `watchdog.py`
+**Run by:** scheduler (every 10 min). No arguments.
+**Manual run:** `docker compose exec scheduler python3 scripts/watchdog.py`
+
+Resets any job stuck in `stage='prep_in_progress'` for more than 60 minutes back to `scored`. Calls `findajob.actions.reset_prep_to_scored()` which writes an `audit_log` row and emits `prep_failed_reset`. Emits a `watchdog_run` summary event at the end of each run.
+
+#### `notify.py`
+**Run by:** scheduler (5 subcommands; see `docs/operations/README.md` → Notifications for the per-subcommand schedule and content).
+**Manual run:** `docker compose exec scheduler python3 scripts/notify.py <subcommand>`
+
+#### `scripts/find_contacts.py` (entry-point shim)
+*Entry-point shim; implementation in `src/findajob/find_contacts.py`.*
+
+**Run by:** `scripts/prep_application.py` (step 5). Args: `company jd_text_excerpt outdir`.
+**Manual run:** `docker compose exec scheduler python3 scripts/find_contacts.py "Acme" "<jd-excerpt>" companies/<folder>`
+
+Reads `data/connections.csv`, finds LinkedIn connections at the target company, generates personalized outreach drafts via the OpenRouter wrapper.
+
+**Output:** `{outdir}/outreach_{FirstName}_{LastName}.txt` for each match.
+
+**Key guard:** `company_match()` always checks `if not s or not c: return False` — blank company strings would otherwise match everything.
+
+#### `manual_prep.py`
+**Run by:** manually (when you have a job outside the pipeline). Args: optional path to a job file (default: `manual_job.txt`).
+**Manual run:** `docker compose exec scheduler python3 scripts/manual_prep.py [path/to/job.txt]`
+
+File format:
+```
+company: CompanyName
+title: Job Title
+url: https://...
+---
+Full JD text below this line
+```
+
+Inserts the job into DB and calls `scripts/prep_application.py` immediately.
+
+#### `rescore_all.py`
+**Run by:** manually (after model or prompt changes). No arguments.
+**Manual run:** `docker compose exec scheduler python3 scripts/rescore_all.py`
+
+Re-runs the scorer on all jobs that have JD text.
+
+#### `rename_folders.py`
+**Run by:** manually. No arguments.
+**Manual run:** `docker compose exec scheduler python3 scripts/rename_folders.py`
+
+Renames `companies/` folders from old format (`{Company}_{date}_{time}`) to new format (`{Company}_{AbbrevTitle}_{date}_{time}`). Looks up DB for title, updates `prep_folder_path` in DB. Safe to re-run.
+
+#### `init_db.py`
+**Run by:** once on new install. No arguments.
+**Manual run:** `docker compose exec scheduler python3 scripts/init_db.py`
+
+Creates `data/pipeline.db` with all tables. Safe to re-run — uses `CREATE TABLE IF NOT EXISTS`.
+
+### Diag scripts (`scripts/diag/`)
+
+Run manually for debugging. Not part of normal pipeline operation.
+
+#### `debug_contacts.py`
+Shows contact matching diagnostics for a batch of jobs. Useful for debugging false positive/negative company-name matches.
+**Manual run:** `docker compose exec scheduler python3 scripts/diag/debug_contacts.py`
+
 @CLAUDE.local.md
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,198 +1,67 @@
 # Contributing to findajob
 
-Welcome. This file is for people who want to contribute code, docs, or bug reports to findajob — the install-it-yourself job-search pipeline.
+If you're trying to *use* findajob, start with [`docs/getting-started/`](docs/getting-started/), not this file.
 
-If you're trying to *use* findajob, you want [`docs/getting-started/`](docs/getting-started/), not this file.
+For how the codebase works, see [`docs/architecture.md`](docs/architecture.md).
+Architectural invariants, code-style patterns, and implementation guardrails live in [`CLAUDE.md`](CLAUDE.md).
+Board conventions and project roadmap live at [`docs/project-board.md`](docs/project-board.md) and the [GitHub project board](https://github.com/users/brockamer/projects/1).
 
 ---
 
 ## Reporting bugs and proposing features
 
-File an issue on the [GitHub Issues page](https://github.com/brockamer/findajob/issues). Include:
-
-- **What you tried** — exact command, exact URL, exact tab in the web UI.
-- **What you expected.**
-- **What happened** — paste the relevant `pipeline.jsonl` lines if it's a runtime error, or the browser network tab if it's a UI bug.
-- **Stack details** — image tag (`docker compose ps` shows it), one-line `compose.yaml` env summary if you've customized it.
-
-Don't paste API keys, real names, or anything from `data/.env` or `candidate_context/`. The repo is public; issues are public.
+File an issue on [GitHub Issues](https://github.com/brockamer/findajob/issues). Include what you tried, what you expected, what happened (paste relevant `pipeline.jsonl` lines for runtime errors), and your image tag. Don't paste API keys, real names, or anything from `data/.env` or `candidate_context/` — the repo and issues are public.
 
 ---
 
-## Setting up a local development environment
+## Dev setup
 
 ```bash
-# Clone
 git clone https://github.com/brockamer/findajob.git
 cd findajob
-
-# Install dev dependencies (uv is the canonical package manager)
-uv sync
-
-# Run the test suite
-uv run pytest
-
-# Lint + format check
-uv run ruff check src/ tests/
-uv run ruff format --check src/ tests/
-
-# Type check (advisory; not a CI gate)
-uv run mypy src/
+uv sync                                          # install dev deps
+uv run pytest                                    # test suite
+uv run ruff check src/ tests/                    # lint
+uv run ruff format --check src/ tests/           # format check
+uv run mypy src/                                 # type check (advisory)
 ```
 
-The repo lays out as:
-
-- `src/findajob/` — library code (installed editable into the venv via `uv sync`)
-- `scripts/` — entry-point shims (≤ ~50 LOC each); business logic goes in `src/findajob/`
-- `tests/` — pytest suite; uses real SQLite (tmpfile or `:memory:`), never mocks `sqlite3.connect`
-- `config/roles/` — LLM role prompts (Markdown with YAML frontmatter)
-- `ops/` — Docker compose template + scheduled-jobs.yaml
-- `docs/getting-started/` — user-facing install + configure
-- `docs/operations/` — operator-facing runbook
-- `docs/maintainers/` — contributor-facing references (project board conventions, plan conventions, release process, generalization tracking)
-
----
-
-## Pre-commit hook (PII protection)
-
-The repo's pre-commit hook scans staged diffs against a PII pattern list before each commit. **The hook is not tracked in the repo** — each clone installs its own — because the patterns include personal identifiers that must not ride into the public repo.
-
-To install it on a fresh clone:
+**Pre-commit hook (PII protection).** Install on each clone — the hook is not tracked because patterns include personal identifiers:
 
 ```bash
 cp docs/getting-started/pre-commit-hook.example.sh .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
-If you're contributing to a fork, edit `.git/hooks/pre-commit` and either remove patterns that don't apply to you or add patterns for your own personal identifiers. Full details: [`docs/getting-started/configure.md`](docs/getting-started/configure.md).
-
-The CI workflow at `.github/workflows/pii-scan.yml` runs an equivalent scan against PRs using a GitHub Secret `PII_PATTERNS_REGEX`. Commits that pass your local hook will pass CI.
+CI runs an equivalent scan (`.github/workflows/pii-scan.yml`). Commits that pass the local hook will pass CI.
 
 ---
 
 ## Commit conventions
 
-This repo uses [Conventional Commits](https://www.conventionalcommits.org/) prefixes:
-
-- `feat(area):` — new functionality
-- `fix(area):` — bug fix
-- `docs(area):` — documentation only
-- `test(area):` — test changes only
-- `refactor(area):` — code restructure with no behavior change
-- `chore(area):` — tooling, dependencies, build config
-
-The commit message body should describe the **why**, not just the **what**. Reference issue numbers (`#123`) where relevant; CHANGELOG entries are drafted in the same PR.
+[Conventional Commits](https://www.conventionalcommits.org/) prefixes: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`. Scope goes in parentheses: `feat(scorer):`. The body should describe the **why**. Reference issue numbers (`#123`); CHANGELOG entries are drafted in the same PR.
 
 ---
 
 ## Pull requests
 
-### When to open a PR vs. commit to main
+**When to PR vs. commit to main:**
 
 | Change type | Flow |
-|-------------|------|
+|---|---|
 | Docs, comment edits, board conventions | Commit to `main` |
-| Code touching pipeline behavior (scoring, fetchers, DB schema, LLM roles) | Feature branch → PR |
-| Anything qualifying for `migration-required` (schema, config, compose, crontab, mounts) | PR — release-notes workflow depends on it |
+| Code touching pipeline behavior | Feature branch → PR |
+| `migration-required` changes (schema, config, compose, crontab, mounts) | PR — required for release notes |
 
-When in doubt: does this change affect what users see when they pull `:latest`? If yes, PR. If no, commit to main.
-
-### `migration-required` label
-
-PRs containing schema changes, config additions/removals, compose-file changes, crontab edits, or bind-mount changes get the `migration-required` label at PR-open time. The release-notes workflow surfaces these PRs to external users so they know an upgrade isn't pure `docker compose pull`. Full criteria: [`docs/maintainers/release-process.md` § migration-required](docs/maintainers/release-process.md#migration-required-criteria).
-
-If your PR introduces any of the above, add the label yourself or call it out in the PR description; a maintainer will tag it.
-
-### Pre-PR checklist
-
-- [ ] `uv run pytest` passes locally.
-- [ ] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` are clean.
-- [ ] If your change touches a documented surface (README, `docs/getting-started/*`, `CLAUDE.md`, `docs/operations/`, `docs/maintainers/`), update the docs in the **same** PR.
-- [ ] If your change adds a state transition, schema column, or new env var: add a `### Migration required` line to your CHANGELOG entry.
-- [ ] If your change touches a known-repeat-bug boundary (cross-stack SQLite immutable URI; audit_log timestamp formats; jobs.id JOIN dependencies; blank-string `company_match` guards), add a regression test.
-
-### Branching off
-
-Local `main` drifts from `origin/main` because squash-merges leave the local branch behind. Always branch off `origin/main`:
+**Branch off `origin/main`** (local `main` drifts via squash-merge):
 
 ```bash
-git fetch
-git checkout -b feat/<n>-<description> origin/main
+git fetch && git checkout -b feat/<n>-<description> origin/main
 ```
 
----
-
-## Architectural invariants
-
-These are non-negotiable. CLAUDE.md describes them in detail; the short list:
-
-- **SQLite is the single source of truth.** Every state transition writes through `findajob.actions`; every read goes through SQL queries against `data/pipeline.db`.
-- **Web is the write surface.** Every status / reject-reason transition is a POST handler in `findajob.web.routes.board_actions` calling into `findajob.actions`.
-- **All LLM calls go through `findajob.llm.openrouter.complete()`.** No new HTTP transports.
-- **Job sources implement the `JobSourceAdapter` Protocol.** Adding a new feed = one new adapter file + one entry in `REGISTERED_ADAPTERS`.
-- **Hard rejects are code, not prompt instructions.** Use `scorer_prefilter.py` regex stages for boolean classification; don't trust the LLM alone.
-- **Use paths from `findajob.paths`.** Never hardcode `/home/...` or `/app/`. Tests must not depend on absolute paths — use tmpdirs or `BASE`-relative paths.
-
----
-
-## Code style and patterns
-
-**Patterns new code must follow:**
-- `findajob.llm.openrouter.complete` for every LLM call.
-- `findajob.actions` for every state transition.
-- Route-matrix tests for new POST handlers.
-- `findajob.audit.log_event` / `write_audit` for events. No `logging.getLogger`.
-- No mocking of `sqlite3.connect` in tests. Use real SQLite (tmpfile or `:memory:`).
-- No prompt-string snapshots. Assert structural properties.
-
-**Patterns to retreat from on every pass-through:**
-- Bare `sqlite3.connect` — use `findajob.db.connect`.
-- Business logic in `scripts/*.py` — extract to `src/findajob/<domain>/`.
-- `.in_progress` sentinel files — use the `background_tasks` table.
-- Inline schema changes — use the versioned migration runner in `src/findajob/migrations/`.
-
-**File size soft caps** (hard signals at ~1.5×):
-- `src/findajob/` modules: ~300 LOC.
-- `scripts/` shims: ≤50 LOC (entry-points only).
-- Route modules: ~400 LOC.
-- Tests: ~500 LOC.
-
-**Tests required when:**
-- New POST handler in `routes/`.
-- New `findajob.actions` helper.
-- Schema change.
-- New adapter registered in `REGISTERED_ADAPTERS`.
-- Change to `complete()` or `cost_rollups`.
-- Change to dedup/cleaning helpers.
-- Change crossing a known-repeat-bug boundary.
-
-**Split a refactor across PRs when:**
-- It crosses a `migration-required` boundary.
-- It exceeds ~500 LOC of behavior change.
-- It mixes cleanup with behavior change.
-- It risks a partial-state outage.
-
-Otherwise keep it one PR.
-
----
-
-## Adding a dependency
-
-Before adding a new Python dependency:
-
-- [ ] Is it actively maintained? (Last release < 18 months.)
-- [ ] Is it pure-Python or does it ship native binaries that affect the Docker image size?
-- [ ] Is the API surface small enough that a vendored 50-line implementation would be cheaper to maintain than the dependency? (Often yes for one-off utilities.)
-- [ ] Is its license compatible? (MIT / BSD / Apache 2.0 / PSF — yes. GPL-flavored — needs explicit discussion.)
-
-Add via `uv add <pkg>`; commit `pyproject.toml` and `uv.lock` together.
-
----
-
-## Where else to look
-
-- **CLAUDE.md** — durable guidance for AI assistants working in this repo. Architectural rules + implementation guardrails + commit flow. Read it; the rules in CLAUDE.md and CONTRIBUTING.md are the same rules.
-- **`docs/project-board.md`** — GitHub Projects v2 board conventions (columns, Priority field, labels, `gh project` CLI). Also jared's config file — the machine-readable header block is parsed on every board operation.
-- **CLAUDE.md `## Plan Structure`** — what every implementation plan must contain.
-- **`docs/maintainers/release-process.md`** — how releases are cut.
-- **`docs/maintainers/generalization.md`** — domain-locked content tracker (this codebase started in tech-careers; the goal is field-agnostic).
+**Pre-PR checklist:**
+- [ ] `uv run pytest` passes.
+- [ ] `ruff check` and `ruff format --check` are clean.
+- [ ] Docs updated in the same PR if a documented surface changed.
+- [ ] `### Migration required` entry in CHANGELOG if applicable.
+- [ ] `migration-required` label added to the PR if applicable. See [`docs/maintainers/release-process.md`](docs/maintainers/release-process.md) for criteria.

--- a/docs/getting-started/api-keys.md
+++ b/docs/getting-started/api-keys.md
@@ -1,177 +1,155 @@
 # Getting your API keys
 
-findajob's onboarding asks you to supply **two API keys** for external
-services. Your keys live only in your stack's `data/.env` and are never
-shared with anyone else's deployment.
+**You need one account to get started: OpenRouter.** That single account
+covers every AI call findajob makes — scoring, resume tailoring, cover
+letters, the onboarding interview, all of it. There's no subscription; you
+pay only for what you use.
 
-| Key | What findajob uses it for | Cost | Required? |
+**RapidAPI is optional.** It lets findajob search LinkedIn and Indeed
+directly. findajob works without it, just with fewer job sources — it will
+still pull from company career portals (Greenhouse, Ashby, Lever) and Gmail
+job-alert emails.
+
+| Key | What it does | Cost | Required? |
 |---|---|---|---|
-| **OpenRouter** | All LLM calls (scoring, briefings, resume tailoring, cover letters, outreach drafts, in-app interview) | Pay-as-you-go. No subscription, no monthly minimum; you pay only for what you use. See [`cost.md`](cost.md) for monthly expectations by usage profile. | **Yes** — pipeline cannot score or generate materials without it |
-| **RapidAPI** | LinkedIn / Indeed / Bing job-search ingestion | Free BASIC tier on every supported feed (150–250 requests/month); paid tiers raise the quota | Optional — pipeline still ingests from Greenhouse / Ashby / Lever / Gmail alerts without it |
+| **OpenRouter** | Powers all AI features — scoring, briefings, resume tailoring, cover letters, outreach drafts, the onboarding interview | Pay-as-you-go, no monthly minimum. See [`cost.md`](cost.md) for monthly estimates by usage profile. | **Yes** |
+| **RapidAPI** | Searches LinkedIn and Indeed for jobs matching your profile | Free plan available (no credit card). See quota details below. | No — you can skip it and add it later |
 
-You can leave RapidAPI blank during onboarding and add it later by
-re-running onboarding via `/onboarding/?mode=rerun`. OpenRouter is the
-only hard requirement.
-
-> **Onboarding also asks for two other credentials** — a Gmail app
-> password (for job-alert ingestion + ATS rejection detection) and
-> your LinkedIn `Connections.csv` (for network-based outreach drafting).
-> Both are optional. See [`gmail.md`](gmail.md) and the LinkedIn step
-> in [the getting-started README](README.md).
+> **Onboarding also asks for two optional credentials** — a Gmail app
+> password (for job-alert emails + rejection detection) and your LinkedIn
+> `Connections.csv` (for personalized outreach). You can skip both.
+> See [`gmail.md`](gmail.md) and the LinkedIn step in
+> [the getting-started README](README.md).
 
 ---
 
 ## OpenRouter
 
-OpenRouter is a single API gateway for many LLM providers (Anthropic,
-Google, DeepSeek, Perplexity, etc.). findajob uses it because the
-pipeline mixes multiple model families and OpenRouter lets you pay one
-bill instead of holding direct accounts with five vendors.
+OpenRouter is the service that handles every AI call findajob makes. One
+account covers everything — you don't need separate accounts for each AI
+model findajob uses.
 
 ### Steps
 
 1. Go to <https://openrouter.ai>.
-2. Sign up using Google, GitHub, or MetaMask (the sign-in / sign-up
-   controls are top right).
-3. Add credit to your account at <https://openrouter.ai/credits>.
-   **$10 minimum** to cover the onboarding interview ($3–6);
-   **$20–$30** is a comfortable starter for a typical first month
-   after that. See [`cost.md`](cost.md) for monthly expectations
-   broken down by usage profile.
-4. Create an API key at <https://openrouter.ai/settings/keys>. Give it
-   a name like "findajob" so you can find it later. Copy the key — it
-   starts with `sk-or-v1-` and is shown to you only once. (If you lose
-   it, just create a new one at the same URL — keys are free to mint.)
+2. Sign up using Google, GitHub, or email (sign-in / sign-up controls are
+   top right).
+3. Add credit at <https://openrouter.ai/credits>.
+   **$10 minimum** covers the onboarding interview ($3–6);
+   **$20–$30** is a comfortable starter for a typical first month after
+   that. See [`cost.md`](cost.md) for monthly estimates by usage profile.
+4. Create an API key at <https://openrouter.ai/settings/keys>. Give it a
+   name like "findajob" so you can find it later. Copy the key — it starts
+   with `sk-or-v1-` and is shown to you only once. (If you lose it, create
+   a new one at the same URL — keys are free to mint.)
 5. Paste it into findajob's onboarding page in the **OpenRouter API key**
    field.
 
 ### What findajob does with it
 
-findajob routes 21 role prompts to 6 OpenRouter models (and 2 Anthropic-direct models for the loose-ends onboarding helpers — those don't draw from your OpenRouter balance):
+findajob routes its AI features across several models — each task uses the
+model best suited to it:
 
-- **Scoring** (`job_scorer`) → DeepSeek v3.2
-- **Briefings, cover letters, recruiter critique, resume tailoring, outreach, interview prep, voice processing** → Claude Opus 4.7
+- **Job scoring** → DeepSeek v3.2
+- **Briefings, cover letters, resume tailoring, outreach, interview prep, recruiter critique** → Claude Opus 4.7
 - **Onboarding interview, speculative role synthesis** → Claude Sonnet 4.6
 - **Network analysis, resume change review** → Gemini 3 Flash
 - **Company research, company discovery, fit analysis** → Perplexity Sonar Reasoning Pro
 - **Candidate-led speculative briefing** → Perplexity Sonar Deep Research
-- **Loose-ends helpers** (onboarding nav) → Claude Haiku 4.5 / Sonnet 4.6 via Anthropic direct
 
 ### Cost expectations
 
 See [`cost.md`](cost.md) for a breakdown of monthly spend by usage
 profile (hosting-only, triage-only, light user, active user, power
-user, sprint mode), plus per-LLM-call estimates and the one-time
+user, sprint mode), plus per-call estimates and the one-time
 onboarding cost.
 
 OpenRouter shows you a live spend breakdown at <https://openrouter.ai/activity>.
-You can also cap monthly LLM spend at any dollar amount you choose —
+You can also cap monthly AI spend at any dollar amount you choose —
 visit `/settings/spend-ceiling/` on your running stack.
 
 ---
 
-## RapidAPI
+## RapidAPI (optional)
 
-Optional — required only if you want LinkedIn / Indeed / Bing direct
-search ingestion (Greenhouse / Ashby / Lever and Gmail alerts work
-without it).
+RapidAPI lets findajob search LinkedIn and Indeed directly. It's optional
+— findajob works without it, just with fewer job sources.
 
-RapidAPI is a marketplace API gateway: you create one account, subscribe
-to whichever job-search APIs you want, and use a single account-level key
-for all of them. findajob supports a curated set of RapidAPI-hosted job
-feeds (currently four — listed below), and the onboarding picker
-recommends the right feed(s) for your field.
+If you skip it, findajob still pulls from:
+- Company career portals (Greenhouse, Ashby, Lever) via direct feeds
+- Gmail job-alert emails from LinkedIn and Indeed (see [`gmail.md`](gmail.md))
 
-> **Already onboarded?** The onboarding interview's source-strategy
-> briefing walks through what RapidAPI is good for and when to skip it.
-> If you opted out of a RapidAPI feed during the interview you can leave
-> the key field blank — the pipeline uses your other sources only.
-> Re-run onboarding via `/onboarding/?mode=rerun` to revisit the
-> source-strategy decision.
+You can leave the field blank during onboarding and add it later at
+`/onboarding/?mode=rerun`.
 
-### How RapidAPI subscriptions work
+### How to sign up
 
-- **One account, many APIs.** Sign up at <https://rapidapi.com> once.
-  Each API on the marketplace has its own subscription with its own
-  BASIC / PRO / ULTRA / MEGA pricing tiers.
-- **Shared account key.** All of your subscriptions use a single
-  account-level key (`X-RapidAPI-Key` header). findajob stores it once
-  in `data/.env` as `RAPIDAPI_KEY` and uses it for every feed you've
-  subscribed to.
-- **Free BASIC tiers.** Every feed findajob supports has a free BASIC
-  plan that doesn't require a credit card. The request ceiling varies
-  per feed (see table below).
-- **Subscriptions are per-API, not per-account.** Subscribing to one
-  RapidAPI feed does not subscribe you to the others. The onboarding
-  picker tells you which feed(s) to subscribe to.
+1. Go to <https://rapidapi.com> and create a free account (no credit card
+   required for the free plan).
+2. Visit the [jobs-api14 listing](https://rapidapi.com/Pat92/api/jobs-api14)
+   and click **Subscribe to Test**. Pick the **BASIC** plan (150 free
+   requests/month, no card required).
+3. On the same page, find your **X-RapidAPI-Key** in the right-hand code
+   sample panel. Copy that value.
+4. Paste it into findajob's onboarding page in the **RapidAPI key** field.
+   The onboarding picker runs a one-request live test before saving the key.
+
+One RapidAPI account and one key covers every job-search feed findajob
+supports — you don't need separate keys per feed.
 
 ### Supported feeds
 
-findajob ships with adapters for four RapidAPI feeds. The onboarding
-picker at `/onboarding/feed-config/` is the right place to choose which
-one(s) to subscribe to — it reads `config/rapidapi_feeds.yaml` (a
-curated allowlist) and recommends per-field based on your interview.
+findajob ships with four RapidAPI feed options. The onboarding picker
+recommends one or more based on your interview answers:
 
-| Feed | Adapter name (`active_sources.txt`) | What it searches | Free BASIC tier |
-|---|---|---|---|
-| **jobs-api14** | `jobs-api14` | LinkedIn — broad coverage, LinkedIn-heavy | 150 req/month |
-| **jobs-api14 (Indeed)** | `jobs-api14-indeed` | Indeed — broad US coverage, inline JD | shares quota with jobs-api14 |
-| **jobs-api14 (Bing)** | `jobs-api14-bing` | Bing — 18 jobs/page, inline JD | shares quota with jobs-api14 |
-| **JSearch** | `jsearch` | LinkedIn + Indeed + Glassdoor + ZipRecruiter | 200 req/month |
+| Feed | What it searches | Free plan quota |
+|---|---|---|
+| **jobs-api14** (LinkedIn) | LinkedIn — broad coverage | 150 req/month |
+| **jobs-api14** (Indeed) | Indeed — broad US coverage, includes full job text | Shares quota with jobs-api14 |
+| **jobs-api14** (Bing) | Bing job listings | Shares quota with jobs-api14 |
+| **JSearch** | LinkedIn + Indeed + Glassdoor + ZipRecruiter | 200 req/month |
 
-The env-var name for all four is `RAPIDAPI_KEY`. Legacy per-adapter
-fallbacks (`JOBS_API14_KEY`, `JSEARCH_API_KEY`) still work for stacks
-that haven't migrated.
+> **Activating feeds.** The onboarding picker writes your chosen feeds to
+> `config/active_sources.txt` automatically. To change feeds later, visit
+> `/settings/active-sources/` or re-run onboarding at `/onboarding/?mode=rerun`.
 
-> **Adapter names matter.** The values in the "Adapter name" column go
-> in `config/active_sources.txt`, one per line. Stacks without that
-> file default to `jobs-api14` (LinkedIn-only); the file is written by
-> the onboarding picker for new stacks.
-
-> **Indeed and Bing are opt-in.** To activate either, add the adapter
-> name to `config/active_sources.txt`. The onboarding picker handles
-> this for new stacks; existing stacks need to add the line manually.
-
-> **PRO/ULTRA/MEGA tiers.** Indeed, Bing, and LinkedIn share the same
+> **PRO/ULTRA/MEGA tiers.** LinkedIn, Indeed, and Bing share the same
 > per-account quota — upgrading raises the limit for all three feeds
-> together (PRO: 20,000 req/month shared).
+> together (PRO: 20,000 req/month shared for jobs-api14; 10,000/month for
+> JSearch).
 
-> **Note (Bing — no allowlist initially).** Unlike Indeed, Bing ships
-> with no title-allowlist post-filter — all titles flow through
-> currently. 18 jobs per page (vs Indeed's 20, LinkedIn's 10) on the
-> same shared quota.
+### Adding support for a new feed
 
-### What happens during onboarding
-
-The picker at `/onboarding/feed-config/` walks you through sign-up plus
-a live connection test:
-
-1. **Recommendation.** Based on your interview answers (field, target
-   companies, target geography), the picker recommends one or more feeds
-   from the supported set.
-2. **Sign up at RapidAPI.** A link button takes you to the recommended
-   feed's listing page. Subscribe to the BASIC plan — free, no credit
-   card required.
-3. **Copy your key.** RapidAPI shows your account key on the listing
-   page after you've subscribed.
-4. **Paste + test.** Paste the key into the picker's field. The picker
-   runs a one-request live test against the feed before writing the key
-   to `data/.env`. If the test fails, you get a specific error message
-   and the key is not written.
-
-If you'd rather walk this manually (or you skipped onboarding entirely),
-the same form is reachable at `/onboarding/feed-config/` on a running
-stack.
+Need a feed that's not in the supported set? Each RapidAPI vendor has a
+different response format, so each feed needs a custom adapter. File an
+issue at <https://github.com/brockamer/findajob/issues> or see
+`CLAUDE.md` § "Source Adapters are Pluggable" for the contributor
+walkthrough.
 
 <details>
-<summary>Pagination tuning (PRO-tier only — skip on the free BASIC plan)</summary>
+<summary>Advanced</summary>
 
-Both jobs-api14 and JSearch let you trade quota for yield via per-stack
-env vars. Each additional page is one billed RapidAPI request (per-call
-billing — empirically confirmed on the operator stack for both APIs).
+### Legacy per-adapter env var fallbacks
 
-**`JobsApi14Adapter`** (LinkedIn endpoint, opaque-token pagination via
-`meta.nextToken`) — set `JOBS_API14_MAX_PAGES=N`:
+Older deployments may have set per-adapter keys instead of the single
+canonical key. These still work as fallbacks:
+
+| Adapter | Canonical key | Legacy fallback |
+|---|---|---|
+| jobs-api14 (LinkedIn / Indeed / Bing) | `RAPIDAPI_KEY` | `JOBS_API14_KEY` |
+| JSearch | `RAPIDAPI_KEY` | `JSEARCH_API_KEY` |
+
+New onboardings write only `RAPIDAPI_KEY`. If you're on an older
+deployment that has `JOBS_API14_KEY` or `JSEARCH_API_KEY` in `data/.env`,
+those will continue to work — no migration required.
+
+### Pagination tuning (PRO tier only — skip on the free BASIC plan)
+
+Both jobs-api14 and JSearch let you trade quota for yield. Each
+additional page uses one additional billed RapidAPI request.
+
+**`JobsApi14Adapter`** (LinkedIn, opaque-token pagination) — set
+`JOBS_API14_MAX_PAGES=N` in `data/.env`:
 
 | Tier | Recommended | Monthly cost (5 queries × N pages × 30 days) |
 |---|---|---|
@@ -180,48 +158,21 @@ billing — empirically confirmed on the operator stack for both APIs).
 
 Clamped to `[1, 20]`.
 
-**`JSearchAdapter`** (server-side pagination via the API's own
-`num_pages` param — single HTTP request per query, billed as N units) —
-set `JSEARCH_NUM_PAGES=N`:
+**`JSearchAdapter`** (server-side pagination, billed as N units per
+query) — set `JSEARCH_NUM_PAGES=N` in `data/.env`:
 
-| Tier | Recommended | Monthly cost (5 queries × N pages × 30 days) | Yield ratio |
+| Tier | Recommended | Monthly cost (5 queries × N pages × 30 days) | Yield |
 |---|---|---|---|
 | BASIC (200 req/mo) | leave at 1 | 150 / 200 = 75% | ~10 jobs/query |
 | PRO (10,000 req/mo) | 3 | 450 / 10,000 = 4.5% | ~27 jobs/query (~2.7x) |
 
-Clamped to `[1, 10]` (half of jobs-api14's ceiling because JSearch's PRO
-quota is half).
+Clamped to `[1, 10]`.
 
-Restart the stack after editing `data/.env`. Live-test in
-`/onboarding/feed-config/` stays single-page for both adapters
-regardless of these settings — it's a connectivity check, not a yield
-benchmark.
+Restart the stack after editing `data/.env`. The live-test in
+`/onboarding/feed-config/` always runs single-page regardless of these
+settings — it's a connectivity check, not a yield benchmark.
 
 </details>
-
-### Skipping RapidAPI entirely
-
-If you skip the RapidAPI key, findajob will:
-
-- still ingest jobs from Greenhouse / Ashby / Lever ATS feeds
-  (configured in `config/feed_urls.txt`)
-- still ingest jobs from Gmail LinkedIn / Indeed alerts (configured in
-  `/config/gmail/`; see [`gmail.md`](gmail.md))
-- skip the LinkedIn / Indeed / Bing direct search path entirely (no
-  errors, no silent failures — the pipeline simply runs with one fewer
-  source)
-
-You can add a key later by visiting `/onboarding/?mode=rerun` and
-running the picker again.
-
-### Adding support for a new RapidAPI feed
-
-Need a feed that's not in the supported set? Adding a new adapter is a
-development task — each RapidAPI vendor has a different response schema
-and pagination mechanism, so each feed needs a custom adapter
-implementing the `JobSourceAdapter` Protocol. File an issue at
-<https://github.com/brockamer/findajob/issues> or see CLAUDE.md
-§"Source Adapters are Pluggable" for the contributor walkthrough.
 
 ---
 
@@ -229,23 +180,20 @@ implementing the `JobSourceAdapter` Protocol. File an issue at
 
 To rotate any key:
 
-1. Generate the new key at the provider (using the steps above).
+1. Generate a new key at the provider (using the steps above).
 2. Visit `/onboarding/?mode=rerun` on your findajob instance.
 3. Paste the new key. The injector backs up the existing `data/.env`
    under `.backups/{UTC-stamp}/` and writes the new value in place.
 
 The pipeline picks up the new key on its next scheduled run; no
-restart needed for keys read at request time.
+restart needed.
 
-If you're running your own stack (e.g. self-hosting via docker-compose
-or deploying to Fly), you ARE the operator — both options above work
-for you. If a separate person manages your stack on your behalf, they
-can edit `data/.env` directly on the host:
+If you manage your own stack (self-hosted or on Fly), you can also edit
+`data/.env` directly:
 - **Docker self-host:** SSH into the host and edit `data/.env` — see
-  `docs/operations/install-docker.md` under "Operating an existing
-  stack."
+  `docs/operations/install-docker.md` under "Operating an existing stack."
 - **Fly.io:** `fly secrets set OPENROUTER_API_KEY=sk-or-v1-... --app findajob-<your-handle>`
-  (Fly redeploys the machine automatically when secrets change).
+  (Fly redeploys automatically when secrets change).
 
 ---
 
@@ -253,15 +201,12 @@ can edit `data/.env` directly on the host:
 
 Two credentials are collected outside the API-keys form:
 
-- **Gmail app password** — for ingesting LinkedIn / Indeed job-alert
-  emails and auto-detecting ATS rejection emails. Optional. The
-  onboarding flow lands at `/onboarding/gmail-config/` after the
-  interview; see [`gmail.md`](gmail.md) for the 2-Step Verification
-  + app-password generation walkthrough.
-- **LinkedIn `Connections.csv`** — for network-based outreach
-  drafting. Optional. The onboarding flow has a dedicated terminal step
-  that walks through exporting from LinkedIn and validating the CSV.
-  See the LinkedIn step in [the getting-started README](README.md).
+- **Gmail app password** — for ingesting job-alert emails and
+  auto-detecting rejection emails from employers. Optional. See
+  [`gmail.md`](gmail.md) for the setup walkthrough.
+- **LinkedIn `Connections.csv`** — for network-based outreach drafting.
+  Optional. See the LinkedIn step in
+  [the getting-started README](README.md).
 
 ---
 

--- a/docs/maintainers/generalization.md
+++ b/docs/maintainers/generalization.md
@@ -1,178 +1,67 @@
 # Generalization Tracking — Making findajob Domain-Agnostic
 
-The pipeline was built for a specific use case (data center operations / hardware NPI job
-search) but the goal is to make it useful for any job seeker — social workers, teachers,
-accountants, designers, operations managers in any field.
-
-This document tracks every piece of the codebase that currently assumes the original
-domain. Each item is a future task to make the pipeline domain-neutral.
-
-**Status key:**
-- `[ ]` — domain-locked, needs work
-- `[~]` — partially generalized (some config-driven, some hardcoded)
-- `[x]` — fully generalized
+This document is for contributors evaluating whether findajob works for their
+field and developers preventing new domain-locked content.
 
 ---
 
 ## Principles
 
-1. **Logic is generic; lists are config.** Pipeline code should not embed any domain knowledge. Target companies, job titles, search queries, reject patterns — all config-driven.
-2. **Prompts reference the profile, not the domain.** Role prompts should instruct the LLM to read the candidate's profile for domain context, not bake in category language.
-3. **Examples are generic or plural.** When an example is needed, use a hypothetical candidate ("Jane Smith, senior social worker at a city health department") rather than a real one. Better: show 2-3 examples from different fields.
-4. **Profile is the source of truth.** The candidate's `candidate_context/profile.md` carries all domain-specific content — target role, target companies, hard-reject categories, in-domain signals.
+1. **Logic is generic; lists are config.** Pipeline code must not embed domain knowledge — target companies, job titles, search queries, reject patterns are all config-driven.
+2. **Prompts reference the profile, not the domain.** Role prompts instruct the LLM to read the candidate's profile for domain context, never hardcode category language.
+3. **Profile is the source of truth.** `candidate_context/profile.md` carries all domain-specific content — target role, target companies, hard-reject categories, in-domain signals.
 
 ---
 
-## Hardcoded Domain Content (needs work)
+## Shipped (resolved items)
 
-### Scorer prefilter — `src/findajob/scorer_prefilter.py`
-
-- [x] **`TIER1` frozenset** — dropped entirely in favor of the Tier 1 section of `config/target_companies.md` (see changelog below). The prefilter no longer consults any company-level list.
-
-- [x] **`_HARD_REJECT_PATTERNS`** — externalized to `config/prefilter_rules.yaml` under `hard_rejects`, grouped by category. Loaded via `src/findajob/config_loader.py`.
-
-- [x] **`_IN_DOMAIN_PATTERNS`** — externalized to `config/in_domain_patterns.yaml` under `positive`.
-
-- [x] **`_IN_DOMAIN_POISON`** — externalized to `config/in_domain_patterns.yaml` under `poison`.
-
-**Resolved 2026-04-17 (#10):**
-- `TIER1` was *dropped*, not externalized. The Tier-1 prefilter bonus (+1 score at the in-domain/no-JD floor) was removed entirely — the LLM already sees the target-companies list via prompt context, so the prefilter kludge is unnecessary.
-- The "companies I care about" concept lives on via the `## Tier 1` section of `config/target_companies.md`, parsed at runtime by `findajob.config_loader.load_companies_of_interest()` and consumed by `scripts/notify.py` (mis-score health check). The prefilter does NOT consult this list. The intermediate `companies_of_interest.txt` derived file was retired in #211 — `target_companies.md` is now the single source of truth.
-- Hard-reject + in-domain rules now load from `config/prefilter_rules.yaml` and `config/in_domain_patterns.yaml` through `src/findajob/config_loader.py`. Both files are gitignored; see `.example` siblings for templates.
-- Items 4 and 5 of #10 (prompt-level neutralization: `job_scorer.md` hard-reject enumerations + ENGINEER TITLE CALIBRATION move to `profile.md`) are **deferred** — they change LLM behavior and need their own validation loop. Tracked as a follow-up issue.
-
-### Scorer role prompt — `config/roles/job_scorer.md`
-
-- [x] **`HARD REJECT RULES`** — fixed 2026-04-25 (#65): no longer enumerates tech categories. Prompt now instructs the LLM to read the candidate's profile under any of `## Excluded Categories`, `## Deal-Breakers`, `## What I Am NOT`, `## Not Open To`, or `## Reduce score for` (under `## Flags for Scorer`). Profile exclusions explicitly take priority over the Tier 1 floor.
-
-- [x] **`TIER 1 COMPANY EXCEPTION`** — fixed 2026-04-25 (#65): in-domain title list removed; prompt now instructs the LLM to derive in-domain from the profile's target-role and core-competency sections. Exception logic (Tier 1 + in-domain → 6 floor) preserved as generic.
-
-- [x] **`ENGINEER TITLE CALIBRATION`** — fixed 2026-04-25 (#65): the operator-specific IC-vs-ops engineer calibration moved into the operator's profile under a new `## Title Calibration Notes` section. The prompt now contains a generic "candidate-token calibration" rule: don't broadly reject on a single token if that token appears in titles the candidate has held; honor any `## Title Calibration Notes` section in the profile for finer guidance. Also added to `profile.md.example` with both tech and non-tech examples.
-
-- [x] **`CROSS-INDUSTRY RECOGNITION`** — fixed 2026-04-25 (#65): hardware-specific industry list (robotics, AVs, satellites, fusion) removed from prompt. Prompt now instructs the LLM to look for cross-industry framing in profile sections like `## Core Competency (Cross-Industry)` or `## Framing for Private-Sector Applications`. Conservative scoring + ai_notes flag when the connection is speculative.
-
-### Role prompts with tech vocabulary — `config/roles/*.md`
-
-- [ ] **`briefing_writer.md`** — mostly generic but may include tech interview framing
-- [ ] **`fit_analyst.md`** — scoring dimensions may be tech-biased
-- [x] **`company_researcher.md`** — fixed 2026-04-22 (#156): opening sentence no longer says "senior infrastructure job candidate"; "Infrastructure Footprint (data centers, cloud strategy, hardware at scale)" section replaced with "Organizational Footprint (locations, scale of operations, resources relevant to this role type)"
-- [ ] **`outreach_drafter.md`** — tone is tech-industry informal; social work/education may need more formal
-- [x] **`cover_letter_writer.md`** — fixed 2026-04-22 (#156): two issues resolved — (1) peer quote attribution example was "a director in site operations" (operator-specific role title copied literally by LLM); (2) metric example included "MW, rack counts" (data center vocabulary). Both replaced with field-neutral alternatives.
-- [x] **`resume_tailor.md`** — fixed 2026-04-22 (#156): "NEVER do" examples used operator-specific labels (`**Data Center Builds**`, `**Infrastructure NPI Operations**`); replaced with generic placeholders (`**Key Projects**`, `**Strategic Initiatives**`)
-
-Remaining roles audited 2026-04-22 and found clean: `briefing_writer.md`, `fit_analyst.md`, `network_analyst.md`, `outreach_drafter.md`, `resume_change_reviewer.md`. `outreach_drafter.md` tone kept as `[ ]` for future review.
-
-### Example files — `config/*.example`, `candidate_context/*`
-
-- [ ] **`candidate_context/profile.md.example`** — target role is "hardware engineer / technical program manager at AI infrastructure companies"
-  - Should show 2-3 examples from different fields (healthcare, education, social services, tech)
-  - Or a more abstract template that's field-neutral
-
-- [ ] **`config/target_companies.md.example`** — lists OpenAI, Anthropic, Google DeepMind
-  - Should show examples from multiple fields or use generic "Company A / Company B / Company C"
-
-- [ ] **`config/jsearch_queries.txt.example`** — tech queries only
-  - Add examples for: social work case manager, elementary school teacher, nonprofit development director, hospital patient advocate
-
-- [ ] **`config/feed_urls.txt.example`** — Greenhouse slugs for tech companies
-  - Greenhouse itself is tech-biased; many non-tech employers use Workday, Taleo, iCIMS
-  - Longer-term: add alternative ATS integrations
-
-### Scripts with domain hints
-
-- [ ] **`scripts/find_contacts.py`** — assumes LinkedIn connections.csv format
-  - LinkedIn is still the dominant professional network across fields, probably OK
-  - But for some fields (education, healthcare) job-relevant contacts may not be on LinkedIn
-  - Could support other contact sources via config
-
-- [ ] **`scripts/ingest_form.py`** — Google Form ingestion, fields assume job search
-  - Generic enough but worth reviewing the field names
-
-### Documentation — `docs/*.md`
-
-- [x] **`docs/architecture.md`** — generic, OK
-- [ ] **`docs/operations/README.md`** — may reference tech workflows; needs review
-- [ ] **`docs/operations/config-reference.md`** — may mention AI company examples
-
-### Search / ingestion logic — `scripts/triage.py`
-
-- [ ] LinkedIn/Indeed query parameters: `experienceLevels: 'midSenior;director'` — hardcoded to senior/director tier
-  - Should be configurable per candidate (junior, mid, senior, exec)
-- [ ] Default `location: 'United States'` — hardcoded, reasonable default but should be configurable
+- **Prefilter: `TIER1` frozenset** — dropped; `config/target_companies.md` is the canonical target-company signal for non-prefilter consumers (#10, 2026-04-17).
+- **Prefilter: `_HARD_REJECT_PATTERNS`** — externalized to `config/prefilter_rules.yaml` via `config_loader` (#10, 2026-04-17).
+- **Prefilter: `_IN_DOMAIN_PATTERNS` / `_IN_DOMAIN_POISON`** — externalized to `config/in_domain_patterns.yaml` (#10, 2026-04-17).
+- **`job_scorer.md`: hard-reject enumerations** — removed; prompt reads candidate profile sections (`## Excluded Categories`, `## Deal-Breakers`, etc.) instead (#65, 2026-04-25).
+- **`job_scorer.md`: TIER 1 COMPANY EXCEPTION** — in-domain title list removed; prompt derives in-domain from profile target-role and core-competency sections (#65, 2026-04-25).
+- **`job_scorer.md`: ENGINEER TITLE CALIBRATION** — moved to operator's `profile.md` under `## Title Calibration Notes`; `profile.md.example` shows tech and non-tech examples (#65, 2026-04-25).
+- **`job_scorer.md`: CROSS-INDUSTRY RECOGNITION** — hardware-specific industry list removed; prompt reads profile cross-industry framing sections instead (#65, 2026-04-25).
+- **`company_researcher.md`** — "senior infrastructure job candidate" and data-center-specific section headings replaced with field-neutral language (#156, 2026-04-22).
+- **`cover_letter_writer.md`** — operator-specific role title in peer quote example and data center metric example (`MW, rack counts`) replaced with field-neutral alternatives (#156, 2026-04-22).
+- **`resume_tailor.md`** — operator-specific section labels (`**Data Center Builds**`, `**Infrastructure NPI Operations**`) replaced with generic placeholders (#156, 2026-04-22).
+- **`company_discoverer.md`** — field-agnostic by design; enumerates no industries, companies, or titles; runs weekly to produce a competency-fit signal separate from the static strategic-preference list in `profile.md` (#284).
 
 ---
 
-## Already Generic (no work needed)
+## Open Items
 
-- [x] `scripts/utils.py` — pure utilities, no domain
-- [x] `scripts/poll_flags.py` — generic stage management
-- [x] `scripts/notify.py` — ntfy wrapper, generic
-- [x] `scripts/analyze_feedback.py` — reads feedback_log and jobs, no domain content
-- [x] `scripts/backfill_jd.py` — generic JD re-fetch
-- [x] `scripts/init_db.py` — generic schema
-- [x] `scripts/prep_application.py` — generic prep orchestration; domain comes from injected profile
-- [x] `config/scoring_schema.json` — generic 1-10 score + string fields
-- [x] `config/reference.docx` — neutral Word template
-- [x] `CLAUDE.md` — project guidance, no candidate details
-- [x] `CLAUDE.local.md.example` — placeholder template
+### Example / template files
 
----
+- [ ] **`candidate_context/profile.md.example`** — target role is tech-specific; should show 2-3 examples from different fields (healthcare, education, social services) or a field-neutral template.
+- [ ] **`config/target_companies.md.example`** — lists AI-company examples; replace with multi-field examples or generic placeholders.
+- [ ] **`config/jsearch_queries.txt.example`** — tech queries only; add examples for non-tech fields (social work, education, nonprofit, healthcare).
+- [ ] **`config/feed_urls.txt.example`** — Greenhouse slugs for tech companies; note that non-tech employers often use Workday, Taleo, or iCIMS.
 
-## Order of Work (suggested)
+### Role prompts
 
-**Phase 1: Config externalization (high value, mechanical)** — ✅ shipped 2026-04-17 (#10)
-1. ~~Move `TIER1` out~~ → dropped; replaced by Tier 1 section of `config/target_companies.md` for non-prefilter consumers (read directly via `config_loader` post-#211).
-2. ~~Move `_HARD_REJECT_PATTERNS`~~ → loaded from `config/prefilter_rules.yaml` via `config_loader`.
-3. ~~Move `_IN_DOMAIN_PATTERNS` and `_IN_DOMAIN_POISON`~~ → loaded from `config/in_domain_patterns.yaml`.
+- [ ] **`briefing_writer.md`** — may include tech interview framing; audit pending.
+- [ ] **`fit_analyst.md`** — scoring dimensions may be tech-biased; audit pending.
+- [ ] **`outreach_drafter.md`** — tone is tech-industry informal; formal-register fields (education, healthcare) may need an alternative.
 
-**Phase 2: Prompt neutralization** — ✅ shipped 2026-04-25 (#65)
-4. ~~Rewrite `job_scorer.md` hard reject section~~ → references profile sections instead of enumerating categories.
-5. ~~Move engineer-calibration logic~~ → moved to operator's `profile.md` under `## Title Calibration Notes`; `profile.md.example` shows the new section with both tech and non-tech examples.
-6. ~~Audit other role prompts for domain vocabulary~~ → completed 2026-04-22 (#156); see status flags above.
+### Ingestion / search
 
-**Phase 3: Example diversification**
-7. Rewrite `profile.md.example` and `target_companies.md.example` to show 3 fields
-8. Add non-tech example queries to `jsearch_queries.txt.example`
-9. Document that Greenhouse integration is tech-heavy; note alternatives for Phase 5
+- [ ] **`scripts/triage.py`**: LinkedIn `experienceLevels: 'midSenior;director'` — should be configurable per candidate.
+- [ ] **`scripts/triage.py`**: default `location: 'United States'` — should be configurable.
+- [ ] **`scripts/find_contacts.py`** — assumes LinkedIn `connections.csv`; fields where job-relevant contacts are not on LinkedIn may need alternative contact sources.
 
-**Phase 4: Setup flow**
-10. Build a guided `scripts/setup_profile.py` that walks new users through creating their own config from scratch based on their field
-11. Document the "I'm a \_\_\_\_" starter flow in README
+### Suggested follow-on phases
 
-**Phase 5: Alternative ingestion**
-12. Add Workday / Taleo / iCIMS feed support for non-tech fields
-13. Evaluate per-field best ATS integrations
-
----
-
-## Company discovery — replaces hand-curated Tier 1 expansion (#284)
-
-The `## Target Companies / Organizations` section in `profile.md` was
-previously the only mechanism for naming companies the candidate would
-take a job at. It conflated two signals: strategic preference (would-take
-even if not a perfect fit) and competency-domain fit (skill-stack
-matches). Hand-expanding the list to cover competency-fit was a known
-dead end — hand-written lists don't track hiring activity and don't scale
-across operator fields.
-
-The `company_discoverer` role (#284) handles competency-fit discovery as
-a parallel, regenerable, field-agnostic signal. The static list stays as
-the strategic-preference signal. The two are read separately by
-downstream consumers (#285's scorer rewire, #283's Greenhouse-slug
-derivation) without either acting as a hard floor.
-
-The discoverer's role file (`config/roles/company_discoverer.md`) is
-intentionally field-agnostic. It enumerates no industries, no companies,
-no role titles. If you fork to tune the prompt for your own field, that
-is expected; if you contribute back upstream, please preserve
-field-agnosticism so other operators in unrelated fields continue to
-benefit.
+- **Phase 3:** Rewrite example files (`profile.md.example`, `target_companies.md.example`, `jsearch_queries.txt.example`) to show multiple fields.
+- **Phase 4:** Build a guided setup flow (`scripts/setup_profile.py`) and document a "I'm a ___" starter flow.
+- **Phase 5:** Add Workday / Taleo / iCIMS feed support for non-tech ATS integrations.
 
 ---
 
 ## Self-Check for Future Sessions
 
 Before committing code or prompt changes, ask:
+
 1. Does this add any hardcoded company name, job title, industry term, or category that only makes sense for one field?
 2. Does this make the pipeline easier or harder to use for a social worker, teacher, or accountant?
 3. Is the domain-specific content in `config/*` (gitignored) or in `scripts/*` (tracked)?

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -2,9 +2,11 @@
 
 > **New to findajob?** Start at [`../usage.md`](../usage.md). This page is the operator reference for running the stack by hand — triage, sync, prep, notifications — from a shell.
 
-Day-to-day operation of the pipeline. The `ghcr.io/brockamer/findajob` image runs supercronic + uvicorn co-process inside one container. Setup: [`install-docker.md`](install-docker.md). All pipeline commands below are shown in their Docker form (`docker compose exec scheduler …`).
+Day-to-day operation of the pipeline. The `ghcr.io/brockamer/findajob` image runs supercronic + uvicorn co-process inside one container. Setup: [`install-docker.md`](install-docker.md). For cloud deployment on Fly.io — one Fly app per tenant, image runs unchanged — see [`fly-deploy.md`](fly-deploy.md).
 
-For cloud deployment on Fly.io as an alternative to the host compose stack — one Fly app per tenant, image runs unchanged — see [`fly-deploy.md`](fly-deploy.md).
+**Command forms:**
+- Docker: `docker compose exec scheduler python3 scripts/<script>.py`
+- Fly: `fly ssh console --app <app> --command "python3 scripts/<script>.py"`
 
 ---
 
@@ -17,39 +19,28 @@ The pipeline is mostly autonomous. Your job is:
 3. **Action** — set STATUS in the Dashboard:
    - `Flag for Prep` → generates application materials (~5–10 min)
    - `REJECT_REASON` (any value) → rejects, logs, moves to `_rejected/`
-4. **Apply** — when prep is done, STATUS auto-changes to `Ready to Apply`; you review materials and submit
+4. **Apply** — when prep finishes, review the briefing and drafted materials on the job's Materials page, then submit
 5. **Track** — set STATUS to `Applied` / `Interviewing` / `Offer` / `Withdrew` as appropriate
 
 ---
 
 ## Manual Commands
 
-### Run triage manually (test or catch-up)
+### Run triage
 ```bash
 docker compose exec scheduler python3 scripts/triage.py
 ```
 
-### Prep a specific job manually
+### Prep a specific job
 ```bash
 docker compose exec scheduler python3 scripts/prep_application.py "Company Name" "Job Title" "https://url" "job-db-id"
-```
-
-Or use `manual_prep.py` with a text file:
-```bash
-# Create manual_job.txt:
-# company: CompanyName
-# title: Job Title
-# url: https://...
-# ---
-# Full JD text here
-docker compose exec scheduler python3 scripts/manual_prep.py
 ```
 
 ### Inject a job manually
 
 Preferred: use the `/ingest/` web form at `http://<your-host>:${FINDAJOB_MATERIALS_PORT}/ingest/` to paste a URL + JD.
 
-CLI fallback (same underlying code path as the web form):
+CLI fallback (job file format: `company:`, `title:`, `url:`, `---`, then JD text):
 ```bash
 docker compose exec scheduler python3 scripts/manual_prep.py /path/to/job.txt
 ```
@@ -73,8 +64,8 @@ Use after changing the `job_scorer` role or switching models.
 ## Monitoring
 
 `logs/pipeline.jsonl` lives at `/app/logs/pipeline.jsonl` inside the container,
-which is bind-mounted from `./state/logs/` on the host. SQLite lives at
-`/app/data/pipeline.db` (host: `./state/data/pipeline.db`).
+bind-mounted from `./state/logs/` on the host. SQLite at `/app/data/pipeline.db`
+(host: `./state/data/pipeline.db`).
 
 ### Check recent pipeline events
 ```bash
@@ -93,7 +84,7 @@ docker compose exec scheduler python3 scripts/notify.py health-check
 
 Or directly against the JSONL log:
 ```bash
-docker compose exec scheduler bash -c 'grep -i "\"event\":\".*error\\|exception\\|failed\"" logs/pipeline.jsonl | tail -10'
+docker compose exec scheduler bash -c 'grep -i "\"event\":\".*error\|exception\|failed\"" logs/pipeline.jsonl | tail -10'
 ```
 
 ### DB stats
@@ -128,12 +119,12 @@ docker compose exec scheduler sqlite3 data/pipeline.db \
 2. No restart needed — profile is read fresh on every triage + every prep
 
 ### Update a role prompt
-1. Edit `config/roles/{role_name}.md` — this file is **baked into the image** at `/app/config/roles/`, NOT bind-mounted. Edit the file in your repo clone, rebuild the image, and `docker compose pull` to deploy.
+1. Edit `config/roles/{role_name}.md` — this file is **baked into the image** at `/app/config/roles/`, NOT bind-mounted. Edit the file in your repo clone, rebuild the image, and deploy to pick up the change.
 2. The OpenRouter wrapper reads the role file (frontmatter `model:`, `temperature:`, `max_tokens:`) fresh on every invocation — no restart.
 
 ### Change a role's model
 1. Edit the `model:` line in the role's frontmatter (e.g. `config/roles/job_scorer.md`).
-2. Rebuild the image and `docker compose pull` to deploy. Each role pins its own model — there's no global default to override.
+2. Rebuild and deploy. Each role pins its own model — there's no global default to override.
 
 ### Export feedback log for analysis
 Free-text columns can shred under naive separator dumps; use `python3 -c` with `csv.QUOTE_ALL` rather than `sqlite3 -separator`.
@@ -152,7 +143,7 @@ w.writerows(rows)
 ```bash
 docker compose exec scheduler python3 scripts/rename_folders.py
 ```
-Safe to re-run — skips already-renamed folders. Historical migration script for old `{Company}_{date}_{time}` folders predating the title-disambiguation suffix.
+Safe to re-run — skips already-renamed folders.
 
 ---
 
@@ -170,21 +161,13 @@ The materials sub-view (`/materials/`) renders prep-folder contents grouped by s
 
 ## Log Rotation
 
-`logs/pipeline.jsonl` rotates in-process at 5 MB. The rotator lives in `findajob.audit` (the same module that writes the file) so the behavior is identical inside and outside Docker without per-host `logrotate` setup.
-
-On rotation, the current file is gzipped to `pipeline.jsonl.1.gz`; older backups shift up (`.1.gz` → `.2.gz`, `.2.gz` → `.3.gz`, …). The ring keeps the 6 most recent backups, so disk usage per stack is bounded at roughly 5 MB current file + 6 × ≪5 MB gzipped backups (a few MB total in practice). At the end of every rotation, any backup older than 90 days is also swept regardless of slot — on low-activity stacks where rotation happens only every few months, this prevents indefinitely-stale gzipped history from accumulating.
-
-Two readers know about rotation:
-- The log tail utility (`findajob.jsonl_tail`) reads only the trailing 1 MB of the *current* file; rotated history is intentionally not surfaced there.
-- The staging green-check (`findajob.staging.green`) reads the current file plus `pipeline.jsonl.1.gz` so the 26h `pipeline_complete` predicate survives a rotation that lands between green-check runs.
-
-If you specifically need a long-running off-host log history, ship `pipeline.jsonl` to syslog / Loki / Datadog from the host — the in-container rotation is intentionally short-window operational visibility, not durable archival. The durable transition trail lives in the `audit_log` SQLite table, not in `pipeline.jsonl`.
+`logs/pipeline.jsonl` rotates in-process at 5 MB (gzipped to `pipeline.jsonl.1.gz`; ring keeps 6 backups; entries older than 90 days pruned). The durable transition trail lives in the `audit_log` SQLite table, not in `pipeline.jsonl`. To ship long-running log history off-host, forward `pipeline.jsonl` to syslog / Loki / Datadog from the host.
 
 ---
 
 ## Stack operations
 
-Operate the stack from the host as the user that owns `/opt/stacks/findajob-{handle}/`.
+Operate the stack from the host as the user that owns the stack directory.
 
 ```bash
 # Stack status
@@ -195,9 +178,13 @@ docker compose logs -f scheduler
 
 # Drop into a shell inside the container
 docker compose exec scheduler bash
+# Fly equivalent:
+fly ssh console --app <app>
 
 # Force a one-shot run of a scheduled job (does not touch supercronic)
 docker compose exec scheduler python3 scripts/triage.py
+# Fly equivalent:
+fly ssh console --app <app> --command "python3 scripts/triage.py"
 
 # Recreate after editing data/.env or compose.yaml
 # (config/ files are hot-reloaded — no restart needed)
@@ -205,12 +192,19 @@ docker compose up -d --force-recreate
 
 # Pull a new image and recreate the container
 docker compose pull && docker compose up -d
+# Fly equivalent:
+fly deploy --config ops/fly.toml
+
+# Verify auth gate after every deploy (exit non-zero = take the stack down)
+docker compose exec scheduler python -m findajob.web.verify_auth
+# Fly equivalent:
+fly ssh console --app <app> --command "python -m findajob.web.verify_auth"
 
 # Stop the stack
 docker compose down
 ```
 
-The scheduler inside the container is **supercronic**. Schedules are declared in `ops/scheduled-jobs.yaml` and rendered to `/app/crontab` by `scripts/render_crontab.py` at entrypoint. Per-job env overrides are documented in CLAUDE.md (`FINDAJOB_<JOB>_SCHEDULE` / `FINDAJOB_<JOB>_ENABLED`).
+The scheduler inside the container is **supercronic**. Schedules are declared in `ops/scheduled-jobs.yaml` and rendered to `/app/crontab` by `scripts/render_crontab.py` at entrypoint. Per-job env overrides: `FINDAJOB_<JOB>_SCHEDULE` / `FINDAJOB_<JOB>_ENABLED`.
 
 ---
 
@@ -228,12 +222,10 @@ Queue depth, jobs added in the last 24h, in-progress applications (prepped/appli
 
 Whether triage completed in the last 25h (looks for `pipeline_complete` event in logs), error events from `pipeline.jsonl` in the last 25h, count of `manual_review` jobs (potential scoring failures), last completion timestamp.
 
-The 7h offset gives triage (which can take 30–60 min) comfortable headroom. Firing earlier would race the run.
-
 ### `apply-reminder` — Daily nudge
 **Schedule:** 06:00 daily.
 
-Rotating motivational quip + a reminder to submit one application today. Quips are mildly sarcastic tech-industry humor; edit `scripts/notify.py` to customize them.
+Rotating motivational quip + a reminder to submit one application today.
 
 ### `feedback-review` — Rejection-pattern alert
 **Schedule:** Sunday 08:00.
@@ -283,105 +275,4 @@ Notification modules live in `src/findajob/notifications/`. To add a new notific
 
 ---
 
-## Scripts reference
-
-All scripts live in `scripts/`. Diag scripts live in `scripts/diag/` and are run manually only. All scripts import `BASE` and `PANDOC` from `findajob.paths` (`src/findajob/paths.py`). Never hardcode binary paths in scripts — add overrides to `config/paths.env` instead.
-
-Each entry below carries a **Manual run** line in the Docker form (`docker compose exec scheduler …`).
-
-### Core pipeline scripts
-
-#### `triage.py`
-**Run by:** scheduler (daily 00:00 PT). No arguments.
-**Manual run:** `docker compose exec scheduler python3 scripts/triage.py`
-
-Fetches jobs from all sources, deduplicates, enriches with JD text, then scores with LLM in parallel (6 concurrent threads), writes to SQLite.
-
-**Sources:**
-- LinkedIn / Indeed via RapidAPI jobs-api14 + JSearch (per `config/active_sources.txt`).
-- Gmail IMAP (LinkedIn job alerts, Indeed digests, recruiter messages — config at `/config/gmail/`).
-- Greenhouse / Lever / Ashby JSON APIs (slugs / URLs in `config/feed_urls.txt`).
-
-**Key events logged:** `triage_started`, `job_ingested`, `job_deduplicated`, `job_scored`, `pipeline_complete`.
-
-#### `scripts/prep_application.py` (entry-point shim)
-*Entry-point shim; implementation in `src/findajob/prep/orchestrator.py`.*
-
-**Run by:** `POST /board/jobs/{fp}/prep` or `/regenerate` (detached subprocess); also callable manually. Args: `company title url job_id`.
-**Manual run:** `docker compose exec scheduler python3 scripts/prep_application.py "Acme" "Engineer" "https://..." "<job_id>"`
-
-Generates a full application package for one job. LLM calls run sequentially.
-
-**Outputs (in `companies/{Company}_{AbbrevTitle}_{date}_{time}/`):**
-- `tailored_resume_DRAFT.md` + `.docx`
-- `tailored_resume_CHANGES.md`
-- `cover_letter_DRAFT.md` + `.docx`
-- `company_briefing.md` + `.docx`
-- `outreach_*.txt` (one per matching contact, if any)
-- `job_description.txt`
-- `REVIEW_CHECKLIST.md`
-
-After completion: updates DB to `stage=materials_drafted`, sends ntfy notification.
-
-#### `watchdog.py`
-**Run by:** scheduler (every 10 min). No arguments.
-**Manual run:** `docker compose exec scheduler python3 scripts/watchdog.py`
-
-Resets any job stuck in `stage='prep_in_progress'` for more than 60 minutes back to `scored`. Calls `findajob.actions.reset_prep_to_scored()` which writes an `audit_log` row and emits `prep_failed_reset`. Emits a `watchdog_run` summary event at the end of each run.
-
-#### `notify.py`
-**Run by:** scheduler (8 subcommands; see [Notifications](#notifications) above for the per-subcommand schedule and content).
-**Manual run:** `docker compose exec scheduler python3 scripts/notify.py <subcommand>`
-
-#### `scripts/find_contacts.py` (entry-point shim)
-*Entry-point shim; implementation in `src/findajob/find_contacts.py`.*
-
-**Run by:** `scripts/prep_application.py` (step 5). Args: `company jd_text_excerpt outdir`.
-**Manual run:** `docker compose exec scheduler python3 scripts/find_contacts.py "Acme" "<jd-excerpt>" companies/<folder>`
-
-Reads `data/connections.csv`, finds LinkedIn connections at the target company, generates personalized outreach drafts via the OpenRouter wrapper.
-
-**Output:** `{outdir}/outreach_{FirstName}_{LastName}.txt` for each match.
-
-**Key guard:** `company_match()` always checks `if not s or not c: return False` — blank company strings would otherwise match everything.
-
-#### `manual_prep.py`
-**Run by:** manually (when you have a job outside the pipeline). Args: optional path to a job file (default: `manual_job.txt`).
-**Manual run:** `docker compose exec scheduler python3 scripts/manual_prep.py [path/to/job.txt]`
-
-File format:
-```
-company: CompanyName
-title: Job Title
-url: https://...
----
-Full JD text below this line
-```
-
-Inserts the job into DB and calls `scripts/prep_application.py` immediately.
-
-#### `rescore_all.py`
-**Run by:** manually (after model or prompt changes). No arguments.
-**Manual run:** `docker compose exec scheduler python3 scripts/rescore_all.py`
-
-Re-runs the scorer on all jobs that have JD text.
-
-#### `rename_folders.py`
-**Run by:** manually. No arguments.
-**Manual run:** `docker compose exec scheduler python3 scripts/rename_folders.py`
-
-Renames `companies/` folders from old format (`{Company}_{date}_{time}`) to new format (`{Company}_{AbbrevTitle}_{date}_{time}`). Looks up DB for title, updates `prep_folder_path` in DB. Safe to re-run.
-
-#### `init_db.py`
-**Run by:** once on new install. No arguments.
-**Manual run:** `docker compose exec scheduler python3 scripts/init_db.py`
-
-Creates `data/pipeline.db` with all tables. Safe to re-run — uses `CREATE TABLE IF NOT EXISTS`.
-
-### Diag scripts (`scripts/diag/`)
-
-Run manually for debugging. Not part of normal pipeline operation.
-
-#### `debug_contacts.py`
-Shows contact matching diagnostics for a batch of jobs. Useful for debugging false positive/negative company-name matches.
-**Manual run:** `docker compose exec scheduler python3 scripts/diag/debug_contacts.py`
+For a full reference of all pipeline scripts and their arguments, see `## Scripts Reference` in `CLAUDE.md`.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,89 @@
+# Updating findajob
+
+Updates bring new features, bug fixes, and improved LLM prompts. The process differs by how you deployed.
+
+---
+
+## When to update
+
+Watch [CHANGELOG.md](https://github.com/brockamer/findajob/blob/main/CHANGELOG.md) for release announcements. Updates are announced with a version number (e.g. `v0.31.0`) and a summary of what changed. You do not need to update on every release — stable deployments can skip versions and update to the latest in one step.
+
+---
+
+## Fly.io users
+
+Run this from your local copy of the repo, after any release you want to pick up:
+
+    fly deploy --config ops/fly.toml
+
+This pulls the latest image from the container registry, deploys it to your Fly machine, and restarts the container. The update takes 30–60 seconds.
+
+After deploying, verify the auth gate is still up:
+
+    fly ssh console --app findajob-<handle> --command "python -m findajob.web.verify_auth"
+
+A zero exit means the gate is active. Any non-zero exit means the stack is unverified — check `fly logs` before using the app again.
+
+> **Note:** Automated Fly updates (no manual `fly deploy` required) are planned for a future release. Until then, the one-command deploy above is the update path.
+
+---
+
+## Docker users — Watchtower enabled
+
+If your compose stack has Watchtower configured to watch the `findajob` service, updates happen automatically within an hour of each new release. No action needed — Watchtower pulls the new image and recreates the container.
+
+To confirm Watchtower is watching your service, check that your compose file does **not** have this label on the scheduler service:
+
+    com.centurylinklabs.watchtower.enable: "false"
+
+If that label is absent (or set to `"true"`), Watchtower is active.
+
+---
+
+## Docker users — manual update
+
+Pull the new image and restart the container:
+
+    docker compose pull && docker compose up -d
+
+The pull downloads the updated image from the registry. `up -d` recreates the running container using it. The container is briefly unavailable during the restart — typically under 10 seconds.
+
+---
+
+## What updates do not touch
+
+Updates replace the application code and LLM prompts inside the container. They do not touch anything in your `state/` directory.
+
+Everything in `state/` is preserved across every update:
+
+- `state/data/pipeline.db` — your job history, scores, notes, and stage transitions
+- `state/config/` — your API keys, filter rules, target companies, excluded employers
+- `state/candidate_context/` — your profile, master resume, voice samples
+- `state/companies/` — briefings, tailored resumes, cover letters, prep materials
+- `state/.backups/` — backup tarballs
+
+If a release requires a schema migration (a structural change to the database), it runs automatically on first startup after the update. The CHANGELOG entry for that release will include a `### Migration required` section describing what changes.
+
+---
+
+## Checking your version
+
+Open [CHANGELOG.md](https://github.com/brockamer/findajob/blob/main/CHANGELOG.md) — the first versioned heading (e.g. `## [0.31.3] - 2026-05-28`) is the latest release. Compare it to what your container is running.
+
+To see the version your running container was built from:
+
+    docker compose exec scheduler python3 -c "
+    from pathlib import Path
+    from findajob.paths import BASE
+    cl = Path(BASE) / 'CHANGELOG.md'
+    for line in cl.read_text().splitlines():
+        if line.startswith('## [') and ']' in line:
+            v = line.split('[',1)[1].split(']',1)[0]
+            if v[:1].isdigit():
+                print(v)
+                break
+    "
+
+For Fly deployments, prefix with `fly ssh console --app findajob-<handle> --command` instead of `docker compose exec scheduler`.
+
+This reads the CHANGELOG baked into the running image and prints the first versioned release heading — the same mechanism the pipeline uses internally.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,7 +83,7 @@ briefing again. Existing source-config files (`jsearch_queries.txt`,
 `.backups/{UTC-stamp}/` before being overwritten.
 
 ### Tuning your config without re-onboarding
-Visit `/tools/` for guided LLM prompts that produce config edits
+Visit `/tools/` for guided prompts that produce config edits
 without re-running the full interview. Three prompt tiles ship by
 default:
 
@@ -118,55 +118,18 @@ Once you've accumulated ~10+ preps, the quickest way to see this is the
 `/tools/critique-review/`) — it computes the aggregate live and renders the
 source-level fixes as cards in the browser, no terminal needed.
 
-For a written report on disk (and the `--since` / `--min-companies` knobs),
-run the CLI:
-
-```
-python scripts/critique_review.py
-```
-
 It scans every critique, anchors each flagged line back to the exact
-source line it came from (fuzzy-matched, so paraphrases still cluster),
-and writes a dated report to
-`candidate_context/critique_aggregate/<date>.md` — gitignored, because
-it quotes your real resume. The report has three parts:
+source line it came from, and organizes the findings into three parts:
 
 - **Source-level fixes** — a resume/profile line flagged by **≥3
-  different companies**, with the exact `file:line`, the recruiter's own
+  different companies**, with the exact location, the recruiter's own
   verbatim words, and a count. Fix it once, kill it across every
   application. These are sorted most-recurring first.
-- **Recurring themes** — words that keep showing up across many
+- **Recurring themes** — patterns that keep showing up across many
   critiques but don't trace to one line (often a generated cover-letter
   pattern or a profile gap). These point at a prompt or profile fix.
 - **One-offs** — lines flagged at only one company, collapsed to a
   count. Per-prep nitpicks, safe to ignore until they recur.
-
-Flags: `--since YYYY-MM-DD` limits to recent critiques; `--min-companies
-N` changes the recurrence floor (default 3); `--print` echoes the report
-to your terminal as well as writing the file.
-
----
-
-## Operator controls at /tools/
-
-`/tools/` is the operator console. Two panels:
-
-**Run a job now.** Buttons for the six high-value cron jobs (triage, detect-rejections, discover, notify-health, notify-stats, watchdog). Each tile shows when the cron last ran and whether one is in flight right now. Cost-bearing crons (triage, discover) ask you to confirm in the browser before launching, and refuse with a 402 page when the monthly LLM spend ceiling is reached.
-
-| Cron | When to fire manually |
-|---|---|
-| Triage | Morning after a scorer prompt change; after a JD-fetcher fix; when you want fresh data NOW instead of waiting for 00:00 PT. |
-| Detect rejections | A rejection email just landed and you want it surfaced in `/board/rejections-review/` immediately. |
-| Discover | Just edited `profile.md` or re-ran onboarding; want fresh `discovered_companies` without waiting for Sunday 02:00. |
-| Notify: health | Want to verify the health-check works before relying on the morning push. |
-| Notify: stats | Preview today's stats push on demand. |
-| Watchdog | Clear any prep job stuck in `prep_in_progress` immediately rather than wait up to 10 minutes for the next cron. |
-
-If a button is greyed out and shows "Running…", the cron is currently in flight (either fired by cron or by an earlier button click). Re-fire only after it finishes — the dispatcher will 409 a concurrent click anyway.
-
-**Pipeline log viewer** (`/tools/logs/pipeline/`). Tail of the last 200 events from `logs/pipeline.jsonl`, newest first. Replaces `ssh + tail -f` for the common case. Filter by event name via the dropdown (typeahead from observed names in the window). v1 limitations: no severity filter, no time-range filter, no auto-refresh, no rotated-file (`.gz`) traversal — refresh the page to pull new events.
-
-**Guided prompts** below the trigger panel is the original `/tools/` surface from #150 — unchanged. Use these when you want to chat with an external LLM (Claude.ai) about config edits that don't have a dedicated UI yet.
 
 ---
 
@@ -180,7 +143,7 @@ A filter row sits directly under each column header. TEXT columns (Title, Compan
 
 Below the table header, active filters appear as a chip strip — click ✕ on any chip to remove that filter, or **Clear all** to reset everything. The 🔗 Copy link button in the top-right copies the current URL (with all active filters and sort) to the clipboard, making any view bookmarkable and shareable.
 
-To browse score-5/6 jobs that the default 7+ cutoff hides (useful for triage), visit:
+To browse lower-scored jobs that the default cutoff hides (useful for triage), visit:
 `/board/dashboard?relevance_score_min=5&stage=scored,manual_review`
 
 Sort is sticky with filters — changing the sort column preserves all active filters, and adding a filter preserves the current sort.
@@ -203,7 +166,7 @@ A job scoring 9 / 9 / 9 is unusual — most good jobs score 7–8 on two of the 
 
 | Option | What happens |
 |---|---|
-| **Flag for Prep** | Starts `prep_application.py` in the background. Stage → `prep_in_progress`. You'll get an ntfy ping when it finishes (~3–5 min). |
+| **Flag for Prep** | Starts materials generation in the background. You'll get an ntfy ping when it finishes (~3–5 min). |
 | **Regenerate** | Re-runs prep with fresh output (profile changed, model flaked, first pass was off). |
 | **Applied** | You already applied through another channel; skip prep and jump straight to the Applied tab. |
 | **Waitlist** | Defer. The job stays in the DB but moves off the Dashboard. Not a rejection — see *Waitlist* below. |
@@ -235,15 +198,9 @@ A reason you remove from the taxonomy doesn't break older rejections that used i
 
 ## What happens when you Flag for Prep
 
-Prep is the heaviest LLM step — it uses Claude Opus to write a tailored resume and cover letter, Perplexity Sonar Pro for company research, and a few Sonnet roles for the outreach drafts. It costs roughly $1.50–$3.00 per job.
+Prep is the heaviest AI step — it uses Claude Opus to write a tailored resume and cover letter, Perplexity Sonar Pro for company research, and a few lighter-weight models for the outreach drafts. It costs roughly $1.50–$3.00 per job.
 
-**Stage progression:**
-
-```
-scored → prep_in_progress → materials_drafted → applied
-                         ↓
-                       (failure/timeout → scored, retry via watchdog after 60 min)
-```
+Prep runs in the background. An ntfy notification arrives when materials are ready (~3–5 minutes). If the run doesn't complete within an hour, the job returns to your dashboard automatically and you can try again.
 
 **Output:** a folder under `companies/{Company}_{AbbrevTitle}_{YYYY-MM-DD}_{HHMMSS}/` containing:
 
@@ -256,19 +213,19 @@ scored → prep_in_progress → materials_drafted → applied
 | `network_outreach_*.md` | Drafts for messaging LinkedIn connections at the company |
 | `job_description.md` | JD snapshot from ingest (so you don't re-fetch the URL) |
 
-**Viewing materials:** the web UI at `/materials/<folder>/` renders everything inline — Markdown is styled, the JD is linked, `.docx` is offered as a download. You don't need to `scp` or sync anything.
+**Viewing materials:** the web UI at `/materials/<folder>/` renders everything inline — Markdown is styled, the JD is linked, `.docx` is offered as a download. You don't need to sync or copy anything.
 
 ---
 
 ## The Review tab (`/board/review`)
 
-Jobs land here when the scorer's output couldn't be confidently validated — the LLM said "needs human review," or returned a low-confidence fit/probability split, or the JD was thin. `stage = manual_review`.
+Jobs land here when the scorer's output couldn't be confidently validated — the AI said "needs human review," or returned a low-confidence fit/probability split, or the JD was thin.
 
 The tab has the same per-column filter row as the Dashboard: substring inputs for Title and Company, a popover (▾) for Source and Date. Active-filter chips appear below the header with ✕ to dismiss individually or **Clear all** to reset. The 🔗 Copy link button copies the current filtered URL to the clipboard.
 
 Use the tab to:
 
-- **Promote** → move the job to `scored` so it appears on the Dashboard.
+- **Promote** → move the job to your Dashboard for consideration.
 - **Reject** → same rejection flow as the Dashboard; pick a reason.
 
 A healthy pipeline has a small (under 20) steady state on Review. If the queue grows past 100, the health check fires a warning — tune the profile or adjust the scoring threshold.
@@ -285,9 +242,9 @@ A filter row sits under each column header: substring inputs for Title, Company,
 
 | Option | What it means |
 |---|---|
-| **Interviewing** | Got a reply, scheduled something. Row turns purple. |
+| **Interviewing** | Got a reply, scheduled something. Row turns purple. findajob also generates interview-prep materials in your folder for that job. |
 | **Offer** | Got the offer. Row turns gold. |
-| **Not Selected** | Company passed. Use the REJECT_REASON dropdown to record why (ghosted → "Other" with a note, formal rejection → pick the closest reason). The job stays on Applied — rejections from companies don't feed the scorer the way your own reject-with-reason calls do. |
+| **Not Selected** | Company passed. Use the REJECT_REASON dropdown to record why (ghosted → "Other" with a note, formal rejection → pick the closest reason). The job stays on Applied — company rejections don't feed the scorer the way your own reject-with-reason calls do. |
 | **Withdrew** | You pulled out. |
 
 ### Row color coding (silent = likely ghosted)
@@ -303,11 +260,11 @@ A filter row sits under each column header: substring inputs for Title, Company,
 
 ### `days_since_applied` is live
 
-The column renders from the DB on every page load, so it's always current.
+The column renders from the database on every page load, so it's always current.
 
 ### `user_notes` — free text
 
-The notes field saves on 800 ms debounce. Type, pause, it's written. Useful for logging follow-up dates, interview feedback, or "Jess gave me a referral link 2026-05-02."
+The notes field saves on 800 ms debounce. Type, pause, it's written. Useful for logging follow-up dates, interview feedback, or "Alex gave me a referral link 2026-05-02."
 
 ---
 
@@ -317,11 +274,11 @@ Waitlisted jobs are jobs you didn't want to reject — maybe the role is good bu
 
 The tab has the same per-column filter row: substring inputs for Title, Company, and Location; min/max range inputs for Rel, Fit, and Likelihood; a popover (▾) for Remote and Date. Active-filter chips and the 🔗 Copy link button work the same way as on the Dashboard.
 
-**Waitlist is not rejection.** It does *not* write to the feedback log. The scorer never sees it.
+**Waitlist is not rejection.** Your waitlisted jobs never feed back into the scorer's training.
 
 From the tab:
 
-- **Reactivate** → back to `scored`, appears on the Dashboard again.
+- **Reactivate** → back on the Dashboard again.
 - **Reject** → standard reject flow; pick a reason.
 
 **Waitlist resurface:** when an active application at the same company ends in rejection or withdrawal, ntfy fires a notification pointing back at the waitlisted job. ("You waitlisted *Acme — Ops Lead*. Your *Acme — Site Manager* application was just rejected. Reconsider?")
@@ -339,10 +296,10 @@ Jobs you withdrew from but might revisit if your other opportunities fall throug
 **What you see:** title, company, withdraw reason, withdraw date, relevance score, location, remote status, and notes. The same per-column filter framework as other tabs.
 
 **Actions:**
-- **Promote** — restores the job to its prior stage (usually `applied` or `interview`). The row leaves the Fallback tab.
-- **Reject** — rejects the job normally (writes `feedback_log`, moves folder to `_rejected/`).
+- **Promote** — restores the job to its prior stage (usually Applied or Interviewing). The row leaves the Fallback tab.
+- **Reject** — rejects the job normally (reasons feed the scorer).
 
-**Fallback is not rejection.** It does *not* write to `feedback_log`. The scorer never sees it.
+**Fallback is not rejection.** Your fallback jobs never feed back into the scorer's training.
 
 ---
 
@@ -354,13 +311,13 @@ Every job the pipeline has ever ingested, in one paginated, filterable, sortable
 
 ## The Rejected tab (`/board/rejected`)
 
-Every rejection, including rejections *from* you (stage = `rejected`) and rejections *from companies* (stage = `not_selected`). The per-column filter row lets you narrow by Title or Company (substring), Reject Reason (popover multi-select), Stage (rejected vs. not_selected), and Date range. Active-filter chips appear below the header with ✕ to clear individual filters or **Clear all** to reset. The 🔗 Copy link button copies the current filtered URL. Useful for catching patterns — if `Skills Mismatch` is spiking, the profile's wrong; if `Geography/Onsite` is spiking, the search queries are.
+Every rejection, including rejections *from* you and rejections *from companies*. The per-column filter row lets you narrow by Title or Company (substring), Reject Reason (popover multi-select), Stage, and Date range. Active-filter chips appear below the header with ✕ to clear individual filters or **Clear all** to reset. The 🔗 Copy link button copies the current filtered URL. Useful for catching patterns — if `Skills Mismatch` is spiking, the profile's wrong; if `Geography/Onsite` is spiking, the search queries are.
 
 ---
 
 ## Auto-detected company rejections (`/board/rejections-review/`)
 
-When Gmail integration is configured, a background scan runs every 30 minutes against your inbox looking for company rejection emails (Greenhouse, Ashby, Lever, Workday-style, in-house ATS senders). Hits are matched against your active applications and surfaced as a review queue — **never auto-applied**. You confirm with one click and the row transitions to `not_selected` through the same `handle_not_selected` path the manual Reject button uses, with `audit_log.changed_by='gmail_rejection_detector'` so the trail distinguishes Gmail-confirmed from manual transitions later.
+When Gmail integration is configured, a background scan runs every 30 minutes against your inbox looking for company rejection emails (Greenhouse, Ashby, Lever, Workday-style, and in-house ATS senders). Hits are matched against your active applications and surfaced as a review queue — **never auto-applied**. You confirm with one click and the row transitions to Not Selected the same way the manual button does.
 
 **Where to find it:**
 
@@ -369,30 +326,23 @@ When Gmail integration is configured, a background scan runs every 30 minutes ag
 
 **Per-card actions:**
 
-- **Confirm** — applies `not_selected` to the matched job. The matched-job stage must be `applied`/`interview`/`offer`; otherwise the endpoint 409s and you reattribute.
-- **Dismiss** — operator says "this isn't a rejection." The job's stage stays put; the suggestion is marked `dismissed`.
-- **Reattribute** — paste a different `jobs.id` if the matcher picked the wrong row (e.g. a duplicate application at the same company). Applies `not_selected` to the chosen job and records `user_chose_job_id` for traceability.
+- **Confirm** — marks the matched job as Not Selected.
+- **Dismiss** — says "this isn't a rejection." The job's stage stays put; the suggestion is archived.
+- **Reattribute** — paste a different job ID if the matcher picked the wrong row (e.g. a duplicate application at the same company).
 
-Rows that the matcher couldn't auto-link to a current application surface as `unmatched` cards — Confirm is hidden, Reattribute or Dismiss are the only paths. The most common cause is **company-name aliasing**: the email's sender display name or body refers to a brand name that doesn't match `jobs.company`. To fix, add an entry to `config/company_aliases.yaml` via the `/config/` editor (the matcher hot-reloads on every cycle — no redeploy):
+Rows that the matcher couldn't automatically link to a current application show as unmatched cards — Confirm is hidden; Reattribute or Dismiss are the only paths. The most common cause is **company-name aliasing**: the email's sender display name doesn't match the company name stored for the job. To fix, add an entry to `config/company_aliases.yaml` via the `/config/` editor (the matcher reloads on every scan — no redeploy):
 
 ```yaml
 # alias-or-display-name: canonical-DB-company
 cobot: collaborative robotics
 ```
 
-**Schedule and triggers:**
-
-- Steady-state: every 30 minutes via supercronic (`detect-rejections` job in `ops/scheduled-jobs.yaml`). Per-stack timeout override via `FINDAJOB_DETECT_REJECTIONS_TIMEOUT` in `data/.env`.
-- First run on a stack: a backlog sweep over the prior 30 days (capped at 60) so existing inbox rejections aren't lost. Sentinel `gmail_state.json:rejection_backlog_scan_complete` flips on success.
-- One-shot historical rescan: `docker exec -u 1000 <container> python scripts/detect_rejections.py --since-days N` bypasses the UID checkpoint and date-windows the IMAP search to the prior `N` days (capped at 60). Use after adding a sender to the allowlist to resurface emails that arrived before the addition. The `-u 1000` is required — bare `docker exec` runs as root and would write a root-owned `gmail_state.json`, breaking subsequent cron ticks. Does not mutate the backlog sentinel or roll the UID checkpoint backward; `INSERT OR IGNORE` on `gmail_message_id` makes the operation safe to re-run.
-- A single ntfy notification fires when new suggestions land — opens directly to the review queue.
-
 **Caveats:**
 
 - **LinkedIn doesn't relay rejection emails** — applications submitted via LinkedIn's apply-on-LinkedIn flow get application receipts but not company-side rejections. This is a structural coverage gap, not a detector flaw. For LinkedIn-applied jobs, manual flips remain the path.
-- **HTML-only senders** (some Microsoft / Oracle / Smartrecruiters templates) are handled by a `bs4` fallback in the parser; if a particular sender shape produces empty bodies, you'll see it in `pipeline.jsonl` and the suggestion just won't surface — log a follow-up issue.
-- **Confirmed and dismissed rows are kept** as a write-once dedup log keyed by `gmail_message_id` (so re-running the scan doesn't re-suggest the same email). They don't appear in the queue but are queryable in `rejection_suggestions`.
-- **Already-handled rejections** (the operator already moved the job to `not_selected`/`rejected` before the detector caught up) emit a `rejection_email_corroborated` event in `pipeline.jsonl` and skip the queue, so the review surface stays focused on actionable rows.
+- **HTML-only senders** (some Microsoft / Oracle / Smartrecruiters templates) are handled by a fallback parser; if a particular sender shape produces empty bodies, you'll see it in the pipeline log and the suggestion just won't surface — log a follow-up issue.
+- **Confirmed and dismissed rows are kept** as a dedup log so re-running the scan doesn't re-suggest the same email. They don't appear in the queue.
+- **Already-handled rejections** (you already moved the job to Not Selected before the detector caught up) are skipped silently, so the review surface stays focused on actionable rows.
 
 ---
 
@@ -403,6 +353,10 @@ Three ways to get here:
 - Click the company name on any Dashboard / Applied / Waitlist row — the cell is a link to the materials folder.
 - Click a materials-folder name directly in the URL bar.
 - `/materials/` root → index of every folder ever created.
+
+Each folder renders its Markdown files inline and offers `.docx` downloads. The JD is linked back to the original posting URL. All served locally — no Drive sync, no rclone.
+
+**Interview prep:** when you mark a job as Interviewing, findajob generates an interview-prep document in the folder — company background, likely question themes, and talking-point prompts tailored to the role. If a recruiter sends updated panel details or you want a fresh pass, click **Re-run interview prep** on the materials page to regenerate it. The button appears whenever the job is at the Interviewing stage.
 
 ---
 
@@ -422,68 +376,14 @@ When you want to reach out to a company that isn't currently posting a matching 
 5. Three actions:
    - **Approve kept cards** — each kept card becomes a `[SPEC]`-prefixed row on the dashboard, ready for prep. Trashed cards are dropped silently.
    - **Regenerate** — re-runs the synthesizer (briefing is preserved on retries to save the expensive Deep Research call). Status page polls again.
-   - **Trash** — drops the whole submission. No `jobs` rows are written.
+   - **Trash** — drops the whole submission. No rows are written.
 6. Approved rows show on the **Dashboard** with a small purple **SPEC** badge and the `[SPEC]` title prefix. Flag them for prep just like a real row. The cover letter and outreach draft will be written in cold-outreach mode automatically (acknowledges no posting exists, leads with hiring-signal from the briefing, ends with a low-pressure ask).
 7. Send the outreach. Then click **Sent Outreach** on that row (replaces the **Applied** dropdown option for speculative rows). The transition counts toward the apply-gate the same way a normal application does.
 
-**Costs:** ~$0.25–$0.75 per speculative submission (Perplexity Deep Research is more expensive than the regular `sonar-reasoning-pro`). The form soft-warns you if you've already submitted today; there's no hard cap.
+**Costs:** ~$0.25–$0.75 per speculative submission (Perplexity Deep Research is more expensive than the regular search option). The form soft-warns you if you've already submitted today; there's no hard cap.
 
 **Failure modes:**
-- If research fails (LLM error, rate limit), the status page shows the error with **Retry** and **Trash** buttons. Retry skips the briefing call if it already succeeded; only the cheap synth step re-runs.
-- If the subprocess dies silently (OOM, container restart), the watchdog flips rows stuck in `researching` for >10 minutes to `failed` so the status page surfaces the retry option instead of polling forever.
+- If research fails (AI error, rate limit), the status page shows the error with **Retry** and **Trash** buttons. Retry skips the briefing call if it already succeeded; only the cheaper synthesis step re-runs.
+- If the process stops unexpectedly (server restart), the watchdog surfaces a retry option within 10 minutes instead of leaving the status page polling forever.
 
-**Synthetic rows are firewalled from the scorer:** rejecting a `[SPEC]` row never writes to `feedback_log`, so synthesizer hallucinations cannot drift the scorer's training history. The guard is enforced at write time (`handle_rejection`) and read time (scorer feedback loader).
-
-Each folder renders its Markdown files inline and offers `.docx` downloads. The JD is linked back to the original posting URL. All served locally — no Drive sync, no rclone.
-
----
-
-<details>
-<summary><strong>For advanced users: stage names and POST handlers</strong></summary>
-
-**Canonical stage names in the DB** (`jobs.stage` column):
-
-| Stage | Meaning |
-|---|---|
-| `scored` | Triaged, LLM-scored, appears on Dashboard |
-| `manual_review` | Scorer flagged as uncertain; appears on Review tab |
-| `prep_in_progress` | `prep_application.py` running; watchdog clears stuck jobs after 60 min |
-| `materials_drafted` | Prep completed; materials folder exists; Dashboard STATUS shows *Ready to Apply* |
-| `applied` | You submitted; appears on Applied |
-| `interview` / `offer` | Post-application progress; appears on Applied |
-| `rejected` | User rejection with reason; writes to `feedback_log`; folder moves to `companies/_rejected/` |
-| `not_selected` | Company rejection; does NOT write to `feedback_log` (don't poison the scorer); folder stays in `companies/_applied/` with a `NOT_SELECTED_*.txt` marker |
-| `withdrawn_fallback` | Withdrew but might revisit; folder stays in `companies/_applied/`; scorer never sees it |
-| `waitlisted` | Deferred; folder moves to `companies/_waitlisted/`; scorer never sees it |
-
-**Every STATUS dropdown action is a POST handler.** `findajob.web.routes.board_actions` contains one handler per transition; each calls straight into `findajob.actions` and responds in the same request. The handlers are:
-
-- `/board/jobs/{fp}/prep` — Flag for Prep
-- `/board/jobs/{fp}/regenerate` — Regenerate
-- `/board/jobs/{fp}/apply` — Applied
-- `/board/jobs/{fp}/waitlist` — Waitlist
-- `/board/jobs/{fp}/reject` — Reject (with REJECT_REASON)
-- `/board/jobs/{fp}/interview` / `/offer` / `/withdraw` — post-application
-- `/board/jobs/{fp}/withdraw-as-fallback` — Withdraw as Fallback (Applied tab)
-- `/board/jobs/{fp}/not-selected` — Not Selected (with REJECT_REASON)
-- `/board/jobs/{fp}/promote` — Review → scored
-- `/board/jobs/{fp}/reactivate` — Waitlist → scored
-- `/board/jobs/{fp}/mark-as-fallback` — Archive withdrawn → Fallback
-- `/board/jobs/{fp}/promote-from-fallback` — Fallback → prior stage
-- `/board/jobs/{fp}/notes` — user_notes save
-
-No poll cycle. The web UI is the canonical surface for everything — board state, materials, stats, ingest.
-
-**Scheduler timing:**
-
-| Timer | Cadence | What it does |
-|---|---|---|
-| triage | 00:00 daily | Fetch + clean + score; writes `pipeline_complete` event |
-| watchdog | every 10 min | Resets jobs stuck in `prep_in_progress` > 60 min |
-| notify-apply | 06:00 daily | "Time to triage" ntfy |
-| notify-stats | 06:15 daily | Morning funnel summary |
-| notify-health | 07:00 daily | Health-check alerts via ntfy |
-
-Running inside the container as supercronic jobs; `docker compose logs scheduler` to see them fire.
-
-</details>
+**Speculative rejections don't affect your scorer:** rejecting a `[SPEC]` row never feeds the scorer's training history, so synthesizer guesses can't distort your future recommendations.

--- a/scripts/test_container_integration.sh
+++ b/scripts/test_container_integration.sh
@@ -309,7 +309,7 @@ echo "  index renders with expected sections"
 # Slug list mirrors a representative subset of findajob.web.routes.docs._PAGES;
 # `setup/*` was renamed to `getting-started/*` in the May-8 docs cleanup
 # (#499–#503) and this list followed in v0.22.
-for slug in "" usage tuning troubleshooting getting-started operations/install-docker getting-started/install-fly getting-started/start-here-fly getting-started/cost; do
+for slug in "" usage tuning troubleshooting updating getting-started operations/install-docker getting-started/install-fly getting-started/start-here-fly getting-started/cost; do
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${VIEWER_PORT}/docs/${slug}" || echo "FAIL")
     if [ "$HTTP_CODE" != "200" ]; then
         echo "ERROR: /docs/${slug} returned $HTTP_CODE (expected 200)" >&2

--- a/src/findajob/web/routes/docs.py
+++ b/src/findajob/web/routes/docs.py
@@ -26,6 +26,7 @@ _PAGES: dict[str, str] = {
     "usage/expanding-sources": "usage/expanding-sources.md",
     "tuning": "tuning.md",
     "troubleshooting": "troubleshooting.md",
+    "updating": "updating.md",
     # Operations
     "operations": "operations/README.md",
     "operations/fly-deploy": "operations/fly-deploy.md",


### PR DESCRIPTION
Epic **#923** — six independent Documentation v2 rewrites, each scoped to a distinct file so they were drafted in parallel (one sub-agent per file) and integrated as one diff. No two children touch the same file.

## Children
| # | File | Change |
|---|------|--------|
| #908 | `getting-started/api-keys.md` | OpenRouter-first; RapidAPI optional w/ skip consequence; legacy env vars behind Advanced fold; cost footnotes kept (273→218) |
| #905 | `usage.md` | drop operator POST-handler/stage tables + `/tools/` controls; keep daily-loop + tab guide; reflect #875 re-run interview-prep button (489→389) |
| #910 | `updating.md` **(new)** | Fly / Docker+Watchtower / Docker-manual update paths; `state/` preservation; version check; wired into `/docs/` `_PAGES` + smoke slug |
| #912 | `CONTRIBUTING.md` | slim 198→67; dev setup + commit conventions + PR process; invariants point at CLAUDE.md/architecture.md |
| #909 | `maintainers/generalization.md` | contributor-audience framing; shipped items → one-liners; open-items + self-check kept (180→69) |
| #913 | `operations/README.md` | trim to operator essentials w/ Docker+Fly command pairs (387→278); script reference absorbed into `CLAUDE.md` § Scripts Reference (CLAUDE.md change is **purely additive**, 107+/0−) |

## Review pass (opus) — fixes folded in
- `CLAUDE.md` § Scripts Reference: corrected `notify.py` to **5 subcommands** (was wrongly "8" in the new content; `COMMANDS` dict has 5).
- `operations/README.md` step 4: removed claim of a nonexistent `Ready to Apply` auto-stage; prep clears to `briefing_ready` then materials review.
- Adjudicated two writer-flagged drops as keep-dropped (CONTRIBUTING dependency checklist not lost-critical; api-keys Anthropic-billing nuance obsolete post-#250, Indeed/Bing opt-in already covered in usage.md).

## Test plan
- [x] `docs.py` valid Python; `ruff check` + `ruff format --check` pass on the changed file
- [x] `_PAGES["updating"]` registered and present in `scripts/test_container_integration.sh` slug loop (mirrors the route — no slug drift)
- [x] `CLAUDE.md` diff is additive-only (`git diff --numstat` = 107/0)
- [x] pre-commit PII scan passed (53 patterns × 459 added lines)
- [x] opus review: AC compliance per child, internal-link integrity across changed files, PII/topology scan
- [ ] **Not run:** full container-integration smoke (`scripts/test_container_integration.sh`) — requires a Docker image build; the slug addition is verified statically against `_PAGES`
- [ ] **Not run:** browser render of `/docs/updating` — verified by static `_PAGES` registration + valid-markdown only

## Notes
- Epic #923 closes when all 6 children close; GitHub does not auto-close the parent from native sub-issues, so I'll close #923 manually after merge.
- Out of scope (filed separately at wrap): `getting-started/cost.md` and `install-fly.md` link to the pre-#904 `install-docker.md` path — a latent #904 relocation miss, not introduced here.

Closes #908, #905, #910, #912, #909, #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)