### PR TITLE
test: backfill unit tests for classification, filter_qs, jsonl_tail (#884, #885, #888)

### DIFF
--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,196 @@
+"""Tests for the pure classifier predicates in findajob.classification.
+
+Covers all six public functions: jd_is_usable, is_aggregator_company,
+is_valid_company, is_ingest_noise_title, is_synthetic_job, and
+strip_jd_boilerplate. (Issue #884 said "seven" and listed five; the
+module exposes six — is_valid_company is the wrapper it omitted.)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from findajob.classification import (
+    is_aggregator_company,
+    is_ingest_noise_title,
+    is_synthetic_job,
+    is_valid_company,
+    jd_is_usable,
+    strip_jd_boilerplate,
+)
+
+# ── jd_is_usable ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "jd_text,expected",
+    [
+        (None, False),
+        ("", False),
+        ("   ", False),
+        ("too short", False),  # < 30 chars after strip
+        ("This is a perfectly usable job description with detail.", True),
+        # Wall signals (case-insensitive) flip a long-enough string to unusable.
+        ("Please sign in to view this posting, it is quite long now.", False),
+        ("ACCESS DENIED — you do not have permission to view this job.", False),
+        ("You need to enable JavaScript to run this app on our site here.", False),
+    ],
+)
+def test_jd_is_usable(jd_text: str | None, expected: bool) -> None:
+    assert jd_is_usable(jd_text) is expected
+
+
+# ── is_aggregator_company ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "company,expected",
+    [
+        (None, False),
+        ("", False),
+        ("Acme Corp", False),
+        ("Jobs via LinkedIn", True),
+        ("job via Indeed", True),
+        ("Posted via Workday", True),
+        ("Adecco Staffing", True),
+        ("ADECCO", True),  # case-insensitive
+        ("  Randstad", True),  # leading whitespace stripped
+        ("Robert Half", True),
+    ],
+)
+def test_is_aggregator_company(company: str | None, expected: bool) -> None:
+    assert is_aggregator_company(company) is expected
+
+
+# ── is_valid_company ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "company,expected",
+    [
+        (None, False),
+        ("", False),
+        ("   ", False),  # blank-after-strip is invalid
+        ("Acme Corp", True),
+        ("Adecco", False),  # aggregator is not valid
+    ],
+)
+def test_is_valid_company(company: str | None, expected: bool) -> None:
+    assert is_valid_company(company) is expected
+
+
+# ── is_ingest_noise_title ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        (None, False),
+        ("", False),
+        ("Senior Software Engineer", False),
+        ("Jobs similar to Data Center Technician", True),
+        ("JOBS SIMILAR to anything", True),  # case-insensitive prefix
+        ("Job similar to", True),  # exact-match variant
+        ("  jobs similar to X  ", True),  # whitespace stripped
+    ],
+)
+def test_is_ingest_noise_title(title: str | None, expected: bool) -> None:
+    assert is_ingest_noise_title(title) is expected
+
+
+# ── is_synthetic_job ────────────────────────────────────────────────
+
+
+def _sqlite_row(**cols: object) -> sqlite3.Row:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    keys = ", ".join(f"? AS {k}" for k in cols)
+    return conn.execute(f"SELECT {keys}", tuple(cols.values())).fetchone()
+
+
+@pytest.mark.parametrize(
+    "job,expected",
+    [
+        (None, False),
+        ({}, False),
+        ({"synthetic": 1}, True),
+        ({"synthetic": 0}, False),
+        ({"synthetic": "1"}, True),  # truthy string
+        ({"synthetic": "0"}, False),
+        ({"synthetic": None}, False),
+        ({"other": 1}, False),  # missing key -> not synthetic
+    ],
+)
+def test_is_synthetic_job_dict(job: object, expected: bool) -> None:
+    assert is_synthetic_job(job) is expected
+
+
+def test_is_synthetic_job_sqlite_row_truthy() -> None:
+    # sqlite3.Row supports __getitem__ but NOT .get() — exercises the
+    # fallback branch that exists specifically for this row type.
+    assert is_synthetic_job(_sqlite_row(synthetic=1)) is True
+
+
+def test_is_synthetic_job_sqlite_row_falsey() -> None:
+    assert is_synthetic_job(_sqlite_row(synthetic=0)) is False
+
+
+def test_is_synthetic_job_sqlite_row_missing_column() -> None:
+    # No 'synthetic' column -> row[...] raises IndexError -> not synthetic.
+    assert is_synthetic_job(_sqlite_row(other=1)) is False
+
+
+# ── strip_jd_boilerplate ────────────────────────────────────────────
+
+_REAL = (
+    "We are hiring a data center infrastructure engineer to own server "
+    "and accelerator bring-up across our fleet. You will partner with "
+    "hardware, software, and operations teams to validate new platforms "
+    "from first power-on through production release. Strong NPI and lab "
+    "experience is highly valued in this role."
+)
+_EEO = "We are an equal opportunity employer and do not discriminate."
+
+
+def test_strip_none_returns_empty_string() -> None:
+    assert strip_jd_boilerplate(None) == ""
+
+
+def test_strip_short_text_unchanged() -> None:
+    short = "Short JD under two hundred chars."
+    assert strip_jd_boilerplate(short) == short
+
+
+def test_strip_single_block_unchanged() -> None:
+    # No double-newline -> single paragraph -> never risk stripping it.
+    single = _REAL + " " + _EEO
+    assert strip_jd_boilerplate(single) == single
+
+
+def test_strip_trailing_boilerplate_removed() -> None:
+    text = _REAL + "\n\n" + _EEO
+    result = strip_jd_boilerplate(text)
+    assert "equal opportunity employer" not in result
+    assert result == _REAL
+
+
+def test_strip_stops_at_real_content() -> None:
+    middle = "The team works on-site three days a week in Los Angeles."
+    text = _REAL + "\n\n" + middle + "\n\n" + _EEO
+    result = strip_jd_boilerplate(text)
+    # EEO trimmed, but the non-boilerplate middle paragraph is retained.
+    assert "equal opportunity employer" not in result
+    assert middle in result
+
+
+def test_strip_respects_minimum_retain() -> None:
+    # Trimming the huge trailing boilerplate would drop > 40% of the text,
+    # so the safety bound returns the original untouched.
+    real_short = "We are hiring an infrastructure engineer for fleet bring-up work here." * 3
+    huge_boilerplate = "equal opportunity employer affirmative action " * 30
+    text = real_short + "\n\n" + huge_boilerplate
+    result = strip_jd_boilerplate(text)
+    assert result == text
+    assert "equal opportunity employer" in result

--- a/tests/test_filter_qs.py
+++ b/tests/test_filter_qs.py
@@ -1,0 +1,54 @@
+"""Tests for filter_qs_with() (findajob.web.helpers).
+
+The helper re-encodes a querystring with one key set to a new value,
+preserving all other params. Used by the density toggle to keep active
+filters/sort across page loads.
+
+Behavioral note: the function ALWAYS appends (key, value), so passing an
+empty value yields ``key=`` (an empty param) rather than removing the
+key. Pre-existing blank params in the input are dropped, because the
+parse uses ``keep_blank_values=False``. These tests pin the real
+behavior, not the (slightly off) phrasing in issue #885.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from findajob.web.helpers import filter_qs_with
+
+
+@pytest.mark.parametrize(
+    "existing,key,value,expected",
+    [
+        # Preserve unrelated params while updating the target key.
+        ("a=1&b=2", "b", "3", "a=1&b=3"),
+        # Updated key is re-appended at the end; survivors keep order.
+        ("sort=name&desc=1", "sort", "date", "desc=1&sort=date"),
+        # Adding a brand-new key to an existing querystring.
+        ("a=1", "b", "2", "a=1&b=2"),
+        # Empty querystring -> just the new pair.
+        ("", "x", "1", "x=1"),
+        # Empty value is appended as key= (NOT removed).
+        ("a=1", "b", "", "a=1&b="),
+        # Duplicate occurrences of the TARGET key collapse to one.
+        ("a=1&a=2", "a", "9", "a=9"),
+        # Duplicate occurrences of an UNRELATED key are preserved.
+        ("a=1&a=2", "b", "3", "a=1&a=2&b=3"),
+        # Pre-existing blank param is dropped (keep_blank_values=False).
+        ("a=1&b=", "c", "2", "a=1&c=2"),
+    ],
+)
+def test_filter_qs_with(existing: str, key: str, value: str, expected: str) -> None:
+    assert filter_qs_with(existing, key, value) == expected
+
+
+def test_special_characters_are_url_encoded() -> None:
+    # Space -> '+', '&' -> '%26' (urlencode uses quote_plus by default).
+    assert filter_qs_with("", "q", "a b&c") == "q=a+b%26c"
+
+
+def test_encoded_input_survivors_are_preserved() -> None:
+    # An incoming encoded value round-trips through parse + re-encode.
+    result = filter_qs_with("q=a+b%26c", "page", "2")
+    assert result == "q=a+b%26c&page=2"

--- a/tests/test_jsonl_tail.py
+++ b/tests/test_jsonl_tail.py
@@ -1,0 +1,100 @@
+"""Tests for the bounded JSONL tail reader (findajob.jsonl_tail).
+
+Exercises tail_events() against real temporary files (no I/O mocking):
+newest-first decode, the max_bytes overflow path that drops a partial
+first line, malformed-line skipping, the two OSError branches
+(missing-file stat failure + directory open failure), and UTF-8
+error='replace' tolerance.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from findajob.jsonl_tail import tail_events
+
+
+def _write(path: Path, lines: list[str]) -> None:
+    path.write_text("".join(f"{line}\n" for line in lines), encoding="utf-8")
+
+
+def test_yields_decoded_events_newest_first(tmp_path: Path) -> None:
+    p = tmp_path / "events.jsonl"
+    _write(p, ['{"i": 0}', '{"i": 1}', '{"i": 2}'])
+
+    events = list(tail_events(p))
+
+    assert events == [{"i": 2}, {"i": 1}, {"i": 0}]
+
+
+def test_empty_file_yields_nothing(tmp_path: Path) -> None:
+    p = tmp_path / "empty.jsonl"
+    p.write_bytes(b"")
+
+    assert list(tail_events(p)) == []
+
+
+def test_overflow_drops_partial_first_line(tmp_path: Path) -> None:
+    # First line is long padding; max_bytes is small enough that the tail
+    # buffer starts mid-way through it. read_len < size, so the partial
+    # first line must be discarded — only the two whole trailing lines
+    # survive, newest-first.
+    p = tmp_path / "big.jsonl"
+    long_first = '{"i": 0, "pad": "' + ("a" * 500) + '"}'
+    _write(p, [long_first, '{"i": 1}', '{"i": 2}'])
+
+    events = list(tail_events(p, max_bytes=100))
+
+    assert events == [{"i": 2}, {"i": 1}]
+    # The padded first line was never emitted (it was the partial).
+    assert all(e.get("i") != 0 for e in events)
+
+
+def test_malformed_lines_are_skipped_with_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    p = tmp_path / "mixed.jsonl"
+    _write(p, ['{"ok": 1}', "this is not json", '{"ok": 2}'])
+
+    with caplog.at_level(logging.WARNING, logger="findajob.jsonl_tail"):
+        events = list(tail_events(p))
+
+    assert events == [{"ok": 2}, {"ok": 1}]
+    assert any("malformed line" in r.message for r in caplog.records)
+
+
+def test_blank_lines_are_skipped(tmp_path: Path) -> None:
+    p = tmp_path / "blanks.jsonl"
+    p.write_text('{"a": 1}\n\n   \n{"a": 2}\n', encoding="utf-8")
+
+    assert list(tail_events(p)) == [{"a": 2}, {"a": 1}]
+
+
+def test_missing_file_yields_nothing(tmp_path: Path) -> None:
+    # os.path.getsize raises FileNotFoundError (an OSError) -> empty.
+    missing = tmp_path / "does_not_exist.jsonl"
+
+    assert list(tail_events(missing)) == []
+
+
+def test_unreadable_file_yields_nothing(tmp_path: Path) -> None:
+    # A directory stats fine but open(..., "rb") raises IsADirectoryError
+    # (an OSError) -> empty. Exercises the "cannot open" branch without
+    # chmod games that break under root.
+    a_dir = tmp_path / "a_directory"
+    a_dir.mkdir()
+
+    assert list(tail_events(a_dir)) == []
+
+
+def test_invalid_utf8_decoded_with_replacement(tmp_path: Path) -> None:
+    # Raw invalid UTF-8 bytes inside a JSON string value. errors="replace"
+    # turns them into U+FFFD, leaving structurally valid JSON that decodes.
+    p = tmp_path / "badbytes.jsonl"
+    p.write_bytes(b'{"k": "\xff\xfe"}\n')
+
+    events = list(tail_events(p))
+
+    assert len(events) == 1
+    assert events[0]["k"] == "��"


### PR DESCRIPTION
Bundles three `good first issue` test-backfill pulls (session-2 worktree). Pure additive test coverage — **no production code changed**, three distinct new test files against three distinct previously-untested modules.

## What's covered

| Issue | Module | Test file | Notes |
|---|---|---|---|
| #884 | `classification.py` | `tests/test_classification.py` | All **six** public predicates (issue said "seven"/listed five — module exposes six; `is_valid_company` was the omitted wrapper). Includes the `sqlite3.Row` `.get()`-fallback branch and `strip_jd_boilerplate` safety bounds. |
| #885 | `web/helpers.py::filter_qs_with` | `tests/test_filter_qs.py` | Pins **actual** behavior: appends `(key, value)` unconditionally, so empty value → `key=` (not removal — the issue's "remove a param" framing was off); pre-existing blank params dropped (`keep_blank_values=False`). |
| #888 | `jsonl_tail.py::tail_events` | `tests/test_jsonl_tail.py` | Real `tmp_path` files (no I/O mocks): newest-first decode, `max_bytes` overflow partial-line drop, malformed-line skip, both `OSError` branches (missing-stat + directory-open), UTF-8 `errors='replace'`. |

## Test plan

- [x] `uv run pytest tests/test_classification.py tests/test_filter_qs.py tests/test_jsonl_tail.py` → **65 passed**
- [x] `ruff check` + `ruff format --check` clean on all three files
- [ ] Full local suite — not run to green locally (a slow/network-bound test elsewhere in the suite stalled at collection); deferring to CI as the authoritative gate. The three new files are isolated and additive, with no production-code or fixture changes.

Closes #884
Closes #885
Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)