### PR TITLE
fix(contacts): consolidate ingest+prep onto canonical company_match() (#963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 - **`uv sync` now installs findajob itself** (#978): `pyproject.toml` gained a `[build-system]` table (setuptools backend), so `uv sync` installs the findajob package (editable) alongside its dependencies in one step. Fresh git worktrees and clean dev checkouts no longer need a separate `uv pip install -e .` before `import findajob` works. CI's install step collapses to `uv sync --locked --extra dev`, with lint/type/test now run via `uv run`. The Docker build commands are unchanged: `pip install --require-hashes` cannot hash an editable install, so findajob stays excluded from the hashed export (`--no-emit-project`) and is editable-installed separately (now resolving the explicit `setuptools.build_meta` backend rather than pip's legacy PEP 517 fallback — equivalent for this src-layout package). No runtime or operator-facing behavior change.
 
+### Fixed
+
+- **False "inside contact" signals on the board for short-named companies** (#963): the ingest-time contact matcher used substring containment, so a connection at "GreenApple" would light up the amber contact cell on an "Apple" job, and the two-letter company "AI" matched any connection whose company merely contained "ai" (e.g. "AIRBUS"). Ingest now routes through the same canonical word-boundary `company_match()` the prep path already used (the #497 fix), so both paths match identically and the divergent matcher is gone. A renamed `connections.csv` header now fails the same way at ingest as at prep — logging a `find_contacts_error` event instead of silently yielding zero contacts (no more silent split-brain). No schema change.
+
 ## [0.32.0] — 2026-06-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,8 @@ Two regression-prone rules every `company_match()` implementation must observe:
 1. **Blank-string guard.** `connections.csv` may have blank-company rows. `'' in 'anything'` is True in Python — without the guard, every blank-company row false-matches. Required: `if not s or not c: return False`.
 2. **Word-boundary matching, not substring containment** (#497). Use `re.search(rf"\b{re.escape(needle)}\b", haystack)` (bidirectional), not `needle in haystack`. Substring `in` matches "Apple" inside "GreenApple" and "AI" inside "AIRBUS"; word boundaries don't.
 
+Ingest (`triage/contacts.py`) and prep (`find_contacts.py`) share the single canonical `company_match()` — ingest delegates to it (#963). Do not reintroduce a separate matcher in the triage path; a divergent copy is what let the substring bug survive there after #497 fixed prep. (The rejection detector's `_company_match()` is intentionally a different, fuzzy algorithm — leave it.)
+
 ### Title/Company Cleaning
 API title and company fields contain appended metadata (location, salary, recency flags).
 `clean_title()` and `clean_company()` must be applied at every ingest path before storing.

--- a/src/findajob/triage/contacts.py
+++ b/src/findajob/triage/contacts.py
@@ -15,17 +15,24 @@ matcher in #963.
 
 from __future__ import annotations
 
-from findajob.find_contacts import find_contacts as _canonical_find_contacts
-
 
 def find_contacts(company: str | None) -> list[str]:
     """Return ``"<name> (<title>)"`` for each LinkedIn connection at *company*.
 
     Guards blank/None *before* delegating: the canonical ``company_match`` has
-    no None-guard, so ``_canonical_find_contacts(None)`` would raise inside the
-    reader and log a spurious ``find_contacts_error`` for a perfectly normal
-    empty-company job (#963).
+    no None-guard, so delegating ``None`` would raise inside the reader and log
+    a spurious ``find_contacts_error`` for a perfectly normal empty-company job
+    (#963).
     """
     if not company or not company.strip():
         return []
-    return [f"{c['name']} ({c['title']})" for c in _canonical_find_contacts(company)]
+    # Resolve the canonical matcher at call time, not via a module-level import.
+    # The import-safety tests pop + reimport ``findajob.find_contacts``; a
+    # module-level binding would then point at a stale, orphaned module object
+    # whose ``CONNECTIONS`` a test's monkeypatch can no longer reach (#963).
+    # Call-time resolution always goes through the live ``sys.modules`` entry,
+    # and keeps this triage submodule's import surface minimal — no transitive
+    # LLM/db imports at module load.
+    from findajob.find_contacts import find_contacts as canonical
+
+    return [f"{c['name']} ({c['title']})" for c in canonical(company)]

--- a/src/findajob/triage/contacts.py
+++ b/src/findajob/triage/contacts.py
@@ -1,28 +1,31 @@
 """LinkedIn-connections contact lookup for ingested jobs.
 
-Reads `data/connections.csv` and returns matching contacts for a company.
-Extracted from `scripts/triage.py` in M3 (#537).
+Thin adapter over the canonical matcher in ``findajob.find_contacts`` (#963).
+The triage orchestrator and the ``known_contacts`` DB column expect a
+``list[str]`` of ``"<name> (<title>)"`` strings, so this wraps the canonical
+``find_contacts`` — which matches via the #497 word-boundary ``company_match``
+— and reformats its structured dicts back to that string shape.
+
+Consolidating ingest and prep onto one matcher fixes the substring-collision
+bug the ingest path used to have ("Apple" matching "GreenApple", "AI" matching
+"AIRBUS") and removes the drift trap of two divergent implementations.
+Extracted from ``scripts/triage.py`` in M3 (#537); folded onto the canonical
+matcher in #963.
 """
 
-import csv
+from __future__ import annotations
 
-from findajob.paths import BASE
-
-CONNECTIONS = f"{BASE}/data/connections.csv"
+from findajob.find_contacts import find_contacts as _canonical_find_contacts
 
 
 def find_contacts(company: str | None) -> list[str]:
-    contacts: list[str] = []
+    """Return ``"<name> (<title>)"`` for each LinkedIn connection at *company*.
+
+    Guards blank/None *before* delegating: the canonical ``company_match`` has
+    no None-guard, so ``_canonical_find_contacts(None)`` would raise inside the
+    reader and log a spurious ``find_contacts_error`` for a perfectly normal
+    empty-company job (#963).
+    """
     if not company or not company.strip():
-        return contacts
-    try:
-        with open(CONNECTIONS) as f:
-            for row in csv.DictReader(f):
-                contact_co = row.get("Company", "").strip()
-                if not contact_co:
-                    continue  # guard: '' in 'anything' is True in Python
-                if company.lower() in contact_co.lower():
-                    contacts.append(f"{row['First Name']} {row['Last Name']} ({row['Position']})")
-    except Exception:
-        pass
-    return contacts
+        return []
+    return [f"{c['name']} ({c['title']})" for c in _canonical_find_contacts(company)]

--- a/tests/test_triage_contacts.py
+++ b/tests/test_triage_contacts.py
@@ -1,0 +1,102 @@
+"""Regression tests for findajob.triage.contacts (#963).
+
+The ingest-time contact matcher must route through the canonical
+word-boundary ``company_match()`` in ``findajob.find_contacts`` rather than
+the old substring ``in`` matcher (the #497 bug class). These tests drive the
+real ingest entry point, ``triage.contacts.find_contacts``, against a seeded
+connections.csv and assert it behaves identically to the prep path — same
+word-boundary matching (AC1/AC4) and the same loud-but-non-crashing failure
+on a renamed header (AC3).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_HEADER = "First Name,Last Name,Company,Position,Connected On,URL\n"
+
+
+@pytest.fixture
+def seeded(monkeypatch, tmp_path):
+    """Redirect both the ingest and canonical CONNECTIONS to one tmp CSV.
+
+    The ingest wrapper delegates to ``findajob.find_contacts``, so post-#963
+    the CSV is read (and any error event logged) there. Pre-#963 the substring
+    matcher read its own ``triage.contacts.CONNECTIONS``. Patching both —
+    guarded by ``hasattr`` so it survives removal of the now-dead ingest
+    constant — keeps the test meaningful across the red→green transition.
+
+    Returns ``(ingest_module, csv_path, events)`` where ``events`` captures
+    every ``log_event`` fired by the canonical reader.
+    """
+    from findajob import find_contacts as canonical
+    from findajob.triage import contacts as ingest
+
+    csv_path = tmp_path / "connections.csv"
+    monkeypatch.setattr(canonical, "CONNECTIONS", str(csv_path))
+    if hasattr(ingest, "CONNECTIONS"):
+        monkeypatch.setattr(ingest, "CONNECTIONS", str(csv_path))
+
+    events: list[tuple] = []
+    monkeypatch.setattr(canonical, "log_event", lambda name, **kw: events.append((name, kw)))
+
+    return ingest, csv_path, events
+
+
+def test_ingest_rejects_prefix_collision(seeded):
+    """#497 headline case on the INGEST path: 'Apple' must not match 'GreenApple'."""
+    ingest, csv_path, _ = seeded
+    csv_path.write_text(_HEADER + "Ada,Lovelace,GreenApple Inc.,Director,01 Jan 2020,https://e.com/a\n")
+
+    assert ingest.find_contacts("Apple") == []
+
+
+def test_ingest_rejects_short_string_substring(seeded):
+    """'AI' must not match 'AIRBUS' at ingest — substring `in` matched every 'ai'."""
+    ingest, csv_path, _ = seeded
+    csv_path.write_text(_HEADER + "Grace,Hopper,AIRBUS Inc.,Engineer,01 Jan 2020,https://e.com/g\n")
+
+    assert ingest.find_contacts("AI") == []
+
+
+def test_ingest_legitimate_match_still_found(seeded):
+    """A real same-company connection is still matched and formatted '<name> (<title>)'."""
+    ingest, csv_path, _ = seeded
+    csv_path.write_text(_HEADER + "Ada,Lovelace,Meta Platforms,Engineering Director,01 Jan 2020,https://e.com/a\n")
+
+    assert ingest.find_contacts("Meta") == ["Ada Lovelace (Engineering Director)"]
+
+
+def test_ingest_blank_or_none_company_no_error_event(seeded):
+    """None/blank company returns [] WITHOUT firing find_contacts_error.
+
+    The wrapper must guard before delegating: canonical ``company_match()`` has
+    no None-guard, so ``canonical.find_contacts(None)`` would hit
+    ``None.lower()`` -> AttributeError -> a spurious ``find_contacts_error`` on
+    a perfectly normal empty-company job.
+    """
+    ingest, csv_path, events = seeded
+    csv_path.write_text(_HEADER + "Ada,Lovelace,Meta,Director,01 Jan 2020,https://e.com/a\n")
+
+    assert ingest.find_contacts(None) == []
+    assert ingest.find_contacts("") == []
+    assert ingest.find_contacts("   ") == []
+    assert not any(e[0] == "find_contacts_error" for e in events), events
+
+
+def test_ingest_renamed_header_fails_loudly_like_prep(seeded):
+    """A renamed header logs find_contacts_error and returns [] on the ingest
+    path — identical observable behavior to prep (AC3), not a silent swallow.
+    """
+    ingest, csv_path, events = seeded
+    # 'Given Name' instead of 'First Name' — DictReader yields rows but the
+    # canonical reader's row['First Name'] raises KeyError inside the loop.
+    csv_path.write_text(
+        "Given Name,Last Name,Company,Position,Connected On,URL\n"
+        "Ada,Lovelace,Meta,Director,01 Jan 2020,https://e.com/a\n"
+    )
+
+    result = ingest.find_contacts("Meta")
+
+    assert result == []
+    assert any(e[0] == "find_contacts_error" for e in events), events


### PR DESCRIPTION
## What & why

The ingest-time contact matcher (`triage/contacts.py`) used substring containment, so a LinkedIn connection at **GreenApple** lit the amber "inside contact" cell on an **Apple** job, and the two-letter company **AI** matched any connection whose company merely contained `ai` (e.g. **AIRBUS**). This is the exact #497 bug class — which the prep path (`find_contacts.py::company_match`) already fixed with bidirectional word-boundary matching. Two divergent matchers also guaranteed future drift.

This folds ingest onto the canonical matcher. `triage/contacts.py::find_contacts` becomes a thin adapter: guard blank/None, delegate to canonical `find_contacts` (word-boundary `company_match` + suffix normalization), and reformat the structured dicts back to the `"<name> (<title>)"` `list[str]` the orchestrator and `known_contacts` TEXT column already expect. Blast radius is one call site; the column shape is unchanged.

## Acceptance criteria

- [x] Ingest-time matching uses word-boundary matching (no substring collisions)
- [x] A single canonical `company_match()` used by both ingest and prep
- [x] A renamed `connections.csv` header fails identically in both paths (logs `find_contacts_error` + returns `[]`, instead of a silent `except: pass`)
- [x] Tests cover the Apple/GreenApple and AI/AIRBUS cases on the **ingest** path

## Design notes

- **None-guard stays in the wrapper, before delegating.** Canonical `company_match` has no None-guard, so delegating `None` would hit `None.lower()` → `AttributeError` → a *spurious* `find_contacts_error` on a normal empty-company job. The new test asserts `None`/blank returns `[]` with **no** error event.
- **Format is byte-identical:** canonical dict `name = "First Last"`, `title = Position`, so `f"{c['name']} ({c['title']})"` reproduces the old `"{First} {Last} ({Position})"` exactly — no board-cell drift.
- **Order preserved:** canonical `find_contacts` returns CSV order (no internal sort; `rank_contacts` is separate and not on the ingest path), so the orchestrator's `contacts[:3]` is unchanged.
- **Scope:** the rejection detector's `_company_match()` is intentionally a *different, fuzzy* algorithm (`rapidfuzz token_set_ratio`) — deliberately left alone. The diag script `scripts/diag/debug_contacts.py` keeps its substring copy because it exists to *diagnose* substring behavior.

## Test plan

- [x] New `tests/test_triage_contacts.py` drives the real ingest entry point (`triage.contacts.find_contacts`) against seeded CSVs — TDD red→green verified (substring + silent-swallow failures observed before the fix)
- [x] `tests/test_triage_import_safety.py` passes (the new transitive import of `findajob.find_contacts` keeps triage import-safe)
- [x] Full unit suite green (`uv run pytest -m "not integration"`, exit 0)
- [x] `ruff check` ✓, `ruff format --check` ✓, `mypy src/findajob/triage/` ✓
- [ ] Integration/browser smoke — N/A (pure-Python matcher consolidation; no web/route/schema change)

## Docs

- `CHANGELOG.md` `[Unreleased] → Fixed` entry
- `CLAUDE.md` `company_match() Discipline` gains a normative anti-drift note (ingest delegates to canonical; don't reintroduce a divergent matcher)
- No migration

Closes #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)