### PR TITLE
feat(fetchers): shared ATS feed-URL probe helper (#984 precursor)

### DIFF
--- a/docs/architecture/file-map.md
+++ b/docs/architecture/file-map.md
@@ -16,6 +16,7 @@ When this map drifts from the actual code (renamed file, new route module, retir
 <repo>/src/findajob/ingest.py               # ingest_manual_job() — shared entry point for the /ingest/ web form
 <repo>/src/findajob/fetchers/                 # Greenhouse, Gmail job fetching; RapidAPI feeds via adapters/
 <repo>/src/findajob/fetchers/adapters/      # JobSourceAdapter Protocol + REGISTERED_ADAPTERS + per-source adapter classes (jobs_api14, jobs_api14_indeed, jobs_api14_bing, jsearch, greenhouse, ashby, lever, gmail, workday_cxs, gem); curation.py = per-adapter signup metadata loaded by /onboarding/feed-config/
+<repo>/src/findajob/fetchers/feed_probe.py  # shared ATS feed-URL liveness probe (#984) — probe_feed_line/probe_feed_urls/is_plausible_company_name + FeedProbeResult; reuses each adapter's _SLUG_RE/_ENDPOINT_TEMPLATE/User-Agent (no drift), never raises; reused by onboarding validation (#984), verify-feed-urls button (#985), 404 health-check (#983)
 <repo>/src/findajob/scoring.py              # score_job(), _build_feedback_block() — calls findajob.llm.openrouter (#470)
 <repo>/src/findajob/scorer_prefilter.py     # deterministic pre-filter (Stage 1 + 2)
 <repo>/src/findajob/llm/openrouter.py       # canonical OpenRouter HTTP wrapper (#470) — complete(), CompletionResult, OpenRouterError; cache_control on cached_prefix + cache_system axes

--- a/src/findajob/fetchers/feed_probe.py
+++ b/src/findajob/fetchers/feed_probe.py
@@ -1,0 +1,222 @@
+"""Shared feed-URL probe helper (#984).
+
+Probes each ATS board URL in ``feed_urls.txt`` against its public API for
+liveness. One source of truth reused by three surfaces:
+
+* onboarding-time validation (#984) — prevention, before first triage
+* the "Verify feed URLs" settings button (#985) — self-serve remediation
+* the runtime persistent-404 health-check (#983) — detection over time
+
+Design note — *no drift*: the per-ATS slug regex and endpoint template are
+read directly off the adapter classes (``GreenhouseAdapter._SLUG_RE`` etc.)
+rather than copied here. If an adapter's URL convention changes, the probe
+follows automatically. Reaching for those underscore-prefixed ClassVars is
+deliberate within-package reuse, not a layering violation.
+
+Contract: probing NEVER raises into the caller. A network failure, timeout,
+or malformed response becomes a result with ``status="unreachable"`` — so
+onboarding completion can never be blocked by a slow or offline ATS API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Literal
+
+import requests
+
+from .adapters.ashby import AshbyAdapter
+from .adapters.greenhouse import GreenhouseAdapter
+from .adapters.lever import LeverAdapter
+
+ProbeStatus = Literal["live", "dead", "unreachable", "unsupported"]
+
+# (kind, slug_regex, endpoint_template) sourced from the adapters themselves
+# so there is exactly one definition of each ATS's URL shape.
+_PROBE_KINDS = (
+    ("greenhouse", GreenhouseAdapter._SLUG_RE, GreenhouseAdapter._ENDPOINT_TEMPLATE),
+    ("ashby", AshbyAdapter._SLUG_RE, AshbyAdapter._ENDPOINT_TEMPLATE),
+    ("lever", LeverAdapter._SLUG_RE, LeverAdapter._ENDPOINT_TEMPLATE),
+)
+
+_DEFAULT_TIMEOUT = 8.0
+_DEFAULT_MAX_WORKERS = 8
+
+# Match the adapters' User-Agent exactly — no-drift extends to headers, not just
+# the URL. An ATS that filters the bare python-requests UA would block the probe
+# (false "unreachable") while the real fetch, which sends this, succeeds.
+_UA = "findajob-pipeline/1.0 (personal job search tool)"
+
+# A clean company display name is short and word-like. Beyond these bounds it
+# reads as provenance/free-text — the #856 failure mode where junk comments
+# pollute jobs.company and diverge the dedup fingerprint.
+_MAX_COMPANY_NAME_LEN = 50
+_MAX_COMPANY_NAME_WORDS = 6
+
+
+@dataclass(frozen=True)
+class FeedProbeResult:
+    """Outcome of probing one ``feed_urls.txt`` line."""
+
+    line: str
+    kind: str | None
+    slug: str | None
+    status: ProbeStatus
+    http_status: int | None
+    reason: str
+    company: str | None
+    company_name_ok: bool
+
+
+def is_plausible_company_name(name: str | None) -> bool:
+    """True unless ``name`` looks like junk (a URL or sentence-like provenance).
+
+    Flags the #856 failure mode only — *present-but-polluting* comments. A
+    missing comment (None/empty) is not junk: the Ashby/Lever parser falls
+    back to ``slug.title()``, so there is nothing to object to → True.
+    """
+    if name is None:
+        return True
+    text = name.strip()
+    if not text:
+        return True
+    lowered = text.lower()
+    if "http://" in lowered or "https://" in lowered or "www." in lowered:
+        return False
+    if len(text) > _MAX_COMPANY_NAME_LEN:
+        return False
+    if len(text.split()) > _MAX_COMPANY_NAME_WORDS:
+        return False
+    return True
+
+
+def _classify(slug: str, status_code: int) -> tuple[ProbeStatus, str]:
+    """Map an HTTP status to a probe verdict + plain-language reason.
+
+    A 404 condemns the slug (dead). Any other non-200 — 5xx, 429, redirects —
+    is treated as transient (unreachable), never as a dead slug, so a server
+    blip can't make the UI cry wolf on a healthy feed.
+    """
+    if status_code == 200:
+        return "live", "Live — board responded 200."
+    if status_code == 404:
+        return (
+            "dead",
+            f"404 — slug '{slug}' isn't a valid board; the company may have changed "
+            "or left this ATS. Correct the slug, or comment the line out.",
+        )
+    return (
+        "unreachable",
+        f"HTTP {status_code} — couldn't verify right now (looks transient); try again later.",
+    )
+
+
+def probe_feed_line(line: str, *, timeout: float = _DEFAULT_TIMEOUT) -> FeedProbeResult | None:
+    """Probe one feed_urls.txt line. Returns None for nothing-to-probe lines.
+
+    Never raises on probe I/O: a network failure, timeout, or HTTP error becomes
+    ``status="unreachable"`` (or ``"dead"`` for a 404). A non-empty URL on no
+    supported ATS is flagged ``status="unsupported"`` — surfaced, never dropped.
+
+    Caller misuse is *not* masked: an invalid ``timeout`` argument surfaces its
+    ValueError rather than being swallowed into a false "unreachable" (which
+    would make every feed look dead and bury the bug). The batch wrapper
+    ``probe_feed_urls`` absorbs even that, so onboarding can never be blocked.
+    """
+    text = line.strip()
+    url_part, _, comment = text.partition("#")
+    url_part = url_part.strip()
+    if not url_part:
+        return None  # blank line or comment-only heading — nothing to probe
+    company = comment.strip() or None
+    company_ok = is_plausible_company_name(company)
+
+    for kind, slug_re, template in _PROBE_KINDS:
+        m = slug_re.search(url_part)
+        if not m:
+            continue
+        slug = m.group(1)
+        api_url = template.format(slug=slug)
+        try:
+            resp = requests.get(api_url, headers={"User-Agent": _UA}, timeout=timeout)
+        except requests.RequestException:
+            return FeedProbeResult(
+                line=text,
+                kind=kind,
+                slug=slug,
+                status="unreachable",
+                http_status=None,
+                reason="Couldn't reach the ATS API (network error or timeout); try again later.",
+                company=company,
+                company_name_ok=company_ok,
+            )
+        status, reason = _classify(slug, resp.status_code)
+        return FeedProbeResult(
+            line=text,
+            kind=kind,
+            slug=slug,
+            status=status,
+            http_status=resp.status_code,
+            reason=reason,
+            company=company,
+            company_name_ok=company_ok,
+        )
+
+    return FeedProbeResult(
+        line=text,
+        kind=None,
+        slug=None,
+        status="unsupported",
+        http_status=None,
+        reason=(
+            "Unsupported ATS — findajob probes Greenhouse, Ashby, and Lever boards. "
+            "Comment this line out, or check whether the company is on a supported ATS."
+        ),
+        company=company,
+        company_name_ok=company_ok,
+    )
+
+
+def _safe_probe(line: str, timeout: float) -> FeedProbeResult | None:
+    """probe_feed_line wrapped so NOTHING escapes — the ultimate fail-safe.
+
+    probe_feed_line already swallows request errors; this guards against any
+    other unexpected exception so a single bad line can never abort the batch
+    (and thus never block onboarding).
+    """
+    try:
+        return probe_feed_line(line, timeout=timeout)
+    except Exception:  # noqa: BLE001 — deliberate fail-safe; see never-block-onboarding contract
+        return FeedProbeResult(
+            line=line.strip(),
+            kind=None,
+            slug=None,
+            status="unreachable",
+            http_status=None,
+            reason="Couldn't verify this line (unexpected error); skipped.",
+            company=None,
+            company_name_ok=True,
+        )
+
+
+def probe_feed_urls(
+    lines: Iterable[str],
+    *,
+    timeout: float = _DEFAULT_TIMEOUT,
+    max_workers: int = _DEFAULT_MAX_WORKERS,
+) -> list[FeedProbeResult]:
+    """Probe every line concurrently (bounded), preserving input order.
+
+    Nothing-to-probe lines (blank / comment-only) are dropped; everything
+    else — including unsupported and unreachable lines — is returned, so the
+    caller can surface a flag rather than silently lose a line. Never raises.
+    """
+    items = list(lines)
+    if not items:
+        return []
+    workers = max(1, min(max_workers, len(items)))
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        results = executor.map(lambda ln: _safe_probe(ln, timeout), items)
+    return [r for r in results if r is not None]

--- a/tests/test_feed_probe.py
+++ b/tests/test_feed_probe.py
@@ -1,0 +1,382 @@
+"""Tests for the shared feed-URL probe helper (#984).
+
+The helper probes each ATS board URL in feed_urls.txt against its public
+API for liveness, so onboarding (#984), the verify-feed-urls settings
+button (#985), and the runtime 404 health-check (#983) can all reuse one
+source of truth — no drift.
+
+The probe must NEVER raise into its caller: onboarding completion must
+not be blockable by a slow or offline ATS API.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from findajob.fetchers.feed_probe import (
+    is_plausible_company_name,
+    probe_feed_line,
+    probe_feed_urls,
+)
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_live_greenhouse_url_returns_live_and_probes_real_api_endpoint(mock_get):
+    """A 200 from the Greenhouse boards API marks the slug live, and the
+    URL actually probed is the adapter's endpoint template — not the board
+    URL from feed_urls.txt. This pins the no-drift contract: the probe
+    reuses GreenhouseAdapter._ENDPOINT_TEMPLATE rather than its own copy.
+    """
+    mock_get.return_value = MagicMock(status_code=200)
+
+    result = probe_feed_line("https://boards.greenhouse.io/acmecorp")
+
+    assert result is not None
+    assert result.kind == "greenhouse"
+    assert result.slug == "acmecorp"
+    assert result.status == "live"
+    assert result.http_status == 200
+
+    probed_url = mock_get.call_args[0][0]
+    assert probed_url == "https://boards-api.greenhouse.io/v1/boards/acmecorp/jobs?content=true"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_404_marks_slug_dead_with_actionable_reason(mock_get):
+    """A 404 is a verdict about the slug itself — it's not a valid board.
+    The reason must name the offending slug so the user knows what to fix.
+    """
+    mock_get.return_value = MagicMock(status_code=404)
+
+    result = probe_feed_line("https://jobs.ashbyhq.com/deadco")
+
+    assert result is not None
+    assert result.status == "dead"
+    assert result.http_status == 404
+    assert "404" in result.reason
+    assert "deadco" in result.reason
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_server_error_is_unreachable_not_dead(mock_get):
+    """A 5xx is transient — about the server right now, not the slug. Must
+    NOT condemn the slug as dead, or the UI cries wolf on a healthy feed.
+    """
+    mock_get.return_value = MagicMock(status_code=503)
+
+    result = probe_feed_line("https://jobs.lever.co/flakyco")
+
+    assert result is not None
+    assert result.status == "unreachable"
+    assert result.http_status == 503
+    assert result.status != "dead"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_rate_limited_is_unreachable_not_dead(mock_get):
+    """429 is transient back-pressure, not a dead slug."""
+    mock_get.return_value = MagicMock(status_code=429)
+
+    result = probe_feed_line("https://jobs.lever.co/busyco")
+
+    assert result is not None
+    assert result.status == "unreachable"
+    assert result.status != "dead"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_network_error_is_unreachable_and_never_raises(mock_get):
+    """A connection failure must be swallowed into a result, never raised —
+    the never-block-onboarding contract. http_status is None (no response).
+    """
+    mock_get.side_effect = requests.exceptions.ConnectionError("dns fail")
+
+    result = probe_feed_line("https://boards.greenhouse.io/offlineco")
+
+    assert result is not None
+    assert result.status == "unreachable"
+    assert result.http_status is None
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_timeout_is_unreachable_and_never_raises(mock_get):
+    """A timeout must be swallowed into a result, never raised."""
+    mock_get.side_effect = requests.exceptions.Timeout("slow")
+
+    result = probe_feed_line("https://boards.greenhouse.io/slowco")
+
+    assert result is not None
+    assert result.status == "unreachable"
+    assert result.http_status is None
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_ashby_url_probes_the_ashby_posting_api(mock_get):
+    """Ashby kind detection + endpoint reuse (no drift vs AshbyAdapter)."""
+    mock_get.return_value = MagicMock(status_code=200)
+
+    result = probe_feed_line("https://jobs.ashbyhq.com/Ramp")
+
+    assert result is not None
+    assert result.kind == "ashby"
+    assert result.slug == "Ramp"
+    assert result.status == "live"
+    assert mock_get.call_args[0][0] == "https://api.ashbyhq.com/posting-api/job-board/Ramp"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_lever_url_probes_the_lever_postings_api(mock_get):
+    """Lever kind detection + endpoint reuse (no drift vs LeverAdapter)."""
+    mock_get.return_value = MagicMock(status_code=200)
+
+    result = probe_feed_line("https://jobs.lever.co/zoox")
+
+    assert result is not None
+    assert result.kind == "lever"
+    assert result.slug == "zoox"
+    assert mock_get.call_args[0][0] == "https://api.lever.co/v0/postings/zoox"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_inline_comment_captured_as_company_and_marked_clean(mock_get):
+    """For Ashby/Lever the inline comment IS the company display name. A
+    clean single-word company name must round-trip and read as plausible.
+    """
+    mock_get.return_value = MagicMock(status_code=200)
+
+    result = probe_feed_line("https://jobs.lever.co/zoox  # Zoox")
+
+    assert result is not None
+    assert result.slug == "zoox"
+    assert result.company == "Zoox"
+    assert result.company_name_ok is True
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_blank_line_is_nothing_to_probe(mock_get):
+    assert probe_feed_line("   ") is None
+    mock_get.assert_not_called()
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_comment_only_line_is_nothing_to_probe(mock_get):
+    assert probe_feed_line("# ===== Greenhouse boards =====") is None
+    mock_get.assert_not_called()
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_unknown_ats_url_is_flagged_unsupported_not_dropped(mock_get):
+    """A non-empty URL that matches no supported ATS must be surfaced as
+    'unsupported' (flagged, not silently dropped) and must make no HTTP call.
+    """
+    result = probe_feed_line("https://acme.wd1.myworkdayjobs.com/careers")
+
+    assert result is not None
+    assert result.status == "unsupported"
+    assert result.kind is None
+    assert result.slug is None
+    assert result.http_status is None
+    mock_get.assert_not_called()
+
+
+def test_clean_company_names_are_plausible():
+    assert is_plausible_company_name("Zoox") is True
+    assert is_plausible_company_name("CoreWeave") is True
+    assert is_plausible_company_name("Astera Labs") is True
+
+
+def test_url_in_company_name_is_implausible():
+    assert is_plausible_company_name("https://acme.com") is False
+    assert is_plausible_company_name("see www.acme.com/jobs") is False
+
+
+def test_sentence_like_provenance_company_name_is_implausible():
+    assert is_plausible_company_name("Acme Corp added via the discovery run on 2026 May cohort sweep") is False
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_junk_inline_comment_flags_company_name_not_ok(mock_get):
+    """A junk comment (provenance/URL) is the #856 failure mode — it would
+    pollute jobs.company. The probe must flag it even when the URL is live.
+    """
+    mock_get.return_value = MagicMock(status_code=200)
+
+    result = probe_feed_line("https://jobs.ashbyhq.com/acme  # https://acme.com careers page")
+
+    assert result is not None
+    assert result.status == "live"
+    assert result.company_name_ok is False
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_batch_probes_supported_lines_in_order_and_skips_blanks(mock_get):
+    """The batch returns one result per probeable line, in input order.
+    Blank and comment-only lines are skipped; unsupported URLs are KEPT
+    (flagged), so a junk line can't silently vanish from the report.
+    """
+    mock_get.return_value = MagicMock(status_code=200)
+    lines = [
+        "https://boards.greenhouse.io/acme  # Acme",
+        "",
+        "# ===== heading =====",
+        "https://jobs.ashbyhq.com/ramp  # Ramp",
+        "https://acme.wd1.myworkdayjobs.com/careers",
+    ]
+
+    results = probe_feed_urls(lines)
+
+    assert [r.kind for r in results] == ["greenhouse", "ashby", None]
+    assert [r.slug for r in results] == ["acme", "ramp", None]
+    assert results[2].status == "unsupported"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_batch_never_raises_on_unexpected_error(mock_get):
+    """A non-RequestException in the request layer must NOT escape the batch
+    — it is the ultimate fail-safe for the never-block-onboarding contract.
+    """
+    mock_get.side_effect = ValueError("boom inside the request layer")
+
+    results = probe_feed_urls(["https://boards.greenhouse.io/acme"])
+
+    assert len(results) == 1
+    assert results[0].status == "unreachable"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_batch_offline_marks_all_unreachable(mock_get):
+    """Fully offline: every line resolves to unreachable, no exception."""
+    mock_get.side_effect = requests.exceptions.ConnectionError("offline")
+
+    results = probe_feed_urls(
+        [
+            "https://boards.greenhouse.io/a",
+            "https://jobs.ashbyhq.com/b",
+            "https://jobs.lever.co/c",
+        ]
+    )
+
+    assert len(results) == 3
+    assert all(r.status == "unreachable" for r in results)
+
+
+def test_batch_empty_input_returns_empty_list():
+    assert probe_feed_urls([]) == []
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_batch_caps_concurrency_at_max_workers(mock_get):
+    """Concurrency is bounded: with max_workers=2, no more than 2 probes are
+    ever in flight at once — so a long feed list can't fan out unboundedly.
+    """
+    in_flight = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def slow(*args, **kwargs):
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        time.sleep(0.05)
+        with lock:
+            in_flight -= 1
+        return MagicMock(status_code=200)
+
+    mock_get.side_effect = slow
+    lines = [f"https://jobs.lever.co/co{i}" for i in range(6)]
+
+    probe_feed_urls(lines, max_workers=2)
+
+    assert peak <= 2  # the cap held
+    assert peak > 1  # ...and parallelism actually happened (not serialized)
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_probe_sends_the_same_user_agent_as_the_adapters(mock_get):
+    """No-drift extends to headers: every adapter sends a findajob User-Agent.
+    If the probe sent the bare python-requests UA, an ATS that filters it would
+    block the probe (-> false 'unreachable') while the real fetch succeeds.
+    """
+    mock_get.return_value = MagicMock(status_code=200)
+
+    probe_feed_line("https://boards.greenhouse.io/acme")
+
+    sent_headers = mock_get.call_args.kwargs.get("headers", {})
+    assert sent_headers.get("User-Agent") == "findajob-pipeline/1.0 (personal job search tool)"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_custom_timeout_is_passed_through_to_requests(mock_get):
+    mock_get.return_value = MagicMock(status_code=200)
+
+    probe_feed_line("https://boards.greenhouse.io/acme", timeout=2.5)
+
+    assert mock_get.call_args.kwargs["timeout"] == 2.5
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_greenhouse_eu_and_jobboards_variants_probe_the_unified_api(mock_get):
+    """EU and job-boards Greenhouse URLs are valid board URLs. There is no
+    separate EU API host (boards-api.eu.greenhouse.io does not resolve), so all
+    variants correctly probe the unified boards-api.greenhouse.io — same host
+    the adapter uses. This pins that an EU board is NOT falsely marked dead.
+    """
+    mock_get.return_value = MagicMock(status_code=200)
+    for url, slug in [
+        ("https://boards.eu.greenhouse.io/eucorp", "eucorp"),
+        ("https://job-boards.greenhouse.io/jbcorp", "jbcorp"),
+    ]:
+        mock_get.reset_mock()
+        mock_get.return_value = MagicMock(status_code=200)
+
+        result = probe_feed_line(url)
+
+        assert result is not None
+        assert result.kind == "greenhouse"
+        assert result.slug == slug
+        assert result.status == "live"
+        assert mock_get.call_args[0][0] == f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs?content=true"
+
+
+@patch("findajob.fetchers.feed_probe.requests.get")
+def test_slug_with_dots_and_dashes_extracted_intact(mock_get):
+    """Slugs legitimately contain dots/dashes (regex char class [A-Za-z0-9_.-]);
+    they must survive into the probed URL unmangled.
+    """
+    mock_get.return_value = MagicMock(status_code=200)
+
+    result = probe_feed_line("https://jobs.lever.co/my-company.io")
+
+    assert result is not None
+    assert result.slug == "my-company.io"
+    assert mock_get.call_args[0][0] == "https://api.lever.co/v0/postings/my-company.io"
+
+
+def test_company_name_length_boundary():
+    assert is_plausible_company_name("A" * 49) is True
+    assert is_plausible_company_name("A" * 50) is True
+    assert is_plausible_company_name("A" * 51) is False
+
+
+def test_company_name_word_count_boundary():
+    assert is_plausible_company_name("one two three four five") is True  # 5 words
+    assert is_plausible_company_name("one two three four five six") is True  # 6 words
+    assert is_plausible_company_name("one two three four five six seven") is False  # 7 words
+
+
+def test_batch_absorbs_real_invalid_timeout_without_raising():
+    """The onboarding-safety guarantee, exercised against the REAL codepath:
+    a genuinely invalid timeout makes urllib3 raise ValueError before any
+    network call. probe_feed_urls must absorb it (degrade to unreachable),
+    never raise — onboarding completion can't be blocked. No mock here on
+    purpose: this is the actual ValueError path, not a simulated one.
+    """
+    results = probe_feed_urls(["https://boards.greenhouse.io/acme"], timeout=-1)
+
+    assert len(results) == 1
+    assert results[0].status == "unreachable"


### PR DESCRIPTION
## What

Adds `findajob.fetchers.feed_probe` — a single shared helper for probing
`feed_urls.txt` ATS board URLs (Greenhouse / Ashby / Lever) for liveness.

This is the **precursor PR** in the Option-1 plan for #984: it lands the shared
probe standalone so the two in-flight feed-integrity features rebase onto one
merged source rather than each growing their own copy:

- **#984** (this PR's parent) — onboarding-time validation of emitted feed URLs
- **#985** (in flight) — the "Verify feed URLs" settings button
- **#983** — runtime persistent-404 health-check

> **Does not close #984.** The onboarding wiring is the follow-up that rebases
> onto this helper.

## API

- `probe_feed_line(line) -> FeedProbeResult | None` — classify one line:
  `live` (200) / `dead` (404) / `unreachable` (5xx, 429, network, timeout) /
  `unsupported` (non-empty URL, no known ATS). `None` only for blank/comment lines.
- `probe_feed_urls(lines) -> list[FeedProbeResult]` — bounded-concurrency batch,
  order-preserving, **never raises**.
- `is_plausible_company_name(name) -> bool` — flags junk inline comments (the
  #856 pollution failure mode) without nagging on merely-missing ones.

## Design contracts (encoded as tests)

- **No drift** — the probe reuses each adapter's `_SLUG_RE`, `_ENDPOINT_TEMPLATE`,
  and `User-Agent`, asserted via `call_args`. It can't disagree with what the
  fetcher actually hits.
- **404 = dead, but 5xx/429/timeout = unreachable** — a server blip never
  condemns a healthy slug.
- **Never block onboarding** — `probe_feed_urls` absorbs every per-line failure,
  including an invalid `timeout` arg (verified against the real ValueError path).
- **Flag, don't drop** — unsupported/dead/unreachable lines are returned;
  only blank/comment lines are dropped.

## Test plan

- [x] 28 unit tests, built test-first (`tests/test_feed_probe.py`)
- [x] Full suite: 3821 passed, 2 skipped, 0 failures
- [x] `ruff check` + `ruff format --check` + `mypy` clean
- [x] Adversarial multi-agent review (4 lenses, findings independently verified);
      hardened in response — User-Agent parity, honest never-raises docstring,
      boundary + EU/job-boards + special-char-slug coverage
- [x] Verified empirically: `boards-api.eu.greenhouse.io` does not resolve →
      EU Greenhouse boards correctly probe the unified API host (no false-dead)
- [ ] No UI / smoke / browser checks — library module, no rendered surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
