### PR TITLE
fix(stats): config-change popover queries cost_log.logged_at, not timestamp (#953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/stats/config-change/{date}` popover 500** (#953): `metrics/stats.py`'s before/after cost query filtered on `cost_log.timestamp`, a column that does not exist — the real column is `logged_at` (as `cost_rollups.py` uses everywhere). Every config-change marker popover on the funnel/feedback/throughput charts returned a 500. A unit fixture that hand-rolled a fabricated `cost_log` schema with a `timestamp` column kept the suite green over the production break (the `feedback_test_real_codepath_when_extracting` anti-pattern, #610/#611, recurring); the test now builds the real schema via `init_test_db`, and a new route-level regression test (`tests/test_web_stats_config_change.py`) asserts the popover returns 200.
+
 ### Migration required
 
 - **Schema 0009 — `jobs.gdrive_folder_url` dropped** (#966): the dead Google Drive sync column is removed via `migrations/0009_drop_gdrive_folder_url.sql`. It held the per-job Drive folder link from the rclone/Drive materials-sync era, retired when the local web materials viewer shipped; it has been NULL in every row since and no code reads it. **Auto-applied on next startup — no operator action, no data loss.** Fresh installs never carry the column.

--- a/src/findajob/metrics/stats.py
+++ b/src/findajob/metrics/stats.py
@@ -135,12 +135,12 @@ def before_after_metrics(
         (
             "before",
             f"date(changed_at) >= date(?, '-{window_days} days') AND date(changed_at) < date(?)",
-            f"date(timestamp) >= date(?, '-{window_days} days') AND date(timestamp) < date(?)",
+            f"date(logged_at) >= date(?, '-{window_days} days') AND date(logged_at) < date(?)",
         ),
         (
             "after",
             f"date(changed_at) >= date(?) AND date(changed_at) < date(?, '+{window_days} days')",
-            f"date(timestamp) >= date(?) AND date(timestamp) < date(?, '+{window_days} days')",
+            f"date(logged_at) >= date(?) AND date(logged_at) < date(?, '+{window_days} days')",
         ),
     ]:
         scored_row = conn.execute(

--- a/tests/test_metrics_stats.py
+++ b/tests/test_metrics_stats.py
@@ -13,6 +13,7 @@ from findajob.metrics.stats import (
     wilson_ci,
     wilson_ci_pct,
 )
+from tests.conftest import init_test_db
 
 
 class TestWilsonCI:
@@ -150,27 +151,15 @@ class TestConfigChangeMarkers:
 
 class TestBeforeAfterMetrics:
     @pytest.fixture
-    def db(self):
-        conn = sqlite3.connect(":memory:")
+    def db(self, tmp_path):
+        # Build the real schema via the production migration chain rather
+        # than hand-rolling CREATE TABLE — a fabricated cost_log with a
+        # nonexistent `timestamp` column masked #953. init_test_db is the
+        # documented anti-fragility helper (#721).
+        db_path = tmp_path / "pipeline.db"
+        init_test_db(db_path)
+        conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
-        conn.executescript("""
-            CREATE TABLE audit_log (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                job_id TEXT,
-                field_changed TEXT,
-                old_value TEXT,
-                new_value TEXT,
-                changed_at TEXT,
-                changed_by TEXT DEFAULT 'test'
-            );
-            CREATE TABLE cost_log (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp TEXT,
-                cost_usd REAL,
-                role TEXT,
-                job_id TEXT
-            );
-        """)
         return conn
 
     def test_empty_tables(self, db):
@@ -206,12 +195,12 @@ class TestBeforeAfterMetrics:
 
     def test_cost_in_both_windows(self, db):
         db.execute(
-            "INSERT INTO cost_log (timestamp, cost_usd, role) VALUES (?, ?, ?)",
-            ("2026-05-12 10:00:00", 1.50, "scorer"),
+            "INSERT INTO cost_log (logged_at, cost_usd, operation, model) VALUES (?, ?, ?, ?)",
+            ("2026-05-12 10:00:00", 1.50, "score", "scorer"),
         )
         db.execute(
-            "INSERT INTO cost_log (timestamp, cost_usd, role) VALUES (?, ?, ?)",
-            ("2026-05-17 10:00:00", 2.50, "scorer"),
+            "INSERT INTO cost_log (logged_at, cost_usd, operation, model) VALUES (?, ?, ?, ?)",
+            ("2026-05-17 10:00:00", 2.50, "score", "scorer"),
         )
         db.execute(
             "INSERT INTO audit_log (job_id, field_changed, new_value, changed_at) VALUES (?, 'stage', 'applied', ?)",

--- a/tests/test_web_stats_config_change.py
+++ b/tests/test_web_stats_config_change.py
@@ -1,0 +1,54 @@
+"""Stats config-change popover route — /stats/config-change/{date} (#953).
+
+Regression guard: the route built its cost filter against a nonexistent
+`cost_log.timestamp` column, so every config-change marker popover 500'd in
+production while a fabricated-schema unit fixture kept the suite green. This
+test exercises the route against the REAL schema (via init_test_db) so the
+500 can't come back masked.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from findajob.onboarding import mark_complete
+from findajob.web.app import create_app
+from tests.conftest import init_test_db
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    db = tmp_path / "pipeline.db"
+    init_test_db(db)
+
+    conn = sqlite3.connect(db)
+    # A real cost_log row in the "after" window — exercises the SUM(cost_usd)
+    # path that raised OperationalError on the bad column.
+    conn.execute(
+        "INSERT INTO cost_log (logged_at, cost_usd, operation, model) VALUES (?, ?, ?, ?)",
+        ("2026-05-17 10:00:00", 2.50, "score", "scorer"),
+    )
+    conn.commit()
+    conn.close()
+
+    companies = tmp_path / "companies"
+    companies.mkdir()
+    mark_complete(tmp_path)
+    return TestClient(create_app(companies_root=companies, db_path=db, base_root=tmp_path))
+
+
+def test_config_change_detail_returns_200(client: TestClient) -> None:
+    resp = client.get("/stats/config-change/2026-05-15")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "before" in body
+    assert "after" in body
+    # The after window contains the seeded $2.50 cost row.
+    assert body["after"]["total_cost"] == 2.50
+
+
+def test_config_change_detail_invalid_date_returns_400(client: TestClient) -> None:
+    resp = client.get("/stats/config-change/not-a-date")
+    assert resp.status_code == 400


### PR DESCRIPTION
## What

The `/stats/config-change/{date}` popover returned a 500 on every config-change marker (funnel / feedback / throughput charts) because `before_after_metrics` in `metrics/stats.py` filtered its cost query on `cost_log.timestamp` — a column that does not exist. The real column is `logged_at` (which `cost_rollups.py` uses everywhere); this module was the lone outlier.

A unit fixture that hand-rolled a fabricated `cost_log` schema with a `timestamp` column kept the suite green over the production break — the `feedback_test_real_codepath_when_extracting` anti-pattern (#610/#611) recurring.

## Changes

- `src/findajob/metrics/stats.py` — `cost_filter` now references `logged_at` (both before/after windows).
- `tests/test_metrics_stats.py` — `TestBeforeAfterMetrics` fixture builds the **real** schema via `init_test_db` (production migration chain) instead of a hand-rolled `CREATE TABLE`. Confirmed RED before the fix: all 5 tests raised `OperationalError: no such column: timestamp`.
- `tests/test_web_stats_config_change.py` (new) — route-level regression test; asserts `GET /stats/config-change/{date}` returns 200. Confirmed RED→GREEN by stashing the production fix.
- `CHANGELOG.md` — `### Fixed` entry under Unreleased.

## Acceptance criteria

- [x] `GET /stats/config-change/<real-date>` returns 200, not 500
- [x] `metrics/stats.py` references `cost_log.logged_at`; no remaining `timestamp` reference
- [x] `tests/test_metrics_stats.py` uses the production `cost_log` schema and fails against the old broken query
- [x] `uv run pytest tests/test_metrics_stats.py` passes against the real schema

## Test plan

- `uv run pytest tests/test_metrics_stats.py tests/test_web_stats_config_change.py` → 27 passed
- Full suite: 3559 passed, 2 skipped
- `ruff check` / `ruff format --check` / `mypy src/findajob/metrics/stats.py` all clean

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)