### PR TITLE
refactor(tz): fold spend_ceiling + spend-chip TZ reads onto timeutil.local_tz() (#990)

### DIFF
--- a/src/findajob/cost_rollups.py
+++ b/src/findajob/cost_rollups.py
@@ -226,9 +226,9 @@ def spend_this_month(
     (the difference can be up to 14h depending on offset). Default ``"UTC"``
     preserves pre-#823 behavior for callers that don't pass a tz.
 
-    Callers read ``os.environ.get("TZ") or "UTC"`` and pass it through,
-    matching :func:`weekly_spend` and the codebase precedent at
-    ``findajob/web/routes/landing.py:42``.
+    Callers pass the stack timezone via :func:`findajob.timeutil.local_tz`,
+    matching :func:`weekly_spend`. This function stays pure (no env read);
+    the ``tz`` arg is the single point where the local zone enters.
 
     Args:
         conn: SQLite connection.

--- a/src/findajob/spend_ceiling.py
+++ b/src/findajob/spend_ceiling.py
@@ -22,7 +22,6 @@ per calendar month (deduped via in-process set + ``notifications`` table).
 from __future__ import annotations
 
 import logging
-import os
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
@@ -34,13 +33,9 @@ from findajob.cost_rollups import spend_this_month
 from findajob.db import connect
 from findajob.llm.openrouter import LLMSpendCeilingExceeded
 from findajob.paths import BASE
+from findajob.timeutil import local_tz
 
 log = logging.getLogger(__name__)
-
-
-def _stack_tz() -> str:
-    """IANA tz for month-boundary math. Mirrors ``landing.py:42`` convention."""
-    return os.environ.get("TZ") or "UTC"
 
 
 _DB_PATH = Path(BASE) / "data" / "pipeline.db"
@@ -69,7 +64,7 @@ def _already_sent_this_month(kind: str, month: str, conn: sqlite3.Connection) ->
     ``notifications.sent_at`` is UTC (``datetime('now')``). We need the
     TZ-aware month boundaries to match ``spend_this_month()``'s reset.
     """
-    tz = _stack_tz()
+    tz = local_tz()
     zi = ZoneInfo(tz)
     year, mon = int(month[:4]), int(month[5:7])
     start_local = datetime(year, mon, 1, tzinfo=zi)
@@ -93,7 +88,7 @@ def _maybe_fire_threshold_alerts(current: float, ceiling: float, conn: sqlite3.C
     failure never prevents the gate from enforcing.
     """
     try:
-        month = _month_key(_stack_tz())
+        month = _month_key(local_tz())
         thresholds: list[tuple[str, float, str, str, str]] = []
 
         if current >= ceiling:
@@ -157,7 +152,7 @@ def check_call_gate() -> None:
 
     conn = connect(_DB_PATH)
     try:
-        current = spend_this_month(conn, tz=_stack_tz())
+        current = spend_this_month(conn, tz=local_tz())
         _maybe_fire_threshold_alerts(current, ceiling, conn)
     finally:
         conn.close()
@@ -176,7 +171,7 @@ def check_launch_gate(conn: sqlite3.Connection) -> LaunchGateRefusal | None:
     if ceiling is None:
         return None
 
-    current = spend_this_month(conn, tz=_stack_tz())
+    current = spend_this_month(conn, tz=local_tz())
     _maybe_fire_threshold_alerts(current, ceiling, conn)
     if current >= ceiling:
         return LaunchGateRefusal(ceiling_usd=ceiling, current_sum_usd=current)

--- a/src/findajob/timeutil.py
+++ b/src/findajob/timeutil.py
@@ -15,9 +15,6 @@ zone (for display or calendar math) should obtain it here rather than re-reading
 ``TZ`` or hardcoding a zone. It reuses the ``astimezone(UTC)`` idiom proven
 DST-correct in ``cost_rollups``; every helper takes ``tz``/``now`` seams so
 callers (and tests) can be deterministic without touching process-global ``TZ``.
-(``cost_rollups`` and ``spend_ceiling`` predate this module and still read ``TZ``
-directly — folding them onto ``local_tz`` is a follow-up refactor, not a behavior
-change.)
 """
 
 from __future__ import annotations

--- a/src/findajob/web/app.py
+++ b/src/findajob/web/app.py
@@ -67,8 +67,9 @@ def create_app(
         try:
             from findajob.config_loader import load_spend_ceiling
             from findajob.cost_rollups import spend_this_month
+            from findajob.timeutil import local_tz
 
-            spent = spend_this_month(conn, tz=os.environ.get("TZ") or "UTC")
+            spent = spend_this_month(conn, tz=local_tz())
             ceiling = load_spend_ceiling()
         except sqlite3.Error:
             return {"spent": 0.0, "ceiling": None, "ratio": 0.0, "state": "no_ceiling"}


### PR DESCRIPTION
Closes #990.

Makes `findajob.timeutil` the genuine single source of truth for the stack timezone by folding the two remaining inline `os.environ.get("TZ") or "UTC"` reads onto `timeutil.local_tz()`. Pure refactor — **no behavior change**.

## What changed

- **`spend_ceiling.py`** — deleted the private `_stack_tz()` helper (no external callers; no test patches it — verified by grep), call `local_tz()` at its four sites, dropped the now-unused `import os`.
- **`web/app.py`** — the spend-chip context passes `tz=local_tz()` instead of the inline read.
- **`timeutil.py`** — removed the docstring note that claimed `cost_rollups`/`spend_ceiling` "still read TZ directly" (AC3 — now false).
- **`cost_rollups.py`** — refreshed `spend_this_month`'s docstring, which named the old inline read.

## Scope decision (recorded for the issue)

The issue body mentions "the [cost_rollups] module's own tz defaulting", but `cost_rollups.py` has an explicit purity contract — *"no env reads, pure SELECTs"* — and its `tz` parameter defaults to `"UTC"` to preserve behavior for callers that don't pass a zone (documented as pre-#823 behavior). Making it read env would break that contract **and** change behavior for default callers, violating the "no behavior change" acceptance criterion. So the fold targets the two actual env-reading call sites; `cost_rollups` internals are intentionally untouched.

## Out of scope (follow-up candidate)

`web/routes/landing.py:42` reads `os.environ.get("TZ", "UTC")` — note the *default-arg* form, not `... or "UTC"`. It has different semantics at the `TZ=""` edge (returns `""` → `ZoneInfo("")` raises, vs `local_tz()`'s `"UTC"`), so folding it in would be a real behavior change. Left alone deliberately; worth a separate tiny issue if we want full consolidation.

## Acceptance criteria

- [x] `spend_ceiling._stack_tz()` and the `cost_rollups`/`web.app` TZ reads route through `timeutil.local_tz()`.
- [x] No behavior change — `local_tz()` is byte-identical to the inlined read for every `TZ` value including unset → UTC; full suite stays green.
- [x] `timeutil`'s docstring note is removed now that the claim is true.

## Documentation Impact

In-code docstrings only (`timeutil`, `cost_rollups` — updated in this PR). No CHANGELOG entry: this is a no-behavior-change internal consolidation with no user/operator/developer-facing surface change; the `[Unreleased]` section reserves entries for behavior changes. No schema/config/env/crontab change.

## Verification

- `ruff check` — All checks passed
- `ruff format --check` — 4 files already formatted
- `mypy src/findajob/{spend_ceiling,cost_rollups,timeutil}.py` — Success, no issues
- Full `uv run pytest -q` — **3697 passed, 2 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
