### PR TITLE
docs: move [Unreleased] → [0.33.0] in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+## [0.33.0] — 2026-06-03
+
 ### Added
 
 - **Change your timezone after onboarding** (#988): a new `/settings/timezone/` page lets you pick a different IANA zone without re-running the onboarding interview. It shows the currently running `TZ` plus any picked-but-pending zone, validates the selection (`ZoneInfo`), and writes `data/timezone` atomically — invalid input is rejected inline with no partial write. The change takes effect on the next app restart (same semantics as the onboarding pick and the dashboard restart-to-apply banner, #981), and that banner now links straight here. A shared sub-nav (`templates/settings/_settings_nav.html`) cross-links every `/settings/` page so each is reachable from the others.
@@ -1514,7 +1516,8 @@ from GHCR and deployed via Docker Compose on a shared Docker host.
 - Documentation cleanup — removing `sigoden/aichat` references in favor of
   `blob42/aichat-ng` — is tracked in #70
 
-[Unreleased]: https://github.com/brockamer/findajob/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/brockamer/findajob/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/brockamer/findajob/releases/tag/v0.33.0
 [0.32.0]: https://github.com/brockamer/findajob/releases/tag/v0.32.0
 [0.31.3]: https://github.com/brockamer/findajob/releases/tag/v0.31.3
 [0.31.2]: https://github.com/brockamer/findajob/releases/tag/v0.31.2


### PR DESCRIPTION
Cuts **v0.33.0** (minor — carries a schema migration). Rolls `[Unreleased]` → `[0.33.0] — 2026-06-03`, adds a fresh empty `[Unreleased]`, and updates the footer comparator links.

Release contents (7 PRs since v0.32.0):
- **Added:** change/suggest timezone in onboarding + `/settings/timezone` (#988, #989)
- **Changed:** `uv sync` installs findajob via `[build-system]` (#978); de-field-lock outreach ranking (#964) and feedback title-keyword signals (#1004)
- **Removed:** dead `jobs.network_depth` column (#964)
- **Fixed:** Fly web-deploy 404 build fix (#1002) + docs (#999); canonical `company_match()` consolidation (#963)
- **Migration required:** schema 0010 drops `jobs.network_depth` (#964) — auto-applied on startup, no operator action, no data loss

Tag `v0.33.0` follows once this lands on `main` and `:latest` rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)