### PR TITLE
feat(a11y): accessible names + group roles on board action controls (#886)

### DIFF
--- a/src/findajob/web/templates/board/_change_not_selected_reason_cell.html
+++ b/src/findajob/web/templates/board/_change_not_selected_reason_cell.html
@@ -10,6 +10,7 @@
   {% if row.stage == 'not_selected' %}
   <select
     class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+    aria-label="Change not-selected reason"
     data-fp="{{ row.fingerprint }}"
     hx-post="/board/jobs/{{ row.fingerprint }}/change-not-selected-reason"
     hx-trigger="change"

--- a/src/findajob/web/templates/board/_change_reject_reason_cell.html
+++ b/src/findajob/web/templates/board/_change_reject_reason_cell.html
@@ -15,6 +15,7 @@
   {% if row.stage == 'rejected' %}
   <select
     class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+    aria-label="Change reject reason"
     data-fp="{{ row.fingerprint }}"
     hx-post="/board/jobs/{{ row.fingerprint }}/change-reject-reason"
     hx-trigger="change"

--- a/src/findajob/web/templates/board/_confirm_modal.html
+++ b/src/findajob/web/templates/board/_confirm_modal.html
@@ -15,7 +15,8 @@
   the trigger cell is swapped via outerHTML.
 #}
 <td class="px-3 py-1 align-top text-sm" data-confirm-modal>
-  <div class="rounded border border-red-300 bg-red-50 p-2">
+  <div class="rounded border border-red-300 bg-red-50 p-2"
+       role="group" aria-label="Confirm action">
     <p class="text-xs text-red-900 mb-1">{{ copy }}</p>
     {% if context_lines %}
     <ul class="text-[11px] text-red-700 mb-2 list-disc list-inside">

--- a/src/findajob/web/templates/board/_exclude_modal.html
+++ b/src/findajob/web/templates/board/_exclude_modal.html
@@ -17,8 +17,9 @@
 #}
 {% set fp = row.fingerprint %}
 <td class="px-3 py-1 align-top text-sm" x-data="{ locus: 'title' }">
-  <div class="rounded border border-rose-300 bg-rose-50 p-2">
-    <p class="text-[11px] text-rose-900 mb-1">
+  <div class="rounded border border-rose-300 bg-rose-50 p-2"
+       role="group" aria-labelledby="exclude-rule-{{ fp }}-desc">
+    <p id="exclude-rule-{{ fp }}-desc" class="text-[11px] text-rose-900 mb-1">
       Add an exclusion rule to prevent matches like
       <span class="font-medium">{{ row.title }}</span> @ {{ row.company }}.
     </p>

--- a/src/findajob/web/templates/board/_notes_cell.html
+++ b/src/findajob/web/templates/board/_notes_cell.html
@@ -20,6 +20,7 @@
   <input
     type="text"
     class="w-full rounded border-slate-300 bg-white px-2 py-1 text-sm"
+    aria-label="Edit notes"
     name="notes"
     value="{{ row.user_notes or '' }}"
     hx-post="/board/jobs/{{ row.fingerprint }}/notes"

--- a/src/findajob/web/templates/board/_reattribute_modal.html
+++ b/src/findajob/web/templates/board/_reattribute_modal.html
@@ -11,8 +11,9 @@
     row — sqlite3.Row with .fingerprint, .title, .company
 #}
 <td class="px-3 py-1 align-top text-sm">
-  <div class="rounded border border-amber-300 bg-amber-50 p-2">
-    <p class="text-xs text-amber-900 mb-1">
+  <div class="rounded border border-amber-300 bg-amber-50 p-2"
+       role="group" aria-labelledby="reattribute-{{ row.fingerprint }}-desc">
+    <p id="reattribute-{{ row.fingerprint }}-desc" class="text-xs text-amber-900 mb-1">
       Reattribute this rejection to a different job. The current row
       (<span class="font-medium">{{ row.title }} @ {{ row.company }}</span>)
       will be un-not-selected and the target will be marked not_selected

--- a/src/findajob/web/templates/board/_reject_cell.html
+++ b/src/findajob/web/templates/board/_reject_cell.html
@@ -21,6 +21,7 @@
   {% else %}
   <select
     class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+    aria-label="Reject with reason"
     data-fp="{{ fp }}"
     onchange="if(this.value){
       const tr=this.closest('tr');

--- a/src/findajob/web/templates/board/_status_cell.html
+++ b/src/findajob/web/templates/board/_status_cell.html
@@ -23,6 +23,7 @@
       {% endif %}
       <select
         class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+        aria-label="Change status"
         data-fp="{{ fp }}"
         onchange="if(!this.value)return;
           const v=this.value;this.value='';
@@ -61,6 +62,7 @@
        (see _reject_cell.html). #}
     <select
       class="block rounded border-slate-300 bg-white px-2 py-1 text-xs"
+      aria-label="Change status"
       data-fp="{{ fp }}"
       onchange="if(!this.value)return;
         const tr=this.closest('tr');

--- a/tests/test_board_modal_accessibility.py
+++ b/tests/test_board_modal_accessibility.py
@@ -1,0 +1,114 @@
+"""Accessibility invariant for board action partials (#886).
+
+Every interactive form control rendered into a board partial must expose an
+accessible name to assistive tech. Screen readers announce a control by its
+accessible name; an unnamed ``<select>`` is read as a bare "combo box" with no
+indication of what it does.
+
+This is a *static-source* invariant: it parses the Jinja templates directly
+rather than rendering them, so it needs no DB, app, or request context and runs
+on the dev VM. Jinja control/expression tokens are stripped before parsing —
+we care about the HTML control structure and its ``aria-*`` / ``<label>``
+plumbing, not the interpolated values.
+
+Sibling in spirit to ``tests/test_transparency_invariants.py``: a failure here
+means a board control is invisible to screen-reader users.
+
+#886 scope note: the board "modals" are HTMX cell-swaps (a ``<td>`` is replaced
+inline), not focus-trapping overlays. ``aria-modal``/``role="dialog"`` are
+therefore inapplicable (they require focus management this UI doesn't have); the
+swap panels use an honest ``role="group"`` instead. This test guards the part
+that *is* enforceable without JS — accessible names on every control.
+"""
+
+import re
+from pathlib import Path
+
+from bs4 import BeautifulSoup, Tag
+
+BOARD_TEMPLATES = Path(__file__).resolve().parent.parent / "src" / "findajob" / "web" / "templates" / "board"
+
+# Control types that do not surface to the user as named, operable widgets and
+# so are exempt from the accessible-name requirement.
+_EXEMPT_INPUT_TYPES = {"hidden", "submit", "button", "reset", "image"}
+
+_JINJA = re.compile(r"\{%.*?%\}|\{\{.*?\}\}", re.DOTALL)
+
+
+def _strip_jinja(source: str) -> str:
+    """Remove Jinja control/expression tokens, leaving the HTML skeleton.
+
+    ``name="{{ fp }}"`` becomes ``name=""`` and ``{% if x %}<i>{% endif %}``
+    becomes ``<i>`` — both fine for structural + attribute-presence checks.
+    """
+    return _JINJA.sub("", source)
+
+
+def _has_accessible_name(control: Tag, label_fors: set[str]) -> bool:
+    if control.get("aria-label", "").strip():
+        return True
+    if control.get("aria-labelledby", "").strip():
+        return True
+    # Explicit <label for="id"> association.
+    control_id = control.get("id")
+    if control_id and control_id in label_fors:
+        return True
+    # Implicit association — control nested inside a <label>.
+    if control.find_parent("label") is not None:
+        return True
+    # A <title> child (rare for form controls, but valid).
+    if control.find("title") is not None:
+        return True
+    return False
+
+
+def _requires_name(control: Tag) -> bool:
+    if control.name in ("select", "textarea"):
+        return True
+    if control.name == "input":
+        return control.get("type", "text").lower() not in _EXEMPT_INPUT_TYPES
+    return False
+
+
+def test_every_board_control_has_accessible_name() -> None:
+    """No ``<select>``/``<textarea>``/named ``<input>`` in board/ is unnamed."""
+    failures: list[str] = []
+
+    for template in sorted(BOARD_TEMPLATES.glob("*.html")):
+        soup = BeautifulSoup(_strip_jinja(template.read_text()), "html.parser")
+        label_fors = {lbl["for"] for lbl in soup.find_all("label") if lbl.get("for")}
+        for control in soup.find_all(("select", "input", "textarea")):
+            if not _requires_name(control):
+                continue
+            if not _has_accessible_name(control, label_fors):
+                snippet = " ".join(str(control).split())[:120]
+                failures.append(f"{template.name}: {snippet}")
+
+    assert not failures, "Board controls missing an accessible name:\n" + "\n".join(failures)
+
+
+def test_swap_panels_declare_group_role() -> None:
+    """The inline cell-swap panels expose a named ``role='group'`` boundary.
+
+    Guards the #886 reshape: these are not overlay dialogs, so the honest role
+    is ``group`` with a label — never ``aria-modal``/``role='dialog'``, which
+    would falsely promise focus containment.
+    """
+    panels = {
+        "_exclude_modal.html",
+        "_reattribute_modal.html",
+        "_confirm_modal.html",
+    }
+    for name in panels:
+        soup = BeautifulSoup(_strip_jinja((BOARD_TEMPLATES / name).read_text()), "html.parser")
+        group = soup.find(attrs={"role": "group"})
+        assert group is not None, f"{name}: expected a role='group' container"
+        named = bool(group.get("aria-label", "").strip()) or bool(group.get("aria-labelledby", "").strip())
+        assert named, f"{name}: role='group' container lacks an accessible name"
+        # The anti-pattern guard: no false modal semantics anywhere in the panel.
+        assert soup.find(attrs={"aria-modal": True}) is None, (
+            f"{name}: aria-modal is inappropriate for an inline cell-swap panel"
+        )
+        assert soup.find(attrs={"role": "dialog"}) is None, (
+            f"{name}: role='dialog' implies focus semantics this panel lacks"
+        )


### PR DESCRIPTION
## What

Screen-reader accessibility for the board action controls (#886).

- **Accessible names** added to 6 previously-unnamed controls via `aria-label`: the dashboard + applied status `<select>`s (`_status_cell.html`), the reject-reason `<select>` (`_reject_cell.html`), the change-reject-reason and change-not-selected-reason `<select>`s, and the notes `<input>` (`_notes_cell.html`). To assistive tech these rendered as bare combo boxes / text fields with no indication of purpose.
- **`role="group"` + label** on the three inline swap panels (`_exclude_modal`, `_reattribute_modal`, `_confirm_modal`).

## AC #2 reshaped (called out, not silently dropped)

The issue asked for `role="dialog"` + `aria-modal="true"`. These "modals" are **HTMX cell-swaps** that replace a `<td>` inline — no overlay, no focus trap, background stays interactive. `aria-modal="true"` asserts the rest of the page is inert (false here; a documented ARIA anti-pattern), and bare `role="dialog"` implies focus/Esc semantics the panels lack. Both require JS focus management, which the issue explicitly excluded ("no logic changes"). The honest substitute is `role="group"` + a label. Full rationale in the [issue comment](https://github.com/brockamer/findajob/issues/886#issuecomment-4585670178).

## Follow-up

#944 — the real remaining SR gap: focus doesn't move into a panel when it swaps in, so a screen-reader user gets no signal it opened. Needs JS; out of scope here.

## Test plan

- [x] `tests/test_board_modal_accessibility.py` — new static-source invariant (no DB/app; runs on the dev VM): every `board/` control has an accessible name; swap panels carry `role="group"` and never `aria-modal`/`role="dialog"`. Mutation-checked that it catches an unnamed control.
- [x] Existing board render tests pass (`test_web_board_not_selected`, `test_web_board_review`, `test_web_board_company_history` — 19 passed).
- [x] `ruff check` + `ruff format --check` clean.
- [x] Browser-engine accessibility-tree check: rendered the partials, loaded in Chromium (Playwright), read computed accessible names — 12 controls, 0 unnamed; `[aria-modal]`/`[role="dialog"]` both 0. (Equivalent to the AC #3 DevTools "no accessible name" check.)

Closes #886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
