### PR TITLE
docs: finalize one-click Fly install, retire obsolete 404 troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ changes may land in minor version bumps; patch releases are bugfix-only.
 
 ## [Unreleased]
 
+### Changed
+
+- **Fly install guides reflect the validated one-click flow** (#1012): `start-here-fly.md` and `install-fly.md` now tell you to accept the launch wizard's defaults (including the **Internal port**) — corrected from the prior claim that the repo `fly.toml` overrides the wizard's port, which it does not. The obsolete "Could not find image" 404 walkthrough (the bug fixed at the source by #1002/#1010) is trimmed to a brief retry safety-net. Docs-only.
+
 ### Fixed
 
 - **No-CLI Fly web install now deploys healthy when you accept all defaults** (#1010): after #1002 made the web "Launch from GitHub" build + run, the deploy still failed its health check unless the user manually changed the launch wizard's Internal port to 8090 — Fly's wizard defaults the port to **8080** and ignores the repo `fly.toml`'s `internal_port` (and the Dockerfile `EXPOSE`, which the pre-build wizard can't read), while uvicorn served 8090. uvicorn's port is now env-driven (`FINDAJOB_INTERNAL_PORT`, default 8090) and the root `fly.toml` (the web-launch config) targets **8080** and sets `FINDAJOB_INTERNAL_PORT=8080` via `[env]` (which the wizard applies to the machine), so the wizard's 8080 default matches the app with no user action. `ops/fly.toml*` and compose are unchanged at 8090 — the CLI deploy path and every existing deploy keep serving 8090. **No `migration-required`** — the default port is unchanged; only the web-launch config differs.

--- a/docs/getting-started/install-fly.md
+++ b/docs/getting-started/install-fly.md
@@ -60,7 +60,7 @@ In the dialog that opens:
 
    ![Region, port, CPU, and memory settings](install-fly-web/05b-launch-config-middle.png)
 
-   Leave everything else as-is. The `fly.toml` in the repo sets the correct internal port (8090), volume (8 GB), and machine size. These override the form defaults.
+   Leave everything else as-is — including the **Internal port** (the shown default is correct; don't change it). The repo's `fly.toml` provides the volume (8 GB) and machine size.
 
    > **If the form shows a "Variables" / "Environment variables" section (Name + Value), leave it blank.** API keys go in **Secrets** after the deploy (next section), not here — anything typed here just becomes an unused environment variable.
 
@@ -206,7 +206,7 @@ See [`cost.md`](cost.md) for the full breakdown with `cost_log`-grounded ranges.
 
 - **Deploy fails with "This functionality is disabled for trial organizations"** — billing isn't enabled on your Fly org. Add a credit card at your Fly dashboard's Billing page and retry.
 - **Browser sees `Connection refused` after deploy** — the machine may still be cold-starting. Wait 60 seconds and retry.
-- **Deploy fails with `Could not find image` (a 404)** — the deploy log shows a green "Build image" step, then "Deploy application" fails with `failed to create release (status 404): … Could not find image …`. Fly built the image but couldn't find it at deploy time — a builder/registry timing issue. First, remove anything you entered in the launch form's Variables/Name-Value field, then re-run the deploy; the transient form of this clears on a retry (try 2–3 times, a minute or two apart). If it persists, use the **CLI deploy** path below — `ops/fly-deploy.sh` deploys findajob's prebuilt public image (`[build] image` in `ops/fly.toml`) and never builds the Dockerfile, so it sidesteps this error class entirely.
+- **A deploy fails or times out** — first deploys occasionally hit a transient Fly builder/registry hiccup. Re-run the deploy; it usually clears on a retry. If it persists, the **CLI deploy** path below pulls findajob's prebuilt image (`ops/fly.toml`'s `[build] image`) instead of building, which sidesteps build/registry issues entirely.
 - **OpenRouter calls fail with `402 PaymentRequired`** — your OpenRouter balance is exhausted. Top up at <https://openrouter.ai/credits>. The onboarding interview handles this gracefully; daily triage does not — it logs and continues at the next cycle.
 - **Secrets not taking effect** — after adding secrets on the Secrets page, you must click **Deploy Secrets** to restart the machine. Secrets are staged until deployed.
 

--- a/docs/getting-started/start-here-fly.md
+++ b/docs/getting-started/start-here-fly.md
@@ -97,7 +97,7 @@ Everything in this section happens in your web browser — no terminal or comman
 
    ![Configuration form — region, port, CPU, memory](install-fly-web/05b-launch-config-middle.png)
 
-   Leave everything else as-is — the `fly.toml` in the repo sets the correct port, volume, and machine size automatically.
+   Leave everything else as-is — including the **Internal port** (the shown default is correct; you don't need to change it). The repo's `fly.toml` sets the volume and machine size automatically.
 
    > **If the form shows a "Variables" or "Environment variables" section (a Name + Value pair), leave it blank.** Your API keys do *not* go here — you'll add them as **Secrets** after the app deploys (Step 6). Anything you type into this field just becomes an unused environment variable; it is not required to deploy.
 
@@ -111,7 +111,7 @@ Everything in this section happens in your web browser — no terminal or comman
 
 - **Deploy fails with "This functionality is disabled for trial organizations"** — billing isn't enabled on your Fly org. Go back to Step 1 and add a credit card.
 - **App-name already taken** — try a different handle (e.g. add the year: `findajob-jamie-2026`). You can delete the failed app from Settings → Delete app and re-launch.
-- **Deploy fails with `Could not find image` (a 404)** — the log shows a green "Build image" step, then "Deploy application" fails with something like `failed to create release (status 404): … Could not find image …`. Fly built the image but couldn't find it when it went to deploy — a timing issue on Fly's side, not anything you did. Work through it in order: **(1)** if you typed anything into the launch form's Variables / Name-Value field, delete it; **(2)** re-run the deploy (click **Deploy** again, or re-trigger the deployment) — the common, transient form of this clears on a retry, so try 2–3 times, a minute or two apart; **(3)** if it still won't go through, the bulletproof fix skips Fly's build step entirely by deploying findajob's ready-made public image from the command line — see the **Alternative: CLI deploy** section near the bottom of [`install-fly.md`](install-fly.md). Prefer not to touch a terminal? [Open an issue](https://github.com/brockamer/findajob/issues) with your deploy log and we'll help you through it.
+- **The deploy fails, or the page shows an error** — first deploys can occasionally hit a transient Fly hiccup. Re-run the deploy (click **Deploy** again, or re-trigger the deployment); it usually clears on a retry. If it keeps failing after a couple of tries, [open an issue](https://github.com/brockamer/findajob/issues) with your deploy log and we'll help you through it.
 
 ### Step 6. Add your API keys and password *(3 min)*
 


### PR DESCRIPTION
Finalizes the install docs to match the cowork-validated one-click Fly flow (#1002/#1008/#1010). Tell users to accept the wizard defaults (incl. Internal port); correct the false 'fly.toml overrides the wizard port' claim; trim #999's obsolete 'Could not find image' 404 walkthrough to a brief retry safety-net; keep the Variables-blank note. Validated via render check + in-app /docs/ Playwright render + cold read. Docs-only. Closes #1012