### PR TITLE
fix(fly): EXPOSE 8090 so web-launch port detection matches uvicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Web "Launch from GitHub" deploy failed its health check (port 8080 vs 8090)** (#1008): after #1002 made the no-terminal Fly launch build the Dockerfile, deploys got past the `Could not find image` 404 but then failed the post-launch health check — Fly's launch scanner sets `internal_port` from the Dockerfile's `EXPOSE` instruction and, finding none, defaulted to **8080**, while findajob's uvicorn serves **8090**. The proxy couldn't route, the health check timed out, and the deploy was marked Failed. Adding `EXPOSE 8090` to the Dockerfile makes the scanner detect 8090, aligning the service and health check with the app. Metadata-only — no runtime change; the CLI deploy path (`fly deploy --config ops/fly.toml`, explicit `internal_port = 8090`, no scanner) and compose were already correct and are unaffected. **No `migration-required`.**
+
 ## [0.33.0] — 2026-06-03
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,13 @@ RUN chmod +x /entrypoint.sh
 # Path resolution — tell src/findajob/paths.py where we live.
 ENV JSP_BASE=/app
 
+# Declare the port uvicorn serves (entrypoint runs it on 8090). This is metadata,
+# not a runtime binding — but Fly's "Launch from GitHub" scanner reads EXPOSE to
+# set internal_port; without it the scanner defaults to 8080 and the deploy's
+# health check targets the wrong port (#1008). Keep this in sync with the
+# uvicorn --port in ops/entrypoint.sh and internal_port in fly.toml / ops/fly.toml.
+EXPOSE 8090
+
 # tini as PID 1 for signal propagation; entrypoint creates the runtime user
 # at PUID:PGID, seeds bundled config, and execs the CMD under gosu.
 ENTRYPOINT ["tini", "--", "/entrypoint.sh"]


### PR DESCRIPTION
## Summary

Follow-up to #1002. The web "Launch from GitHub" deploy now builds + creates the image (no more 404), but **fails its post-launch health check**: Fly's launch scanner sets `internal_port` from the Dockerfile's `EXPOSE` and, finding none, defaulted to **8080**, while uvicorn serves **8090**. Proxy can't route → health check times out → deploy Failed. Confirmed via cowork validation on a fresh launch (machine logs: `servicecheck-00-http-8080` failing while `Uvicorn running on http://0.0.0.0:8090`).

## Change

- **`Dockerfile`:** add `EXPOSE 8090` so Fly's launch scanner detects the right port. Metadata only — no runtime change.
- **`CHANGELOG.md`:** `[Unreleased]` → Fixed.

The CLI path (`fly deploy --config ops/fly.toml`, explicit `internal_port = 8090`, no scanner) and compose were already correct and are unaffected — which is why the CLI deploy succeeded.

## Test plan

- [x] CI build-image / docker-build-smoke pass (EXPOSE is a no-op for the build)
- [ ] **Cowork:** a fresh web "Use a public repo" launch now reaches a healthy "Deployed" state and the URL serves findajob (no 8080 health-check timeout)

Closes #1008
