### PR TITLE
feat(deploy): add Deploy-to-Fly badge to README (#915)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Built and operated daily; pre-1.0 means active development.
 
 *Fictional demo data spanning data-center ops, social services, and K-12 education — the same pipeline works for every field, only your candidate profile changes.*
 
-**→ [Deploy in about 20 minutes, no terminal needed](docs/getting-started/start-here-fly.md)**
+[![Deploy to Fly.io](https://img.shields.io/badge/Deploy%20to%20Fly.io-8B5CF6?style=for-the-badge&logo=flydotio&logoColor=white)](docs/getting-started/start-here-fly.md)
+
+*No terminal needed — about 20 minutes, start to finish.*
 
 ---
 


### PR DESCRIPTION
## Summary

Upgrades the README's plain-text Fly walkthrough link into a prominent **"Deploy to Fly.io"** badge (shields.io, `for-the-badge` style, Fly logo) that links to the zero-CLI web walkthrough at `docs/getting-started/start-here-fly.md`, with a "no terminal needed — about 20 minutes" reassurance caption beneath it.

## Why the scope was reshaped

The original #915 premise — a button that pre-fills app name, region, and secrets via a Fly launch URL — **is not feasible**. Fly has no supported one-click deep-link deploy URL: the old launch badge was deprecated, and the current documented paths are the `flyctl` CLI and the dashboard "Launch an App" button (manual repo select + a separate Secrets step). Verified against Fly's own docs, the deprecation thread, and a real self-host repo (trigger.dev, which falls back to CLI instructions).

So a true Heroku-style one-click deploy from a README badge can't be built. The honest, shippable win is a button **affordance** that lands non-technical users on the hand-held walkthrough #881 already verified screenshot-by-screenshot. #915's acceptance criteria were reshaped to match (see the issue body).

## Acceptance criteria (reshaped)

- [x] Prominent "Deploy to Fly" badge in README.md
- [x] Badge links to the zero-CLI web walkthrough (`start-here-fly.md`)
- [x] Reassurance copy retained ("no terminal needed")

Out of scope (documented on #915): one-click app creation (no supported Fly deep-link); API-key prompting + post-deploy onboarding redirect are existing app behavior, not built here.

## Test plan

- [x] Badge URL resolves: `curl` → HTTP 200, `image/svg+xml`, embeds the Fly logo, `aria-label="DEPLOY TO FLY.IO"`
- [x] Link target `docs/getting-started/start-here-fly.md` exists; relative path correct from repo-root README
- [ ] **Visual render on GitHub** — confirm the badge displays correctly in this PR's rendered README (the reason this went via PR rather than straight to main)

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
