### PR TITLE
docs(v2 P3.1): humanize onboarding jargon for non-technical users (#917)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
-## [0.31.3] — 2026-05-30
+### Changed
+
+- **Onboarding copy humanized** (#917): Plain-English rewrite of the developer jargon every new user reads during onboarding. "Your seven config files are installed" → "Your profile and settings are saved"; "Discovery deferred to the weekly cron … the next Sunday 02:00 cron run" → "We'll look for companies automatically once a week … the next weekly run (Sunday mornings)"; "All required blocks have been emitted … write your config files atomically" → "Everything we need is ready … save your settings"; "this container's environment" / "this stack's `data/.env`" / "per-stack key isolation" → "your findajob". The length-error recovery message drops `max_tokens`/`emit` wording. Malformed-response errors no longer show the user the raw upstream body and "unexpected response shape" jargon: the interview-turn error and the Step 1 key-verification smoke check (which deliberately share wording) both now say a plain "Something unexpected happened. Try again." / "OpenRouter sent back a response findajob couldn't read…", with the diagnostic detail moved to a `logging.warning` for the operator. The jargon term `container` survives only in a literal `docker logs` command example. "your findajob" is adopted as the canonical phrasing the deferred per-surface polish (#919) will apply consistently elsewhere.
 
 ### Added
 

--- a/src/findajob/onboarding/interview_runner.py
+++ b/src/findajob/onboarding/interview_runner.py
@@ -11,6 +11,8 @@ directly. Callers (``routes/onboarding_interview.py``) must drop that argument.
 
 from __future__ import annotations
 
+import logging
+
 from findajob.llm.openrouter import LLMSpendCeilingExceeded, OpenRouterError, complete
 
 # Model pin retained as module-level constants so existing imports in
@@ -51,10 +53,11 @@ class InterviewRunnerError(Exception):
 def _translate(e: OpenRouterError | LLMSpendCeilingExceeded) -> InterviewRunnerError:
     """Map OpenRouterError or LLMSpendCeilingExceeded to an InterviewRunnerError.
 
-    Strings are byte-identical to the messages that the Phase 1 inline HTTP
-    client produced. Dynamic data (status_code, reason, body snippet) is
-    reconstructed from the wrapper's kind/status_code/message fields so the
-    chat UI banner renders the same text it always has.
+    Most user messages mirror the Phase 1 inline HTTP client's text, with
+    dynamic data (status_code, reason) reconstructed from the wrapper's
+    kind/status_code/message fields. The ``malformed`` and ``length`` cases
+    were humanized for non-technical onboarding users (#917) — the malformed
+    upstream detail now goes to a log line rather than the chat UI banner.
     """
     if isinstance(e, LLMSpendCeilingExceeded):
         msg = (
@@ -100,8 +103,10 @@ def _translate(e: OpenRouterError | LLMSpendCeilingExceeded) -> InterviewRunnerE
         reason = _extract_network_reason(raw)
         msg = f"Could not reach OpenRouter ({reason}). Check the deployment's network connectivity and try again."
     elif kind == "malformed":
-        # Wrapper uses short prefixes; map to Phase 1's longer strings.
-        msg = _map_malformed(raw)
+        # The exact upstream shape isn't actionable for the user — show a
+        # plain message and keep the diagnostic detail in the logs (#917).
+        logging.getLogger(__name__).warning("malformed interview response: %s", _map_malformed(raw))
+        msg = "Something unexpected happened. Try again."
     elif kind == "config":
         msg = (
             "No OpenRouter key on file for this stack. Visit /onboarding/ "
@@ -110,9 +115,8 @@ def _translate(e: OpenRouterError | LLMSpendCeilingExceeded) -> InterviewRunnerE
         )
     elif kind == "length":
         msg = (
-            "OpenRouter capped this response at the max_tokens limit — your "
-            "input is too long for a single emit. Trim the longest block "
-            "(usually voice samples) to a shorter version and try again."
+            "Your reply was too long and got cut off. Trim the longest part "
+            "(usually your voice samples) to something shorter and try again."
         )
     else:
         raw_msg = raw.removeprefix("Unexpected error: ")
@@ -131,8 +135,12 @@ def _extract_network_reason(raw: str) -> str:
 
 
 def _map_malformed(raw: str) -> str:
-    """Map wrapper's short malformed messages to Phase 1's longer strings."""
-    # Wrapper prefix → Phase 1 prefix mapping
+    """Expand the wrapper's short malformed prefixes into a diagnostic string.
+
+    The result is logged for operator diagnosis, not shown to the user — the
+    user sees a plain "Something unexpected happened" message (#917).
+    """
+    # Wrapper prefix → diagnostic detail mapping
     if raw.startswith("Non-JSON response:"):
         body_snippet = raw[len("Non-JSON response:") :].lstrip()
         return f"OpenRouter returned non-JSON response: {body_snippet}"

--- a/src/findajob/onboarding/openrouter_smoke.py
+++ b/src/findajob/onboarding/openrouter_smoke.py
@@ -12,6 +12,7 @@ Pure stdlib (urllib + json) — no new dependencies.
 from __future__ import annotations
 
 import json
+import logging
 import urllib.error
 import urllib.request
 
@@ -92,15 +93,19 @@ def verify_openrouter_key(api_key: str) -> tuple[bool, str | None]:
     try:
         data = json.loads(body)
     except json.JSONDecodeError:
+        logging.getLogger(__name__).warning("OpenRouter key smoke: non-JSON response: %s", body[:200])
         return False, (
-            f"OpenRouter returned non-JSON response: {body[:200]}. "
-            "Check OpenRouter status at https://status.openrouter.ai/."
+            "OpenRouter sent back a response findajob couldn't read — this "
+            "usually means OpenRouter is having a problem. Check its status "
+            "at https://status.openrouter.ai/ and try again."
         )
 
     if not isinstance(data, dict) or not data.get("choices"):
+        logging.getLogger(__name__).warning("OpenRouter key smoke: unexpected response shape: %s", body[:200])
         return False, (
-            f"OpenRouter returned unexpected response shape: {body[:200]}. "
-            "Check OpenRouter status at https://status.openrouter.ai/."
+            "OpenRouter sent back an unexpected response — this usually means "
+            "OpenRouter is having a problem. Check its status at "
+            "https://status.openrouter.ai/ and try again."
         )
 
     return True, None

--- a/src/findajob/web/templates/onboarding/_auth_form.html
+++ b/src/findajob/web/templates/onboarding/_auth_form.html
@@ -1,9 +1,9 @@
 {# Step 0 — Instance password setup (#895).
 
 Conditional — only rendered when FINDAJOB_AUTH_USER / FINDAJOB_AUTH_PASS
-are not set (neither env vars nor data/.env).  When auth is already
-configured (via Fly secrets or a prior onboarding run) this partial is
-not included at all.
+are not set (neither as environment variables nor in the saved config).
+When auth is already configured (via Fly secrets or a prior onboarding
+run) this partial is not included at all.
 
 After submit the middleware activates immediately and the browser will
 prompt for Basic Auth on the next request — the user re-enters the
@@ -28,9 +28,9 @@ credentials they just set (one-time confirmation).
   <div class="border border-blue-300 bg-blue-50 text-blue-900 px-3 py-2 rounded text-sm space-y-1">
     <p class="font-medium">One-time setup token required</p>
     <p>
-      Look at your container's startup logs and search for
+      Look at your findajob's startup logs and search for
       <code>FINDAJOB_SETUP_TOKEN=</code> — paste that value below. This
-      stops anyone who scans the public URL from setting your password
+      stops anyone who finds the public URL from setting your password
       before you do.
     </p>
     <p class="text-xs">
@@ -55,7 +55,7 @@ credentials they just set (one-time confirmation).
       <input type="text" name="setup_token" id="setup_token"
              autocomplete="off" spellcheck="false"
              class="w-full border rounded p-2 font-mono text-xs"
-             placeholder="from container logs"
+             placeholder="from your startup logs"
              required>
     </div>
     {% endif %}

--- a/src/findajob/web/templates/onboarding/_keys_form.html
+++ b/src/findajob/web/templates/onboarding/_keys_form.html
@@ -10,7 +10,7 @@ Three render branches:
 
 2. `env_keys_available=True` (#676) — OPENROUTER_API_KEY / RAPIDAPI_KEY are
    present in `os.environ` (Fly secrets, compose env_file, or any other
-   delivery path that reaches the container's environment) AND no SQLite
+   delivery path that reaches the process environment) AND no SQLite
    credentials row exists yet. Renders masked tails + a "Use detected
    keys" button (POST /onboarding/keys/use-detected — re-reads env vars
    server-side, no secrets in hidden inputs) and an "Enter keys manually"
@@ -28,7 +28,7 @@ Three render branches:
   {% if keys_collected %}
   <div class="space-y-2 text-sm">
     <p class="text-slate-700">
-      Your keys are collected and ready. They live only in this stack's <code>data/.env</code>.
+      Your keys are saved and ready. They're stored privately in your own findajob — nowhere else.
     </p>
     <ul class="list-disc list-inside text-slate-700">
       <li>OpenRouter — <code>***{{ openrouter_last4 }}</code></li>
@@ -53,7 +53,7 @@ Three render branches:
   {% elif env_keys_available %}
   <div class="space-y-3 text-sm">
     <p class="text-slate-700">
-      Detected API keys already set in this container's environment (e.g. Fly secrets,
+      We found API keys already set up for your findajob (for example, Fly secrets or a
       <code>compose env_file</code>). Use these to skip re-entering them:
     </p>
     <ul class="list-disc list-inside text-slate-700">
@@ -90,7 +90,7 @@ Three render branches:
   {% endif %}
 
   <p class="text-sm text-slate-700">
-    Provide your own API keys so this stack runs on your accounts, not someone
+    Provide your own API keys so your findajob runs on your accounts, not someone
     else's. Full walk-through:
     <a class="underline" href="/docs/getting-started/api-keys" target="_blank" rel="noopener">how to get each key</a>.
   </p>

--- a/src/findajob/web/templates/onboarding/_turn.html
+++ b/src/findajob/web/templates/onboarding/_turn.html
@@ -9,7 +9,7 @@
      user_message        — raw user text (auto-escaped in bubble)
      assistant_message   — raw assistant text (stored in DB)
      assistant_message_html — pre-rendered HTML from render_chat_assistant_html()
-                              (emitted via | safe in bubble)
+                              (rendered via | safe in bubble)
 
    When the latest captured-blocks count satisfies ALLOWED_FILENAMES, an OOB
    swap injects the finalize block into #finalize-slot in interview.html.
@@ -46,8 +46,8 @@
          class="border border-green-300 bg-green-50 rounded p-4 space-y-3 mt-4">
   <h2 class="font-semibold text-green-900">Finalize onboarding</h2>
   <p class="text-sm text-green-900">
-    All required blocks have been emitted. Click Finalize and we'll verify
-    your OpenRouter key and write your config files.
+    Everything we need is ready. Click Finalize and we'll check your
+    OpenRouter key and save your settings.
   </p>
   {% if keys_collected %}
   <p class="text-xs text-green-900">

--- a/src/findajob/web/templates/onboarding/_turn_bubble.html
+++ b/src/findajob/web/templates/onboarding/_turn_bubble.html
@@ -11,7 +11,7 @@
                         before the template is invoked)
 
    User turns: auto-escaped plain text (whitespace-pre-wrap).
-   Assistant turns: pre-rendered HTML emitted via `| safe`; FILE blocks
+   Assistant turns: pre-rendered HTML output via `| safe`; FILE blocks
    have already been replaced with badge spans by the route layer.
 #}
 <div class="rounded p-3

--- a/src/findajob/web/templates/onboarding/_turn_error.html
+++ b/src/findajob/web/templates/onboarding/_turn_error.html
@@ -22,7 +22,7 @@
         {% elif error_kind == "rate_limit" %}Rate-limited
         {% elif error_kind == "upstream" %}OpenRouter / model error
         {% elif error_kind == "network" %}Network error
-        {% elif error_kind == "malformed" %}Unexpected response shape
+        {% elif error_kind == "malformed" %}Something unexpected
         {% elif error_kind == "config" %}Configuration error
         {% else %}Error
         {% endif %}
@@ -33,7 +33,7 @@
       {% if error_kind == "auth" or error_kind == "payment" %}
       <p class="text-xs text-red-800 mt-2">
         This is on the operator's side, not yours. The administrator of this
-        findajob deployment can fix it at
+        findajob can fix it at
         <a class="underline" target="_blank"
            href="{% if error_kind == 'payment' %}https://openrouter.ai/credits{% else %}https://openrouter.ai/keys{% endif %}">
           openrouter.ai/{% if error_kind == 'payment' %}credits{% else %}keys{% endif %}</a>.

--- a/src/findajob/web/templates/onboarding/complete.html
+++ b/src/findajob/web/templates/onboarding/complete.html
@@ -7,8 +7,8 @@
   <h1 class="text-2xl font-semibold">Onboarding complete</h1>
 
   <p class="text-slate-700">
-    Your seven config files are installed. The pipeline is ready to run on
-    its next scheduled tick.
+    Your profile and settings are saved. findajob is ready and will start
+    working on its next scheduled run.
   </p>
 
   <div class="rounded-lg border border-slate-200 bg-white p-4 space-y-2">
@@ -20,14 +20,15 @@
       </p>
     {% else %}
       <p class="text-amber-700">
-        Discovery deferred to the weekly cron. Reason:
+        We'll look for companies automatically once a week — it didn't run
+        just now. Reason:
         <code class="text-xs">{{ discovery_error or "unknown" }}</code>
       </p>
       <p class="text-slate-600 text-sm">
-        Your pipeline will work without the discovered set; the next Sunday
-        02:00 cron run will produce one. You can also run
-        <code>python3 scripts/discover_companies.py</code> manually if your
-        environment supports it.
+        findajob works fine in the meantime; the next weekly run (Sunday
+        mornings) will produce one. If you're comfortable with the command
+        line, you can also run
+        <code>python3 scripts/discover_companies.py</code> yourself.
       </p>
     {% endif %}
   </div>

--- a/src/findajob/web/templates/onboarding/index.html
+++ b/src/findajob/web/templates/onboarding/index.html
@@ -24,9 +24,8 @@
   <div class="border border-emerald-300 bg-emerald-50 text-emerald-900 px-4 py-3 rounded">
     <p class="font-medium">You've already onboarded.</p>
     <p class="text-sm mt-1">
-      Your existing keys live in this stack's <code>data/.env</code> from your
-      original onboarding. Step 1 below is for collecting (or rotating) keys
-      under findajob's per-stack key isolation —
+      Your existing keys are saved privately in your findajob from your
+      original onboarding. Step 1 below is for adding (or replacing) keys —
       <a class="underline" href="/board/dashboard">go to your dashboard</a>
       if you didn't mean to land here, or use <a class="underline" href="/onboarding/?mode=rerun">rerun mode</a>
       if you intend to redo onboarding from scratch.

--- a/src/findajob/web/templates/onboarding/interview.html
+++ b/src/findajob/web/templates/onboarding/interview.html
@@ -21,9 +21,9 @@
   </div>
 
   <p class="text-sm text-slate-600">
-    Work through the interview at your pace — answers persist server-side, so
-    you can close this tab and resume later by reloading this URL. When the
-    LLM emits the file blocks, the Finalize box below will unhide.
+    Work through the interview at your pace — your answers are saved as you go,
+    so you can close this tab and pick up later by reloading this page. Once
+    you've answered everything we need, the Finalize button below will appear.
   </p>
 
   {# #623: slot is always present so _turn.html can OOB-empty it on success.
@@ -105,9 +105,9 @@
     {% if finalize_ready %}
     <h2 class="font-semibold text-green-900">Finalize onboarding</h2>
     <p class="text-sm text-green-900">
-      All required blocks have been emitted. Click Finalize and we'll verify
-      your OpenRouter key, write your config files atomically, and back up any
-      existing files first.
+      Everything we need is ready. Click Finalize and we'll check your
+      OpenRouter key and save your settings — any existing files are backed
+      up first.
     </p>
     {% if keys_collected %}
     <p class="text-xs text-green-900">

--- a/tests/test_onboarding_interview_runner.py
+++ b/tests/test_onboarding_interview_runner.py
@@ -238,53 +238,72 @@ def test_translates_network_urlerror() -> None:
     assert "Check the deployment's network connectivity and try again." in e.user_message
 
 
+# #917: all malformed sub-cases surface one plain user message; the
+# upstream-shape detail moves to a logged diagnostic (see _map_malformed).
+_MALFORMED_USER_MSG = "Something unexpected happened. Try again."
+
+
 def test_translates_malformed_non_json() -> None:
-    """malformed (non-JSON) → Phase 1's 'non-JSON response' string prefix."""
+    """malformed (non-JSON) → kind=malformed + plain user message (#917)."""
     with patch(_URLOPEN, return_value=_FakeResp(b"<html>500 Bad Gateway</html>")):
         with pytest.raises(InterviewRunnerError) as excinfo:
             run_turn(api_key="sk-or-v1-test", history=[], user_message="hi")
     e = excinfo.value
     assert e.kind == "malformed"
-    assert "non-JSON" in e.user_message
+    assert e.user_message == _MALFORMED_USER_MSG
 
 
 def test_translates_malformed_unexpected_shape() -> None:
-    """malformed (no choices) → Phase 1's 'unexpected response shape' string."""
+    """malformed (no choices) → kind=malformed + plain user message (#917)."""
     with patch(_URLOPEN, return_value=_ok_resp({"unexpected": "shape"})):
         with pytest.raises(InterviewRunnerError) as excinfo:
             run_turn(api_key="sk-or-v1-test", history=[], user_message="hi")
     e = excinfo.value
     assert e.kind == "malformed"
-    assert "unexpected response shape" in e.user_message.lower()
+    assert e.user_message == _MALFORMED_USER_MSG
 
 
 def test_translates_malformed_empty_choices() -> None:
     with patch(_URLOPEN, return_value=_ok_resp({"choices": []})):
         with pytest.raises(InterviewRunnerError) as excinfo:
             run_turn(api_key="sk-or-v1-test", history=[], user_message="hi")
-    assert excinfo.value.kind == "malformed"
+    e = excinfo.value
+    assert e.kind == "malformed"
+    assert e.user_message == _MALFORMED_USER_MSG
 
 
 def test_translates_malformed_missing_message_content() -> None:
-    """malformed (content parse fail) → Phase 1's 'Could not parse assistant content' string."""
+    """malformed (content parse fail) → kind=malformed + plain user message (#917)."""
     body = {"choices": [{"index": 0, "finish_reason": "stop"}]}
     with patch(_URLOPEN, return_value=_ok_resp(body)):
         with pytest.raises(InterviewRunnerError) as excinfo:
             run_turn(api_key="sk-or-v1-test", history=[], user_message="hi")
     e = excinfo.value
     assert e.kind == "malformed"
-    assert "Could not parse assistant content" in e.user_message
+    assert e.user_message == _MALFORMED_USER_MSG
 
 
 def test_translates_malformed_non_string_content() -> None:
-    """malformed (content not a string) → Phase 1's 'not a string' string."""
+    """malformed (content not a string) → kind=malformed + plain user message (#917)."""
     body = {"choices": [{"message": {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}}]}
     with patch(_URLOPEN, return_value=_ok_resp(body)):
         with pytest.raises(InterviewRunnerError) as excinfo:
             run_turn(api_key="sk-or-v1-test", history=[], user_message="hi")
     e = excinfo.value
     assert e.kind == "malformed"
-    assert "not a string" in e.user_message
+    assert e.user_message == _MALFORMED_USER_MSG
+
+
+def test_map_malformed_preserves_diagnostic_detail() -> None:
+    """The plain user message hides the shape, but _map_malformed still
+    expands each upstream prefix into a distinct diagnostic for the log
+    line (#917) — so operator-facing debuggability is retained."""
+    from findajob.onboarding.interview_runner import _map_malformed
+
+    assert "non-JSON response" in _map_malformed("Non-JSON response: <html>")
+    assert "unexpected response shape" in _map_malformed("Unexpected shape: {}")
+    assert "Could not parse assistant content" in _map_malformed("Could not parse content: x")
+    assert "not a string" in _map_malformed("Content not a string: list")
 
 
 def test_translates_config_missing_key() -> None:

--- a/tests/test_openrouter_smoke.py
+++ b/tests/test_openrouter_smoke.py
@@ -116,6 +116,9 @@ def test_unexpected_response_shape_returns_false() -> None:
         ok, err = verify_openrouter_key("sk-or-v1-good")
     assert ok is False
     assert err is not None
+    # #917: humanized — names the service, no raw body leaked to the user.
+    assert "OpenRouter" in err
+    assert "other-shape" not in err
 
 
 def test_non_json_response_returns_false() -> None:
@@ -138,4 +141,8 @@ def test_non_json_response_returns_false() -> None:
         ok, err = verify_openrouter_key("sk-or-v1-good")
     assert ok is False
     assert err is not None
-    assert "non-JSON" in err or "JSON" in err
+    # #917: humanized — names the service + actionable status link, and no
+    # longer leaks the raw upstream body to the user.
+    assert "OpenRouter" in err
+    assert "status.openrouter.ai" in err
+    assert "<html>" not in err


### PR DESCRIPTION
Closes #917.

Plain-English rewrite of the developer jargon every new user reads during onboarding — the highest-leverage UX copy fix in the docs-v2 arc (everyone walks through onboarding).

## What changed

**Rendered template copy** (9 onboarding templates) — "seven config files" → "your profile and settings"; "weekly cron / 02:00 cron run" → "automatically once a week / the next weekly run (Sunday mornings)"; "blocks have been emitted / write config files atomically" → "everything we need is ready / save your settings"; "this container's environment" / "this stack's `data/.env`" / "per-stack key isolation" → **"your findajob"**.

**Error messages** (`interview_runner.py` + `openrouter_smoke.py`):
- Length error drops `max_tokens`/`emit` wording (keeps the test-pinned "too long"/"trim"/"shorter" recovery tokens).
- Malformed responses no longer show the user the raw upstream body + "unexpected response shape" jargon. The interview-turn error and the Step 1 key-verify smoke check **deliberately share wording**, so both are humanized in parity ("Something unexpected happened. Try again." / "OpenRouter sent back a response findajob couldn't read…"), with the diagnostic detail moved to a `logging.warning` so operator debuggability is retained.

## Decisions

- **Test-contract over issue-sketch** — the issue's suggested length-error text would have failed the pinned `"trim"`/`"shorter"` assertion; honored the test contract while removing the jargon.
- **Parity, not a one-sided change** — humanizing `_map_malformed` alone would desync it from `openrouter_smoke.py`, which shares the exact strings (a regression). Both touched together. `openrouter_smoke.py` is **outside #917's listed files** — touched solely for parity.
- **"your findajob"** adopted as the canonical replacement so the deferred per-surface polish (#919) inherits a settled term.
- **Scope discipline** — the runner's `config`/`network` messages and smoke's "container has network access" line are jargon too, but outside #917's listed scope and not part of the malformed parity; left for the #919 consistency pass.

## Test plan

- [x] 203 passed / 1 skipped across onboarding/interview/smoke/transparency suites
- [x] `ruff check` + `ruff format --check` clean
- [x] Banned-token grep over `templates/onboarding/` leaves only the literal `docker logs <container-name>` command (a real CLI invocation — unhumanizable) and no rendered jargon
- [x] New unit test pins `_map_malformed`'s per-shape diagnostic mapping (the detail that moved from the user message into the log)
- [x] Smoke tests strengthened with negative assertions confirming the raw upstream body no longer leaks to the user
- [ ] Browser walkthrough of the onboarding flow not run (copy-only change; render tests cover template validity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)