### PR TITLE
refactor(db): drop dead jobs.gdrive_folder_url column (migration 0009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Migration required
+
+- **Schema 0009 — `jobs.gdrive_folder_url` dropped** (#966): the dead Google Drive sync column is removed via `migrations/0009_drop_gdrive_folder_url.sql`. It held the per-job Drive folder link from the rclone/Drive materials-sync era, retired when the local web materials viewer shipped; it has been NULL in every row since and no code reads it. **Auto-applied on next startup — no operator action, no data loss.** Fresh installs never carry the column.
+
+### Removed
+
+- **`jobs.gdrive_folder_url` column** and its last writer (a `gdrive_folder_url=NULL` clause in `board_actions._regenerate`) — see *Migration required* above (#966).
+- **Stale `analyze_feedback` mypy override** in `pyproject.toml`: the #558 extraction it guarded shipped (`scripts/analyze_feedback.py` is now a thin shim importing `findajob.analyze_feedback`), so the override suppressed nothing. (#966)
+
 ### Added
 
 - **Keyboard/screen-reader focus management for board action panels** (#944): The board's HTMX cell-swap panels (add-exclusion-rule, reattribute, generic confirm, and the change-reason `<select>` re-render) now move keyboard focus when they open and return it when they close. Builds directly on #886's `role="group"` panel markers: a small global `htmx:afterSettle` handler (`static/focus_panels.js`) reads the live swapped-in `<td>` (`evt.detail.elt` — not the detached `evt.detail.target`), and on open moves focus to the labelled panel **container** via `tabindex="-1"` rather than its first control, so a screen reader announces the panel's purpose and no destructive button (e.g. the confirm modal's "Confirm", which deletes a `feedback_log` row or re-runs paid prep) is pre-armed. The generic confirm modal — previously `aria-label="Confirm action"`, which would have announced only that generic label on focus — now labels its container via `aria-labelledby` pointing at the warning copy (and any context lines), scoped by a `modal_id` (the job fingerprint) the callers pass, so focusing it actually reads out the consequence being confirmed. On cancel/submit — or when a change-reason select re-renders itself — focus returns to the restored cell's first interactive control instead of being stranded on `<body>`. Scoped to `<td>`-level swaps, so row-level actions (`closest tr`) and the dashboard `/rows` refresh never hijack focus. Focus landing on exclude/reattribute/confirm/change-reason verified via `document.activeElement`; the real VoiceOver/NVDA announcement smoke is the one acceptance check that requires a live screen reader.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -266,7 +266,6 @@ prep_folder_path TEXT            -- absolute path to the companies/ subfolder
 synthetic INTEGER                -- 1 for speculative cold-outreach rows
 speculative_briefing_folder TEXT -- reused briefing for synthetic rows
 dupe_of TEXT
-gdrive_folder_url TEXT           -- legacy, unused (Drive sync retired)
 stage_updated / created_at / updated_at TEXT
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,16 +84,6 @@ disable_error_code = []
 module = ["docx", "docx.*"]
 ignore_missing_imports = true
 
-# `findajob.notifications.scoreboard` imports the script-side
-# `analyze_feedback` module (which lives in scripts/, off mypy's
-# package path). Issue #558 tracks extracting it into
-# `findajob.analyze_feedback`; until then, scope the missing-import
-# error here rather than introduce a ``# type: ignore`` at the import
-# site.
-[[tool.mypy.overrides]]
-module = "analyze_feedback"
-ignore_missing_imports = true
-
 [tool.ruff]
 target-version = "py312"
 line-length = 120

--- a/src/findajob/migrations/0009_drop_gdrive_folder_url.sql
+++ b/src/findajob/migrations/0009_drop_gdrive_folder_url.sql
@@ -1,0 +1,14 @@
+-- 0009_drop_gdrive_folder_url.sql — drop the dead Google Drive sync column.
+--
+-- ``jobs.gdrive_folder_url`` held the per-job Google Drive folder link from
+-- the rclone/Drive materials-sync era. That layer was retired when the local
+-- web materials viewer shipped (see docs/architecture.md). The column has
+-- been NULL in every row since; no code reads it, and the last writer (a
+-- ``gdrive_folder_url=NULL`` clause in board_actions._regenerate) is removed
+-- in the same change as this migration.
+--
+-- Single statement — atomic on its own (no dependence on the migration
+-- runner wrapping multiple statements). Fresh installs create the column in
+-- 0001 and drop it here; existing stacks drop it on next startup. No data
+-- loss: the column is NULL everywhere.
+ALTER TABLE jobs DROP COLUMN gdrive_folder_url;

--- a/src/findajob/web/routes/board_actions.py
+++ b/src/findajob/web/routes/board_actions.py
@@ -416,7 +416,7 @@ def _execute_regenerate(db: sqlite3.Connection, job: sqlite3.Row, *, source_even
     now = datetime.now(UTC).isoformat()
     db.execute(
         "UPDATE jobs SET stage='prep_in_progress', prep_folder_path=NULL, "
-        "gdrive_folder_url=NULL, apply_flag=1, stage_updated=?, updated_at=? "
+        "apply_flag=1, stage_updated=?, updated_at=? "
         "WHERE id=?",
         (now, now, job["id"]),
     )

--- a/tests/fixtures/schema_baseline_fresh.json
+++ b/tests/fixtures/schema_baseline_fresh.json
@@ -776,21 +776,13 @@
         {
           "cid": 26,
           "dflt_value": null,
-          "name": "gdrive_folder_url",
-          "notnull": 0,
-          "pk": 0,
-          "type": "TEXT"
-        },
-        {
-          "cid": 27,
-          "dflt_value": null,
           "name": "fit_score",
           "notnull": 0,
           "pk": 0,
           "type": "REAL"
         },
         {
-          "cid": 28,
+          "cid": 27,
           "dflt_value": null,
           "name": "probability_score",
           "notnull": 0,
@@ -798,7 +790,7 @@
           "type": "REAL"
         },
         {
-          "cid": 29,
+          "cid": 28,
           "dflt_value": "''",
           "name": "user_notes",
           "notnull": 0,
@@ -806,7 +798,7 @@
           "type": "TEXT"
         },
         {
-          "cid": 30,
+          "cid": 29,
           "dflt_value": "datetime('now')",
           "name": "created_at",
           "notnull": 0,
@@ -814,7 +806,7 @@
           "type": "TEXT"
         },
         {
-          "cid": 31,
+          "cid": 30,
           "dflt_value": "datetime('now')",
           "name": "updated_at",
           "notnull": 0,
@@ -822,7 +814,7 @@
           "type": "TEXT"
         },
         {
-          "cid": 32,
+          "cid": 31,
           "dflt_value": "''",
           "name": "dupe_of",
           "notnull": 0,
@@ -830,7 +822,7 @@
           "type": "TEXT"
         },
         {
-          "cid": 33,
+          "cid": 32,
           "dflt_value": "0",
           "name": "synthetic",
           "notnull": 1,
@@ -838,7 +830,7 @@
           "type": "INTEGER"
         },
         {
-          "cid": 34,
+          "cid": 33,
           "dflt_value": null,
           "name": "speculative_briefing_folder",
           "notnull": 0,
@@ -846,7 +838,7 @@
           "type": "TEXT"
         },
         {
-          "cid": 35,
+          "cid": 34,
           "dflt_value": "'unknown'",
           "name": "company_tier",
           "notnull": 0,
@@ -854,7 +846,7 @@
           "type": "TEXT"
         },
         {
-          "cid": 36,
+          "cid": 35,
           "dflt_value": "''",
           "name": "scored_by",
           "notnull": 0,
@@ -864,7 +856,7 @@
       ],
       "foreign_keys": [],
       "name": "jobs",
-      "sql": "CREATE TABLE jobs(id TEXT PRIMARY KEY,fingerprint TEXT UNIQUE NOT NULL,loose_fingerprint TEXT,url TEXT NOT NULL,title TEXT NOT NULL,company TEXT NOT NULL,location TEXT DEFAULT '',source TEXT NOT NULL,raw_jd_text TEXT,relevance_score INTEGER CHECK(relevance_score BETWEEN 1 AND 10),interview_likelihood INTEGER CHECK(interview_likelihood BETWEEN 1 AND 10),strengths_alignment TEXT,industry_sector TEXT,comp_estimate TEXT DEFAULT '',ai_notes TEXT,score_status TEXT CHECK(score_status IN('scored','manual_review')),score_flag_reason TEXT,remote_status TEXT DEFAULT 'Unknown',network_depth INTEGER DEFAULT 0,known_contacts TEXT DEFAULT '',stage TEXT DEFAULT 'discovered' CHECK(stage IN('discovered','enriched','scored','manual_review','prep_in_progress','briefing_ready','materials_drafted','waitlisted','applied','response_received','interview','offer','rejected','not_selected','withdrawn','withdrawn_fallback')),stage_updated TEXT,status TEXT DEFAULT 'active' CHECK(status IN('active','manual_review','skipped','applied','rejected','interviewing','offer')),apply_flag INTEGER DEFAULT 0,reject_reason TEXT DEFAULT '',prep_folder_path TEXT,gdrive_folder_url TEXT,fit_score REAL,probability_score REAL,user_notes TEXT DEFAULT '',created_at TEXT DEFAULT(datetime('now')),updated_at TEXT DEFAULT(datetime('now')),dupe_of TEXT DEFAULT '',synthetic INTEGER NOT NULL DEFAULT 0,speculative_briefing_folder TEXT,company_tier TEXT DEFAULT 'unknown',scored_by TEXT DEFAULT '')",
+      "sql": "CREATE TABLE jobs(id TEXT PRIMARY KEY,fingerprint TEXT UNIQUE NOT NULL,loose_fingerprint TEXT,url TEXT NOT NULL,title TEXT NOT NULL,company TEXT NOT NULL,location TEXT DEFAULT '',source TEXT NOT NULL,raw_jd_text TEXT,relevance_score INTEGER CHECK(relevance_score BETWEEN 1 AND 10),interview_likelihood INTEGER CHECK(interview_likelihood BETWEEN 1 AND 10),strengths_alignment TEXT,industry_sector TEXT,comp_estimate TEXT DEFAULT '',ai_notes TEXT,score_status TEXT CHECK(score_status IN('scored','manual_review')),score_flag_reason TEXT,remote_status TEXT DEFAULT 'Unknown',network_depth INTEGER DEFAULT 0,known_contacts TEXT DEFAULT '',stage TEXT DEFAULT 'discovered' CHECK(stage IN('discovered','enriched','scored','manual_review','prep_in_progress','briefing_ready','materials_drafted','waitlisted','applied','response_received','interview','offer','rejected','not_selected','withdrawn','withdrawn_fallback')),stage_updated TEXT,status TEXT DEFAULT 'active' CHECK(status IN('active','manual_review','skipped','applied','rejected','interviewing','offer')),apply_flag INTEGER DEFAULT 0,reject_reason TEXT DEFAULT '',prep_folder_path TEXT,fit_score REAL,probability_score REAL,user_notes TEXT DEFAULT '',created_at TEXT DEFAULT(datetime('now')),updated_at TEXT DEFAULT(datetime('now')),dupe_of TEXT DEFAULT '',synthetic INTEGER NOT NULL DEFAULT 0,speculative_briefing_folder TEXT,company_tier TEXT DEFAULT 'unknown',scored_by TEXT DEFAULT '')",
       "tbl_name": "jobs",
       "type": "table"
     },

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -42,7 +42,6 @@ CREATE TABLE jobs (
     reject_reason TEXT DEFAULT '',
     fit_score REAL,
     probability_score REAL,
-    gdrive_folder_url TEXT,
     remote_status TEXT DEFAULT 'Unknown',
     ai_notes TEXT,
     comp_estimate TEXT DEFAULT '',
@@ -106,7 +105,6 @@ def insert_job(
     raw_jd_text=None,
     score_status="scored",
     apply_flag=0,
-    gdrive_url=None,
 ):
     """Insert a job with sane defaults; returns the row as sqlite3.Row."""
     job_id = str(uuid.uuid4())[:8]
@@ -114,8 +112,8 @@ def insert_job(
     conn.execute(
         """INSERT INTO jobs (id, fingerprint, url, title, company, relevance_score,
                              stage, prep_folder_path, raw_jd_text, score_status,
-                             apply_flag, gdrive_folder_url)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                             apply_flag)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             job_id,
             fp,
@@ -128,7 +126,6 @@ def insert_job(
             raw_jd_text,
             score_status,
             apply_flag,
-            gdrive_url,
         ),
     )
     conn.commit()

--- a/tests/test_board_actions.py
+++ b/tests/test_board_actions.py
@@ -511,7 +511,7 @@ class TestRegenerate:
         (folder / "resume.pdf").touch()
         conn = sqlite3.connect(client._db_path)
         conn.execute(
-            "UPDATE jobs SET prep_folder_path=?, gdrive_folder_url='https://drive/abc' WHERE fingerprint=?",
+            "UPDATE jobs SET prep_folder_path=? WHERE fingerprint=?",
             (str(folder), fingerprint),
         )
         conn.commit()
@@ -528,13 +528,12 @@ class TestRegenerate:
 
         conn = sqlite3.connect(client._db_path)
         row = conn.execute(
-            "SELECT stage, prep_folder_path, gdrive_folder_url, apply_flag FROM jobs WHERE fingerprint='fp_drafted'"
+            "SELECT stage, prep_folder_path, apply_flag FROM jobs WHERE fingerprint='fp_drafted'"
         ).fetchone()
         conn.close()
         assert row[0] == "prep_in_progress"
         assert row[1] is None
-        assert row[2] is None
-        assert row[3] == 1
+        assert row[2] == 1
 
         assert len(popen_calls) == 1
         assert "prep_application.py" in popen_calls[0][1]

--- a/tests/test_prep_phase_split.py
+++ b/tests/test_prep_phase_split.py
@@ -44,7 +44,6 @@ CREATE TABLE jobs (
     prep_folder_path TEXT,
     fit_score REAL,
     probability_score REAL,
-    gdrive_folder_url TEXT,
     updated_at TEXT DEFAULT (datetime('now')),
     synthetic INTEGER NOT NULL DEFAULT 0,
     speculative_briefing_folder TEXT

--- a/tests/test_prep_pipeline.py
+++ b/tests/test_prep_pipeline.py
@@ -47,7 +47,6 @@ CREATE TABLE jobs (
     prep_folder_path TEXT,
     fit_score REAL,
     probability_score REAL,
-    gdrive_folder_url TEXT,
     updated_at TEXT DEFAULT (datetime('now')),
     synthetic INTEGER NOT NULL DEFAULT 0
 );
@@ -83,15 +82,14 @@ def insert_job(
     folder=None,
     fit_score=None,
     prob_score=None,
-    gdrive_url=None,
 ):
     """Insert a job with sane defaults; returns the job_id."""
     job_id = str(uuid.uuid4())[:8]
     fp = f"fp_{job_id}"
     conn.execute(
         """INSERT INTO jobs (id, fingerprint, url, title, company, relevance_score,
-                             stage, prep_folder_path, fit_score, probability_score, gdrive_folder_url)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                             stage, prep_folder_path, fit_score, probability_score)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             job_id,
             fp,
@@ -103,7 +101,6 @@ def insert_job(
             folder,
             fit_score,
             prob_score,
-            gdrive_url,
         ),
     )
     conn.commit()
@@ -371,41 +368,18 @@ class TestDBStateTransitions:
         assert row["fit_score"] == 76.7
         assert row["probability_score"] == 60.0
 
-    def test_gdrive_url_stored_on_success(self, db):
-        """Drive URL stored in DB when gdrive_folder_url is set."""
-        job_id = insert_job(
-            db, stage="materials_drafted", folder="/home/user/companies/Acme_Ops_Manager_2026-04-13_140000"
-        )
-        drive_url = "https://drive.google.com/drive/folders/abc123"
-
-        db.execute("UPDATE jobs SET gdrive_folder_url=? WHERE id=?", (drive_url, job_id))
-        db.commit()
-
-        row = db.execute("SELECT gdrive_folder_url FROM jobs WHERE id=?", (job_id,)).fetchone()
-        assert row["gdrive_folder_url"] == drive_url
-
-    def test_gdrive_url_stays_null_when_not_set(self, db):
-        """Drive URL stays NULL when no update is executed."""
-        job_id = insert_job(
-            db, stage="materials_drafted", folder="/home/user/companies/Acme_Ops_Manager_2026-04-13_140000"
-        )
-        # No UPDATE issued — URL should remain NULL
-        row = db.execute("SELECT gdrive_folder_url FROM jobs WHERE id=?", (job_id,)).fetchone()
-        assert row["gdrive_folder_url"] is None
-
     def test_regenerate_clears_prep_state(self, db):
-        """Regeneration clears folder path, Drive URL, and resets stage to prep_in_progress."""
+        """Regeneration clears folder path and resets stage to prep_in_progress."""
         job_id = insert_job(
             db,
             stage="materials_drafted",
             folder="/home/user/companies/Acme_Ops_Manager_2026-04-13_140000",
             fit_score=76.7,
             prob_score=60.0,
-            gdrive_url="https://drive.google.com/drive/folders/abc123",
         )
 
         db.execute(
-            """UPDATE jobs SET prep_folder_path=NULL, gdrive_folder_url=NULL,
+            """UPDATE jobs SET prep_folder_path=NULL,
                    stage='prep_in_progress' WHERE id=?""",
             (job_id,),
         )
@@ -414,7 +388,6 @@ class TestDBStateTransitions:
         row = db.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
         assert row["stage"] == "prep_in_progress"
         assert row["prep_folder_path"] is None
-        assert row["gdrive_folder_url"] is None
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_prep_subprocess_failure.py
+++ b/tests/test_prep_subprocess_failure.py
@@ -30,7 +30,6 @@ CREATE TABLE jobs (
     prep_folder_path TEXT,
     fit_score REAL,
     probability_score REAL,
-    gdrive_folder_url TEXT,
     updated_at TEXT DEFAULT (datetime('now')),
     synthetic INTEGER NOT NULL DEFAULT 0
 );

--- a/tests/test_speculative_approver.py
+++ b/tests/test_speculative_approver.py
@@ -36,7 +36,6 @@ CREATE TABLE jobs (
     apply_flag INTEGER DEFAULT 0,
     reject_reason TEXT DEFAULT '',
     prep_folder_path TEXT,
-    gdrive_folder_url TEXT,
     fit_score REAL,
     probability_score REAL,
     user_notes TEXT DEFAULT '',


### PR DESCRIPTION
## Context

`jobs.gdrive_folder_url` held the per-job Google Drive folder link from the rclone/Drive materials-sync era. That layer was retired when the local web materials viewer shipped; the column has been NULL in every row since, no code reads it, and the only writer was a `gdrive_folder_url=NULL` clause in `board_actions._regenerate`. Surfaced by the 2026-06-01 repository audit (finding G6) and tracked as the schema half of #966.

## Why

Dead schema is drift that misleads contributors and pads every `SELECT *`. Removing it before the Distribution/Packaging fresh-install fan-out keeps new installs clean.

## Approach

A numbered migration — honoring `0001`'s explicit "append-only; ship schema changes as numbered migrations" rule. Deliberately **not** editing `0001` (forbidden) and **not** using the `_DOCUMENTED_DEAD_COLUMNS` set (that set's contract is "absent from 0001"; this is a head column being retired, not never-was-there drift).

- `migrations/0009_drop_gdrive_folder_url.sql` — single-statement `ALTER TABLE jobs DROP COLUMN` (atomic on its own; no dependence on the multi-statement executescript path).
- Remove the `gdrive_folder_url=NULL` writer in `board_actions._regenerate` (**required** — it would throw "no such column" on a fresh DB post-migration).
- Regenerate `tests/fixtures/schema_baseline_fresh.json`.
- Tidy: drop the column from the self-contained hand-rolled test fixtures; delete two dead-behavior tests (`test_gdrive_url_stored_on_success`, `test_gdrive_url_stays_null_when_not_set`); fix `test_board_actions` (it builds via `apply_pending`, i.e. the real schema). Kept in `tests/fixtures/_legacy_v0_10_setup.py` (pre-migration schema — now exercises the drop on a legacy DB).
- Remove the stale `analyze_feedback` mypy override in `pyproject.toml` — the #558 extraction it guarded shipped, so it suppressed nothing (the other half of #966).

### Resurrection note (considered, non-issue)

The legacy-reconciliation rebuild helpers recreate `jobs` from `0001`'s DDL (which still defines the column) and replay only ADD COLUMNs, so a post-migration rebuild *could* re-add `gdrive_folder_url`. That degrades to an inert NULL column identical to today's state, and only on a stale-CHECK DB that triggers a rebuild — which no fresh install or current stack is, and the fresh-init snapshot test never triggers a rebuild. Not worth a permanent runtime drop-helper.

## Acceptance criteria

- [x] Fresh `init_db` produces a `jobs` table without `gdrive_folder_url` (snapshot regenerated + committed).
- [x] `apply_pending` on a legacy DB carrying the column drops it (exercised by the `_legacy_v0_10` board tests).
- [x] No `gdrive_folder_url` reference in `src/`/`scripts/` beyond `0001`'s definition + `0009`'s drop.
- [x] Full gate green: `pytest` 3558 passed / 0 failed, `ruff check`, `ruff format --check`, `mypy`.

## Migration required

Schema change — **auto-applied on next startup, no operator action, no data loss** (column was NULL everywhere). Documented under `### Migration required` in CHANGELOG.

Closes #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
